### PR TITLE
Fix bug allowing votes on archived content

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -635,4 +635,7 @@
     <string name="imageview_invalid_video">Invalid video. Trying internal browser.</string>
     <string name="download_authorizing">Authenticating…</string>
 
+    <!-- 2015-06-07 -->
+    <string name="error_archived_vote" >sorry, this has been archived and can no longer be voted on</string>
+
 </resources>

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedComment.java
@@ -299,7 +299,7 @@ public final class RedditPreparedComment implements RedditPreparedInboxItem {
 				| action == RedditAPI.RedditAction.UNVOTE);
 
 		if(src.archived && vote){
-			Toast.makeText(activity, "sorry, this has been archived and can no longer be voted on", Toast.LENGTH_SHORT)
+			Toast.makeText(activity, R.string.error_archived_vote, Toast.LENGTH_SHORT)
 					.show();
 			return;
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedComment.java
@@ -22,6 +22,7 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.text.SpannableStringBuilder;
 import android.view.ViewGroup;
+import android.widget.Toast;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.http.StatusLine;
 import org.holoeverywhere.app.Activity;
@@ -272,14 +273,36 @@ public final class RedditPreparedComment implements RedditPreparedInboxItem {
 		final int lastVoteDirection = voteDirection;
 
 		switch(action) {
-			case DOWNVOTE: voteDirection = -1; break;
-			case UNVOTE: voteDirection = 0; break;
-			case UPVOTE: voteDirection = 1; break;
+			case DOWNVOTE:
+				if(!src.archived) {
+					voteDirection = -1;
+				}
+				break;
+			case UNVOTE:
+				if(!src.archived) {
+					voteDirection = 0;
+				}
+				break;
+			case UPVOTE:
+				if(!src.archived) {
+					voteDirection = 1;
+				}
+				break;
 			case SAVE: saved = true; break;
 			case UNSAVE: saved = false; break;
 		}
 
 		refreshView(activity);
+
+		boolean vote = (action == RedditAPI.RedditAction.DOWNVOTE
+				| action == RedditAPI.RedditAction.UPVOTE
+				| action == RedditAPI.RedditAction.UNVOTE);
+
+		if(src.archived && vote){
+			Toast.makeText(activity, "sorry, this has been archived and can no longer be voted on", Toast.LENGTH_SHORT)
+					.show();
+			return;
+		}
 
 		RedditAPI.action(CacheManager.getInstance(activity),
 				new APIResponseHandler.ActionResponseHandler(activity) {
@@ -337,6 +360,7 @@ public final class RedditPreparedComment implements RedditPreparedInboxItem {
 					}
 
 				}, user, idAndType, action, activity);
+
 	}
 
 	public int getVoteDirection() {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -697,22 +697,16 @@ public final class RedditPreparedPost {
 			case DOWNVOTE:
 				if(!src.archived) {
 					voteDirection = -1;
-				} else {
-					voteDirection = lastVoteDirection;
 				}
 				break;
 			case UNVOTE:
 				if(!src.archived) {
 					voteDirection = 0;
-				} else {
-					voteDirection = lastVoteDirection;
 				}
 				break;
 			case UPVOTE:
 				if(!src.archived) {
 					voteDirection = 1;
-				} else {
-					voteDirection = lastVoteDirection;
 				}
 				break;
 
@@ -735,7 +729,7 @@ public final class RedditPreparedPost {
 				| action == RedditAPI.RedditAction.UNVOTE);
 
 		if(src.archived && vote){
-			Toast.makeText(activity, "sorry, this has been archived and can no longer be voted on", Toast.LENGTH_SHORT)
+			Toast.makeText(activity, R.string.error_archived_vote, Toast.LENGTH_SHORT)
 					.show();
 			return;
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -694,9 +694,27 @@ public final class RedditPreparedPost {
 		final int lastVoteDirection = voteDirection;
 
 		switch(action) {
-			case DOWNVOTE: voteDirection = -1; break;
-			case UNVOTE: voteDirection = 0; break;
-			case UPVOTE: voteDirection = 1; break;
+			case DOWNVOTE:
+				if(!src.archived) {
+					voteDirection = -1;
+				} else {
+					voteDirection = lastVoteDirection;
+				}
+				break;
+			case UNVOTE:
+				if(!src.archived) {
+					voteDirection = 0;
+				} else {
+					voteDirection = lastVoteDirection;
+				}
+				break;
+			case UPVOTE:
+				if(!src.archived) {
+					voteDirection = 1;
+				} else {
+					voteDirection = lastVoteDirection;
+				}
+				break;
 
 			case SAVE: saved = true; break;
 			case UNSAVE: saved = false; break;
@@ -711,6 +729,16 @@ public final class RedditPreparedPost {
 		}
 
 		refreshView(activity);
+
+		boolean vote = (action == RedditAPI.RedditAction.DOWNVOTE
+				| action == RedditAPI.RedditAction.UPVOTE
+				| action == RedditAPI.RedditAction.UNVOTE);
+
+		if(src.archived && vote){
+			Toast.makeText(activity, "sorry, this has been archived and can no longer be voted on", Toast.LENGTH_SHORT)
+					.show();
+			return;
+		}
 
 		final RedditAccount user = RedditAccountManager.getInstance(activity).getDefaultAccount();
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
@@ -26,7 +26,7 @@ public final class RedditComment implements Parcelable {
 	
 	public String body, body_html, author, subreddit;
 	public String author_flair_text;
-	public Boolean likes, score_hidden;
+	public Boolean archived, likes, score_hidden;
 	
 	public JsonValue replies;
 	
@@ -52,6 +52,8 @@ public final class RedditComment implements Parcelable {
 		subreddit = in.readString();
 		author_flair_text = in.readString();
 
+
+		archived = in.readInt() == 1;
 		switch(in.readInt()) {
 			case -1: likes = false; break;
 			case 0: likes = null; break;
@@ -91,6 +93,7 @@ public final class RedditComment implements Parcelable {
 		parcel.writeString(author);
 		parcel.writeString(subreddit);
 		parcel.writeString(author_flair_text);
+		parcel.writeInt(archived ? 1 : 0);
 
 		if(likes == null) {
 			parcel.writeInt(0);

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -26,7 +26,7 @@ public final class RedditPost implements Parcelable {
 	public String id, name;
 	public String title, url, author, domain, subreddit, subreddit_id;
 	public int num_comments, score, ups, downs;
-	public boolean over_18, hidden, saved, is_self, clicked, stickied;
+	public boolean archived, over_18, hidden, saved, is_self, clicked, stickied;
 	public Object edited;
 	public Boolean likes;
 
@@ -51,6 +51,7 @@ public final class RedditPost implements Parcelable {
 		score = in.readInt();
 		ups = in.readInt();
 		downs = in.readInt();
+		archived = in.readInt() == 1;
 		over_18 = in.readInt() == 1;
 		hidden = in.readInt() == 1;
 		saved = in.readInt() == 1;
@@ -98,6 +99,7 @@ public final class RedditPost implements Parcelable {
 		parcel.writeInt(score);
 		parcel.writeInt(ups);
 		parcel.writeInt(downs);
+		parcel.writeInt(archived ? 1 : 0);
 		parcel.writeInt(over_18 ? 1 : 0);
 		parcel.writeInt(hidden ? 1 : 0);
 		parcel.writeInt(saved ? 1 : 0);


### PR DESCRIPTION
This is a fix for issue #176. There is an archived flag in the JSON for posts and comments, so all this pr does is add support for the archived flag and place a few if statements to block votes and show error messages in toasts.

This is my first ever PR and while I'm not necessarily a beginner programmer, my android dev experience is limited, so let me know if this has to be changed around.