### PR TITLE
Corrected HTTP user agent generation

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/Constants.java
+++ b/src/main/java/org/quantumbadger/redreader/common/Constants.java
@@ -110,7 +110,7 @@ public final class Constants {
 
 	public static String ua(final Context context) {
 		final String canonicalName = RedReader.class.getCanonicalName();
-		return canonicalName.substring(0, canonicalName.lastIndexOf('.')) + "-" + version(context);
+		return canonicalName.substring(0, canonicalName.lastIndexOf('.')) + "/" + version(context);
 	}
 
 	public static final class Priority {


### PR DESCRIPTION
I noticed this issue when I was looking through my web server logs a few minutes ago.

The product token was plain and simply poorly generated. The format ought to be <product token>/<version>, not <product token>-<version>.

See [RFC 2068, section 3.8](http://tools.ietf.org/html/rfc2068#section-3.8) (HTTP 1.1) and [RFC 1945, section 3.7](http://tools.ietf.org/html/rfc1945#section-3.7) (HTTP 1.0).
