### PR TITLE
Make comment long-tap behavior dependent on comment tap behavior setting

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -274,14 +274,27 @@ public class CommentListingFragment extends RRFragment
 
 	@Override
 	public void onCommentLongClicked(final RedditCommentView view) {
-		final RedditCommentListItem item = view.getComment();
-		if(item != null && item.isComment()) {
-			RedditAPICommentAction.showActionMenu(
-					getActivity(),
-					this,
-					item.asComment(),
-					view,
-					RedditChangeDataManagerVolatile.getInstance(mUser));
+		switch(PrefsUtility.pref_behaviour_actions_comment_tap(
+			getActivity(),
+			PreferenceManager.getDefaultSharedPreferences(getActivity()))) {
+
+			case ACTION_MENU:
+				handleCommentVisibilityToggle(view);
+				break;
+
+			case COLLAPSE:case NOTHING: {
+				final RedditCommentListItem item = view.getComment();
+				if(item != null && item.isComment()) {
+					RedditAPICommentAction.showActionMenu(
+						getActivity(),
+						this,
+						item.asComment(),
+						view,
+						RedditChangeDataManagerVolatile.getInstance(mUser));
+				}
+				break;
+			}
+
 		}
 	}
 


### PR DESCRIPTION
i.e. a long-tap will cause a comment to collapse if a normal tap is set to show the action menu, and vice versa. This way, tap and long-tap won't do the exact same thing when the tap action is set to 'Action Menu.'