### PR TITLE
Remember toggled comments outside of session

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
@@ -56,6 +56,7 @@ import org.quantumbadger.redreader.views.liststatus.ErrorView;
 import org.quantumbadger.redreader.views.liststatus.LoadingView;
 
 import java.net.URI;
+import java.util.LinkedList;
 import java.util.UUID;
 
 public final class InboxListingActivity extends BaseActivity {
@@ -253,7 +254,7 @@ public final class InboxListingActivity extends BaseActivity {
 							case COMMENT:
 								final RedditComment comment = thing.asComment();
 								final RedditParsedComment parsedComment = new RedditParsedComment(comment);
-								final RedditRenderableComment renderableComment = new RedditRenderableComment(parsedComment, null, -100000, false);
+								final RedditRenderableComment renderableComment = new RedditRenderableComment(parsedComment, null, -100000, false, new LinkedList<String>());
 								itemHandler.sendMessage(General.handlerMessage(0, renderableComment));
 
 								break;

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -583,4 +583,50 @@ public final class PrefsUtility {
 
 		sharedPreferences.edit().putString(context.getString(prefId), resultStr).commit();
 	}
+
+	///////////////////////////////
+	// pref_toggled_comments
+	///////////////////////////////
+	public static ArrayList<String> pref_toggled_comments(final Context context, final SharedPreferences sharedPreferences) {
+		final String value = getString(R.string.pref_toggled_comments_key, "", context, sharedPreferences);
+		return WritableHashSet.escapedStringToList(value);
+	}
+
+	public static Long pref_toggled_comments_max_check(final Context context, final SharedPreferences sharedPreferences) {
+		long defaultMax = 100;
+		return getLong(R.string.pref_toggled_comments_max_key, defaultMax, context, sharedPreferences);
+	}
+
+	public static void pref_toggled_comments_add(
+			final Context context,
+			final SharedPreferences sharedPreferences,
+			final String commentId) {
+
+		final int prefId = R.string.pref_toggled_comments_key;
+		final ArrayList<String> list = pref_toggled_comments(context, sharedPreferences);
+		list.add(commentId);
+
+		// Keep the list pruned
+		if (list.size() > pref_toggled_comments_max_check(context, sharedPreferences)) {
+			list.remove(0);
+		}
+
+		final String result = WritableHashSet.listToEscapedString(list);
+
+		sharedPreferences.edit().putString(context.getString(prefId), result).apply();
+	}
+
+	public static void pref_toggled_comments_remove(
+			final Context context,
+			final SharedPreferences sharedPreferences,
+			final String commentId) {
+
+		final int prefId = R.string.pref_toggled_comments_key;
+		final ArrayList<String> list = pref_toggled_comments(context, sharedPreferences);
+		list.remove(commentId);
+
+		final String result = WritableHashSet.listToEscapedString(list);
+
+		sharedPreferences.edit().putString(context.getString(prefId), result).apply();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -189,6 +189,16 @@ public class CommentListingFragment extends RRFragment
 					comment,
 					!comment.isCollapsed(changeDataManager));
 
+			AppCompatActivity activity = getActivity();
+			SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
+			String commentId = comment.getIdAlone();
+
+			if (comment.isCollapsed(changeDataManager)) {
+				PrefsUtility.pref_toggled_comments_add(activity, preferences, commentId);
+			} else {
+				PrefsUtility.pref_toggled_comments_remove(activity, preferences, commentId);
+			}
+
 			mCommentListingManager.notifyCommentChanged(item);
 			mCommentListingManager.updateHiddenStatus();
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -12,6 +12,7 @@ import org.quantumbadger.redreader.reddit.things.RedditComment;
 import org.quantumbadger.redreader.reddit.things.RedditThingWithIdAndType;
 
 import java.net.URI;
+import java.util.List;
 
 public class RedditRenderableComment implements RedditRenderableInboxItem, RedditThingWithIdAndType {
 
@@ -19,17 +20,20 @@ public class RedditRenderableComment implements RedditRenderableInboxItem, Reddi
 	private final String mParentPostAuthor;
 	private final Integer mMinimumCommentScore;
 	private final boolean mShowScore;
+	private final List<String> mToggledComments;
 
 	public RedditRenderableComment(
 			final RedditParsedComment comment,
 			final String parentPostAuthor,
 			final Integer minimumCommentScore,
-			final boolean showScore) {
+			final boolean showScore,
+			final List<String> toggledComments) {
 
 		mComment = comment;
 		mParentPostAuthor = parentPostAuthor;
 		mMinimumCommentScore = minimumCommentScore;
 		mShowScore = showScore;
+		mToggledComments = toggledComments;
 	}
 
 	private int computeScore(final RedditChangeDataManagerVolatile changeDataManager) {
@@ -217,6 +221,10 @@ public class RedditRenderableComment implements RedditRenderableInboxItem, Reddi
 
 		if(collapsed != null) {
 			return collapsed;
+		}
+
+		if (mToggledComments.contains(this.getIdAlone())) {
+			return true;
 		}
 
 		return isScoreBelowThreshold(changeDataManager);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -756,4 +756,8 @@
     <!-- 2016-04-02 -->
     <string name="open_with">Open with</string>
 
+    <!-- 2016-04-06 -->
+    <string name="pref_toggled_comments_key">pre_toggled_comments</string>
+    <string name="pref_toggled_comments_max_key">pre_toggled_comments_max_key</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -758,6 +758,6 @@
 
     <!-- 2016-04-06 -->
     <string name="pref_toggled_comments_key">pre_toggled_comments</string>
-    <string name="pref_toggled_comments_max_key">pre_toggled_comments_max_key</string>
+    <string name="pref_toggled_comments_max_key">pre_toggled_comments_max</string>
 
 </resources>


### PR DESCRIPTION
A mechanism to remember whether comments have been toggled outside of the current session.  Useful for AMAs, AskReddit posts, etc. where the user may save the post and come back to it later. 

Has a key for the maximum value (currently set to 100), but in order to avoid adding even more settings for the user, this is currently non-configurable.

Borrows somewhat from the Reddit Enhancement Suite approach of just-in-time pruning (although it only removes one entry when the limit is reached).