### PR TITLE
Fixed compilation error

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/cache/PrioritisedDownloadQueue.java
+++ b/src/main/java/org/quantumbadger/redreader/cache/PrioritisedDownloadQueue.java
@@ -20,6 +20,8 @@ package org.quantumbadger.redreader.cache;
 import org.apache.http.client.HttpClient;
 
 import java.util.HashMap;
+import java.util.Map;
+
 
 class PrioritisedDownloadQueue {
 
@@ -109,7 +111,7 @@ class PrioritisedDownloadQueue {
 		CacheDownload next = null;
 		RequestIdentifier nextKey = null;
 
-		for(final HashMap.Entry<RequestIdentifier, CacheDownload> entry : downloadsQueued.entrySet()) {
+		for(final Map.Entry<RequestIdentifier, CacheDownload> entry : downloadsQueued.entrySet()) {
 			if(next == null || entry.getValue().isHigherPriorityThan(next)) {
 				next = entry.getValue();
 				nextKey = entry.getKey();
@@ -131,7 +133,7 @@ class PrioritisedDownloadQueue {
 		CacheDownload next = null;
 		RequestIdentifier nextKey = null;
 
-		for(final HashMap.Entry<RequestIdentifier, CacheDownload> entry : redditDownloadsQueued.entrySet()) {
+		for(final Map.Entry<RequestIdentifier, CacheDownload> entry : redditDownloadsQueued.entrySet()) {
 			if(next == null || entry.getValue().isHigherPriorityThan(next)) {
 				next = entry.getValue();
 				nextKey = entry.getKey();


### PR DESCRIPTION
I was getting this error when compiling with maven 3 and jdk 1.6_37;

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.5.1:compile (default-compile) on project redreader: Compilation failure: Compilation failure:
[ERROR] /Users/edmundd/Projects/RedReader/src/main/java/org/quantumbadger/redreader/cache/PrioritisedDownloadQueue.java:[112,19] java.util.HashMap.Entry is not public in java.util.HashMap; cannot be accessed from outside package
[ERROR] /Users/edmundd/Projects/RedReader/src/main/java/org/quantumbadger/redreader/cache/PrioritisedDownloadQueue.java:[134,19] java.util.HashMap.Entry is not public in java.util.HashMap; cannot be accessed from outside package
