### PR TITLE
Handle Imgur's subreddit links like the gallery

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -190,7 +190,7 @@ public class LinkHandler {
 	}
 
 	public static final Pattern imgurPattern = Pattern.compile(".*imgur\\.com/(\\w+).*"),
-			imgurAlbumPattern = Pattern.compile(".*imgur\\.com/(a|gallery)/(\\w+).*"),
+			imgurAlbumPattern = Pattern.compile(".*imgur\\.com/(a|gallery|r/\\w+)/(\\w+).*"),
 			qkmePattern1 = Pattern.compile(".*qkme\\.me/(\\w+).*"),
 			qkmePattern2 = Pattern.compile(".*quickmeme\\.com/meme/(\\w+).*"),
 			lvmePattern = Pattern.compile(".*livememe\\.com/(\\w+).*");


### PR DESCRIPTION
Currently, images hosted on Imgur's subreddit pages will be loaded in the internal browser.

This patch allows the following url:

    http://imgur.com/r/gaming/r1aETsQ

to be interpreted in the same way as the equivalent gallery url:

    http://imgur.com/gallery/r1aETsQ