### PR TITLE
Search in Tablet Mode (two pane) fixed

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
@@ -230,7 +230,7 @@ public class PostListingActivity extends RefreshableActivity
 					url = RedditURLParser.SearchPostListURL.build(null, query);
 				}
 
-				final Intent intent = new Intent(activity, activity.getClass());
+				final Intent intent = new Intent(activity, PostListingActivity.class);
 				intent.setData(url.generateJsonUri());
 				activity.startActivity(intent);
 			}


### PR DESCRIPTION
In Tablet Mode (two pane), search opened MainActivity with the empty right pane.

Now it opens PostListingActivity.
