### PR TITLE
Accept subreddit input in various forms

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -193,14 +193,16 @@ public class MainActivity extends RefreshableActivity
 				alertBuilder.setPositiveButton(R.string.dialog_go, new DialogInterface.OnClickListener() {
 					public void onClick(DialogInterface dialog, int which) {
 
-						final String name = editText.getText().toString().toLowerCase().trim();
+						String subredditInput = editText.getText().toString().trim();
 
-						if(!name.matches("[\\w\\+]+")) {
-							General.quickToast(MainActivity.this, R.string.mainmenu_custom_invalid_name);
-						} else {
-							final RedditSubreddit subreddit = new RedditSubreddit("/r/" + name, "/r/" + name, true);
-							onSelected(subreddit);
-						}
+                        try {
+                            final String normalizedName = RedditSubreddit.getNormalizedName(subredditInput);
+                            final RedditSubreddit subreddit = new RedditSubreddit(normalizedName, normalizedName, true);
+                            onSelected(subreddit);
+                        }
+                        catch (RedditSubreddit.InvalidSubredditNameException e){
+                            General.quickToast(MainActivity.this, R.string.mainmenu_custom_invalid_name);
+                        }
 					}
 				});
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditSubreddit.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditSubreddit.java
@@ -20,7 +20,12 @@ package org.quantumbadger.redreader.reddit.things;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class RedditSubreddit implements Parcelable, Comparable<RedditSubreddit> {
+
+    public static final class InvalidSubredditNameException extends RuntimeException {}
 
 	public String header_img, header_title;
 	public String description, description_html, public_description;
@@ -29,6 +34,21 @@ public class RedditSubreddit implements Parcelable, Comparable<RedditSubreddit> 
 	public Integer accounts_active, subscribers;
 	public boolean over18;
 	private final boolean isReal, isSortable;
+    private static final Pattern NAME_PATTERN = Pattern.compile("(/)?(r/)?(\\w+)");
+
+    /**
+     * @param name a subreddit name in the form "subreddit", "r/subreddit" or "/r/subreddit" (case-insensitive)
+     * @return a subreddit name in the form "/r/subreddit" (lower-cased)
+     * @throws InvalidSubredditNameException if {@code name} is null or not in the expected format
+     */
+    public static final String getNormalizedName(String name) throws InvalidSubredditNameException {
+        Matcher matcher = NAME_PATTERN.matcher(name);
+        if(matcher.matches()) {
+            return "/r/" + matcher.group(3).toLowerCase();
+        } else {
+            throw new InvalidSubredditNameException();
+        }
+    }
 
 	public int describeContents() {
 		return 0;


### PR DESCRIPTION
I was using RedReader today and went to select a custom subreddit. I input "r/denver" and got an error stating that this was an invalid subreddit. I thought it would be cool if the input were flexible enough to understand "/r/denver", "r/denver" or "denver", so I made a quick change to do this.

I thought a static util method on <code>RedditSubreddit</code> which normalized the names seemed like a good solution. I was then able to use the normalized name where the code was concatenating "/r/" with the last part of the subreddit name in a call to that class' constructor.

I tested this out and it looks to be working as expected.
