### PR TITLE
Allowing the webview to proceed when no change to the URL is needed

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/OAuthLoginActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OAuthLoginActivity.java
@@ -171,7 +171,7 @@ public class OAuthLoginActivity extends BaseActivity {
 
 				} else {
 					setTitle(url);
-					mWebView.loadUrl(url);
+					return false;
 				}
 
 				return true;


### PR DESCRIPTION
You can simply return false from shouldOverrideUrlLoading() to allow the WebView to proceed loading a page when no change to the URL is required.

From the [shouldOverrideUrlLoading (WebView view, String url)](http://developer.android.com/reference/android/webkit/WebViewClient.html#shouldOverrideUrlLoading(android.webkit.WebView,%20java.lang.String)) docs:
"_If WebViewClient is provided, return true means the host application handles the url, while return false means the current WebView handles the url._"