### PR TITLE
Highlight stickied posts green

### DIFF
--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -30,6 +30,7 @@
 
     <attr name="rrPostTitleCol" format="color" />
     <attr name="rrPostTitleReadCol" format="color" />
+    <attr name="rrPostTitleStickyCol" format="color" />
     <attr name="rrPostSubtitleCol" format="color" />
     <attr name="rrPostSubtitleBoldCol" format="color" />
     <attr name="rrPostSubtitleUpvoteCol" format="color" />

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -35,6 +35,7 @@
 
         <item name="rrPostTitleCol">#DDDDDD</item>
         <item name="rrPostTitleReadCol">#909090</item>
+        <item name="rrPostTitleStickyCol">#228822</item>
         <item name="rrPostSubtitleCol">#909090</item>
         <item name="rrPostSubtitleBoldCol">#BBBBBB</item>
         <item name="rrPostSubtitleUpvoteCol">#FF9B76</item>

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -80,7 +80,7 @@ public final class RedditPreparedPost {
 	public final String idAlone, idAndType;
 
 	private int voteDirection;
-	private boolean saved, hidden, read;
+	private boolean saved, hidden, read, stickied;
 
 	public final boolean hasThumbnail;
 	private boolean gotHighResThumb = false;
@@ -135,6 +135,7 @@ public final class RedditPreparedPost {
 
 		this.saved = post.saved;
 		this.hidden = post.hidden;
+		this.stickied = post.stickied;
 
 		imageUrl = LinkHandler.getImageUrl(url);
 		thumbnailUrl = post.thumbnail;
@@ -605,6 +606,8 @@ public final class RedditPreparedPost {
 	public boolean isRead() {
 		return read;
 	}
+
+	public boolean isSticky() { return stickied; }
 
 	public void bind(RedditPostView boundView) {
 		this.boundView = boundView;

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -26,7 +26,7 @@ public final class RedditPost implements Parcelable {
 	public String id, name;
 	public String title, url, author, domain, subreddit, subreddit_id;
 	public int num_comments, score, ups, downs;
-	public boolean over_18, hidden, saved, is_self, clicked;
+	public boolean over_18, hidden, saved, is_self, clicked, stickied;
 	public Object edited;
 	public Boolean likes;
 
@@ -56,6 +56,7 @@ public final class RedditPost implements Parcelable {
 		saved = in.readInt() == 1;
 		is_self = in.readInt() == 1;
 		clicked = in.readInt() == 1;
+		stickied = in.readInt() == 1;
 
 		final long in_edited = in.readLong();
 		if(in_edited == -1) {
@@ -102,6 +103,7 @@ public final class RedditPost implements Parcelable {
 		parcel.writeInt(saved ? 1 : 0);
 		parcel.writeInt(is_self ? 1 : 0);
 		parcel.writeInt(clicked ? 1 : 0);
+		parcel.writeInt(stickied ? 1 : 0);
 
 		if(edited instanceof Long) {
 			parcel.writeLong((Long)edited);

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -66,7 +66,7 @@ public final class RedditPostView extends SwipableListItemView implements Reddit
 	private final TextView leftOverlayText, rightOverlayText;
 
 	private final Drawable rrIconFfLeft, rrIconFfRight, rrIconTick;
-	private final int rrPostTitleReadCol, rrPostTitleCol;
+	private final int rrPostTitleReadCol, rrPostTitleCol, rrPostTitleStickyCol;
 
 	private final int offsetBeginAllowed, offsetActionPerformed;
 
@@ -266,7 +266,8 @@ public final class RedditPostView extends SwipableListItemView implements Reddit
 				R.attr.rrIconFfRight,
 				R.attr.rrIconTick,
 				R.attr.rrPostTitleCol,
-				R.attr.rrPostTitleReadCol
+				R.attr.rrPostTitleReadCol,
+				R.attr.rrPostTitleStickyCol
 		});
 
 		rrIconFfLeft = attr.getDrawable(0);
@@ -274,6 +275,7 @@ public final class RedditPostView extends SwipableListItemView implements Reddit
 		rrIconTick = attr.getDrawable(2);
 		rrPostTitleCol = attr.getColor(3, 0);
 		rrPostTitleReadCol = attr.getColor(4, 0);
+		rrPostTitleStickyCol = attr.getColor(5, 0);
 
 		setDescendantFocusability(FOCUS_BLOCK_DESCENDANTS);
 
@@ -317,8 +319,9 @@ public final class RedditPostView extends SwipableListItemView implements Reddit
 	}
 
 	public void updateAppearance() {
-
-		if(post.isRead()) {
+		if(post.isSticky()) {
+			title.setTextColor(rrPostTitleStickyCol);
+		} else if(post.isRead()) {
 			title.setTextColor(rrPostTitleReadCol);
 		} else {
 			title.setTextColor(rrPostTitleCol);


### PR DESCRIPTION
Fixes issue #118, highlights stickied posts green (#228822, same color green as the website).
