### PR TITLE
Tidy up Toolbar creation

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/AlbumListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/AlbumListingActivity.java
@@ -53,12 +53,11 @@ public class AlbumListingActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		OptionsMenuUtility.fixActionBar(AlbumListingActivity.this, getString(R.string.imgur_album));
-
 		ActionBar ab = getSupportActionBar();
 		if (ab != null) {
 			ab.setHomeButtonEnabled(true);
 			ab.setDisplayHomeAsUpEnabled(true);
+			ab.setTitle(R.string.imgur_album);
 		}
 
 		final Intent intent = getIntent();
@@ -137,7 +136,10 @@ public class AlbumListingActivity extends BaseActivity {
 					public void run() {
 
 						if(info.title != null && !info.title.trim().isEmpty()) {
-							OptionsMenuUtility.fixActionBar(AlbumListingActivity.this, getString(R.string.imgur_album) + ": " + info.title);
+							ActionBar ab = getSupportActionBar();
+							if (ab != null) {
+								ab.setTitle(getString(R.string.imgur_album) + getString(R.string.imgur_album) + ": " + info.title);
+							}
 						}
 
 						layout.removeAllViews();

--- a/src/main/java/org/quantumbadger/redreader/activities/AlbumListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/AlbumListingActivity.java
@@ -19,10 +19,12 @@ package org.quantumbadger.redreader.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.util.Log;
 import android.view.MenuItem;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.adapters.AlbumAdapter;
 import org.quantumbadger.redreader.cache.CacheRequest;
@@ -53,9 +55,10 @@ public class AlbumListingActivity extends BaseActivity {
 
 		OptionsMenuUtility.fixActionBar(AlbumListingActivity.this, getString(R.string.imgur_album));
 
-		if(getSupportActionBar() != null) {
-			getSupportActionBar().setHomeButtonEnabled(true);
-			getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
 		}
 
 		final Intent intent = getIntent();

--- a/src/main/java/org/quantumbadger/redreader/activities/CaptchaActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CaptchaActivity.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.text.InputType;
 import android.view.Gravity;
 import android.view.View;
@@ -56,7 +57,10 @@ public class CaptchaActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setTitle(R.string.post_captcha_title);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setTitle(R.string.post_captcha_title);
+		}
 
 		final LoadingView loadingView = new LoadingView(this, R.string.download_waiting, true, true);
 		setBaseActivityContentView(loadingView);

--- a/src/main/java/org/quantumbadger/redreader/activities/ChangelogActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ChangelogActivity.java
@@ -20,11 +20,11 @@ public class ChangelogActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		OptionsMenuUtility.fixActionBar(this, getString(R.string.title_changelog));
 		ActionBar ab = getSupportActionBar();
 		if (ab != null) {
 			ab.setHomeButtonEnabled(true);
 			ab.setDisplayHomeAsUpEnabled(true);
+			ab.setTitle(R.string.title_changelog);
 		}
 
 		final LinearLayout items = new LinearLayout(this);

--- a/src/main/java/org/quantumbadger/redreader/activities/ChangelogActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ChangelogActivity.java
@@ -1,9 +1,11 @@
 package org.quantumbadger.redreader.activities;
 
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.ChangelogManager;
 import org.quantumbadger.redreader.common.PrefsUtility;
@@ -19,8 +21,11 @@ public class ChangelogActivity extends BaseActivity {
 		super.onCreate(savedInstanceState);
 
 		OptionsMenuUtility.fixActionBar(this, getString(R.string.title_changelog));
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		final LinearLayout items = new LinearLayout(this);
 		items.setOrientation(LinearLayout.VERTICAL);

--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -20,9 +20,11 @@ package org.quantumbadger.redreader.activities;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccountChangeListener;
 import org.quantumbadger.redreader.account.RedditAccountManager;
@@ -61,8 +63,11 @@ public class CommentListingActivity extends RefreshableActivity
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		OptionsMenuUtility.fixActionBar(this, getString(R.string.app_name));
 
@@ -138,7 +143,10 @@ public class CommentListingActivity extends RefreshableActivity
 	protected void doRefresh(final RefreshableFragment which, final boolean force, final Bundle savedInstanceState) {
 		mFragment = controller.get(this, force, savedInstanceState);
 		setBaseActivityContentView(mFragment.getView());
-		getSupportActionBar().setTitle(controller.getCommentListingUrl().humanReadableName(this, false));
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setTitle(controller.getCommentListingUrl().humanReadableName(this, false));
+		}
 		invalidateOptionsMenu();
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -67,9 +67,8 @@ public class CommentListingActivity extends RefreshableActivity
 		if (ab != null) {
 			ab.setHomeButtonEnabled(true);
 			ab.setDisplayHomeAsUpEnabled(true);
+			ab.setTitle(R.string.app_name);
 		}
-
-		OptionsMenuUtility.fixActionBar(this, getString(R.string.app_name));
 
 		RedditAccountManager.getInstance(this).addUpdateListener(this);
 

--- a/src/main/java/org/quantumbadger/redreader/activities/HtmlViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/HtmlViewActivity.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
 import android.view.View;
 import org.quantumbadger.redreader.R;
@@ -36,8 +37,11 @@ public class HtmlViewActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		final Intent intent = getIntent();
 

--- a/src/main/java/org/quantumbadger/redreader/activities/ImgurUploadActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImgurUploadActivity.java
@@ -24,6 +24,7 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
+import android.support.v7.app.ActionBar;
 import android.util.Base64OutputStream;
 import android.view.MenuItem;
 import android.view.View;
@@ -78,8 +79,11 @@ public class ImgurUploadActivity extends BaseActivity {
 
 		OptionsMenuUtility.fixActionBar(this, getString(R.string.upload_to_imgur));
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		final FrameLayout outerLayout = new FrameLayout(this);
 

--- a/src/main/java/org/quantumbadger/redreader/activities/ImgurUploadActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImgurUploadActivity.java
@@ -77,12 +77,11 @@ public class ImgurUploadActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		OptionsMenuUtility.fixActionBar(this, getString(R.string.upload_to_imgur));
-
 		ActionBar ab = getSupportActionBar();
 		if (ab != null) {
 			ab.setHomeButtonEnabled(true);
 			ab.setDisplayHomeAsUpEnabled(true);
+			ab.setTitle(R.string.upload_to_imgur);
 		}
 
 		final FrameLayout outerLayout = new FrameLayout(this);

--- a/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
@@ -151,12 +151,6 @@ public final class InboxListingActivity extends BaseActivity {
 
 		final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
-		ActionBar ab = getSupportActionBar();
-		if (ab != null) {
-			ab.setHomeButtonEnabled(true);
-			ab.setDisplayHomeAsUpEnabled(true);
-		}
-
 		final String title;
 
 		isModmail = getIntent() != null && getIntent().getBooleanExtra("modmail", false);
@@ -168,7 +162,12 @@ public final class InboxListingActivity extends BaseActivity {
 			title = getString(R.string.mainmenu_modmail);
 		}
 
-		OptionsMenuUtility.fixActionBar(this, title);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+			ab.setTitle(title);
+		}
 
 		final LinearLayout outer = new LinearLayout(this);
 		outer.setOrientation(android.widget.LinearLayout.VERTICAL);

--- a/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
@@ -24,6 +24,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -150,8 +151,11 @@ public final class InboxListingActivity extends BaseActivity {
 
 		final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		final String title;
 

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -25,6 +25,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.Menu;
@@ -567,8 +568,11 @@ public class MainActivity extends RefreshableActivity
 				subredditPinState,
 				subredditBlockedState);
 
-		getSupportActionBar().setHomeButtonEnabled(!isMenuShown);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(!isMenuShown);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(!isMenuShown);
+			ab.setDisplayHomeAsUpEnabled(!isMenuShown);
+		}
 
 		if(commentListingFragment != null) {
 			commentListingFragment.onCreateOptionsMenu(menu);

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -111,7 +111,10 @@ public class MainActivity extends RefreshableActivity
 				onSelected(SubredditPostListURL.getFrontPage());
 		}
 
-		OptionsMenuUtility.fixActionBar(this, getString(R.string.app_name));
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setTitle(R.string.app_name);
+		}
 
 		twoPane = General.isTablet(this, sharedPreferences);
 

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -81,9 +81,8 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 		if (ab != null) {
 			ab.setHomeButtonEnabled(true);
 			ab.setDisplayHomeAsUpEnabled(true);
+			ab.setTitle(R.string.app_name);
 		}
-
-		OptionsMenuUtility.fixActionBar(this, getString(R.string.app_name));
 
 		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -39,6 +39,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -76,8 +77,11 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		OptionsMenuUtility.fixActionBar(this, getString(R.string.app_name));
 
@@ -144,7 +148,10 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 
 		mPane.removeAllViews();
 		mPane.addView(mFragment.getView());
-		getSupportActionBar().setTitle("More Comments");
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setTitle("More Comments");
+		}
 	}
 
 	public void onRefreshComments() {

--- a/src/main/java/org/quantumbadger/redreader/activities/OAuthLoginActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OAuthLoginActivity.java
@@ -22,13 +22,14 @@ import android.annotation.TargetApi;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
 import android.webkit.CookieManager;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import info.guardianproject.netcipher.web.WebkitProxy;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.RedReader;
 import org.quantumbadger.redreader.common.AndroidApi;
@@ -37,6 +38,8 @@ import org.quantumbadger.redreader.common.TorCommon;
 import org.quantumbadger.redreader.reddit.api.RedditOAuth;
 
 import java.io.ByteArrayInputStream;
+
+import info.guardianproject.netcipher.web.WebkitProxy;
 
 public class OAuthLoginActivity extends BaseActivity {
 
@@ -128,8 +131,11 @@ public class OAuthLoginActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		mWebView = new WebView(this);
 

--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -570,9 +570,4 @@ public final class OptionsMenuUtility {
 
 		void onSortSelected(PostCommentListingURL.Sort order);
 	}
-
-	public static void fixActionBar(final AppCompatActivity activity, final String title) {
-		if(activity.getSupportActionBar() == null) return;
-		activity.getSupportActionBar().setTitle(title);
-	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -70,8 +71,11 @@ public class PostListingActivity extends RefreshableActivity
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		getWindow().setBackgroundDrawable(new ColorDrawable(obtainStyledAttributes(new int[] {R.attr.rrListBackgroundCol}).getColor(0,0)));
 

--- a/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
@@ -111,7 +111,9 @@ public class PostListingActivity extends RefreshableActivity
 				}
 			}
 
-			OptionsMenuUtility.fixActionBar(this, url.humanReadableName(this, false));
+			if (ab != null) {
+				ab.setTitle(url.humanReadableName(this, false));
+			}
 
 			setBaseActivityContentView(R.layout.main_single);
 			doRefresh(RefreshableFragment.POSTS, false, fragmentSavedInstanceState);

--- a/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
@@ -21,6 +21,7 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.text.InputType;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -67,8 +68,11 @@ public class PostSubmitActivity extends BaseActivity {
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		final LinearLayout layout = (LinearLayout) getLayoutInflater().inflate(R.layout.post_submit, null);
 

--- a/src/main/java/org/quantumbadger/redreader/activities/WebViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/WebViewActivity.java
@@ -20,6 +20,7 @@ package org.quantumbadger.redreader.activities;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -49,8 +50,11 @@ public class WebViewActivity extends BaseActivity implements RedditPostView.Post
 
 		super.onCreate(savedInstanceState);
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 
 		final Intent intent = getIntent();
 

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -380,7 +381,10 @@ public class CommentListingFragment extends RRFragment
 			}
 
 			if(!General.isTablet(context, PreferenceManager.getDefaultSharedPreferences(context))) {
-				getActivity().getSupportActionBar().setTitle(post.src.getTitle());
+				ActionBar ab = getActivity().getSupportActionBar();
+				if (ab != null) {
+					ab.setTitle(post.src.getTitle());
+				}
 			}
 
 			if(!mAllUrls.isEmpty()

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsActivity.java
@@ -21,6 +21,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
 import android.view.Window;
 import org.quantumbadger.redreader.R;
@@ -44,8 +45,11 @@ public final class SettingsActivity
 		sharedPreferences.registerOnSharedPreferenceChangeListener(this);
 		setOrientationFromPrefs();
 
-		getSupportActionBar().setHomeButtonEnabled(true);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		ActionBar ab = getSupportActionBar();
+		if (ab != null) {
+			ab.setHomeButtonEnabled(true);
+			ab.setDisplayHomeAsUpEnabled(true);
+		}
 	}
 
 	@Override

--- a/src/main/res/layout/rr_actionbar.xml
+++ b/src/main/res/layout/rr_actionbar.xml
@@ -15,7 +15,6 @@
 				android:layout_width="match_parent"
 				android:layout_height="?actionBarSize"
 				android:background="?attr/colorPrimary"
-				app:titleTextAppearance="@style/RR.Toolbar.TitleText"
 				app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
 				app:popupTheme="?rrActionBarPopupThemeStyle" />
 

--- a/src/main/res/layout/rr_actionbar.xml
+++ b/src/main/res/layout/rr_actionbar.xml
@@ -13,7 +13,7 @@
 		<android.support.v7.widget.Toolbar
 				android:id="@+id/rr_actionbar_toolbar"
 				android:layout_width="match_parent"
-				android:layout_height="?attr/actionBarSize"
+				android:layout_height="?actionBarSize"
 				android:background="?attr/colorPrimary"
 				app:titleTextAppearance="@style/RR.Toolbar.TitleText"
 				app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -18,8 +18,6 @@
 
 <resources>
 
-    <attr name="rrActionBarCol" format="color" />
-
 	<attr name="rrActionBarPopupThemeStyle" format="reference" />
 
     <attr name="rrListDividerCol" format="color" />

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -30,8 +30,4 @@
         <item name="android:minHeight">@dimen/abc_action_button_min_height_material</item>
     </style>
 
-	<style name="RR.Toolbar.TitleText" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
-		<item name="android:textSize">18sp</item>
-	</style>
-
 </resources>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
 <resources>
 
     <style name="RR.Startup.ActionBarStyle" parent="@style/Widget.AppCompat.ActionBar">
-        <item name="android:background">?rrActionBarCol</item>
+        <item name="android:background">?colorPrimary</item>
     </style>
 
     <style name="RR.Base.Widget.AppCompat.ActionButton.Overflow" parent="RtlUnderlay.Widget.AppCompat.ActionButton.Overflow">

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -22,8 +22,7 @@
 
         <item name="android:actionOverflowButtonStyle">@style/RR.Base.Widget.AppCompat.ActionButton.Overflow</item>
 
-        <item name="rrActionBarCol">#222222</item>
-        <item name="colorPrimary">?rrActionBarCol</item>
+        <item name="colorPrimary">#222222</item>
         <item name="colorPrimaryDark">#000000</item>
         <item name="colorAccent">#99DDDD</item>
 
@@ -104,8 +103,7 @@
 
 		<item name="alertDialogTheme">@style/Theme.AppCompat.Dialog.Alert</item>
 
-		<item name="rrActionBarCol">#555555</item>
-		<item name="colorPrimary">?rrActionBarCol</item>
+		<item name="colorPrimary">#555555</item>
 		<item name="colorPrimaryDark">#555555</item>
 		<item name="colorAccent">#99DDDD</item>
 		<item name="android:windowBackground">@color/settingsWindowBackground</item>
@@ -118,8 +116,7 @@
 
         <item name="android:actionOverflowButtonStyle">@style/RR.Base.Widget.AppCompat.ActionButton.Overflow</item>
 
-        <item name="rrActionBarCol">#222222</item>
-        <item name="colorPrimary">?rrActionBarCol</item>
+        <item name="colorPrimary">#222222</item>
         <item name="colorPrimaryDark">#111111</item>
         <item name="colorAccent">?colorPrimaryDark</item>
 
@@ -128,7 +125,7 @@
         <item name="android:textColorPrimary">#000000</item>
         <item name="android:textColorSecondary">#000000</item>
 
-        <item name="rrLoadingRingForegroundCol">?rrActionBarCol</item>
+        <item name="rrLoadingRingForegroundCol">?colorPrimary</item>
         <item name="rrLoadingRingBackgroundCol">#22000000</item>
 
         <item name="android:windowBackground">@color/lightWindowBackground</item>
@@ -150,7 +147,7 @@
         <item name="rrCommentBodyCol">#000000</item>
         <item name="rrCommentHeaderCol">#666666</item> <!-- TODO -->
         <item name="rrCommentHeaderBoldCol">#333333</item>
-        <item name="rrCommentHeaderAuthorCol">?rrActionBarCol</item>
+        <item name="rrCommentHeaderAuthorCol">?colorPrimary</item>
         <item name="rrCommentSpecificThreadHeaderBackCol">#FFFFCC</item>
         <item name="rrCommentSpecificThreadHeaderTextCol">#000000</item>
 
@@ -166,7 +163,7 @@
         <item name="rrPostCommentsButtonHighlightCol">#CCCCCC</item>
         <item name="rrPostCommentsButtonTextCol">#666666</item>
         <item name="rrPostThumbnailBackground">#DDDDDD</item>
-        <item name="rrPostFlingTextCol">?rrActionBarCol</item>
+        <item name="rrPostFlingTextCol">?colorPrimary</item>
         <item name="rrPostBackgroundColSticky">#DDFFDD</item>
         <item name="rrPostCommentsButtonBackColSticky">#BBEEBB</item>
         <item name="rrFlairBackCol">#DDDDDD</item>
@@ -200,33 +197,33 @@
     </style>
 
     <style name="RR.Light.Gray" parent="RR.Light.DarkActionBar">
-        <item name="rrActionBarCol">#222222</item>
+        <item name="colorPrimary">#222222</item>
         <item name="colorPrimaryDark">#222222</item>
         <item name="colorAccent">#607d8b</item>
     </style>
 
     <style name="RR.Light.Blue" parent="RR.Light.DarkActionBar">
-        <item name="rrActionBarCol">#2196f3</item>
+        <item name="colorPrimary">#2196f3</item>
         <item name="colorPrimaryDark">#1976d2</item>
     </style>
 
     <style name="RR.Light.LtBlue" parent="RR.Light.DarkActionBar">
-        <item name="rrActionBarCol">#03a9f4</item>
+        <item name="colorPrimary">#03a9f4</item>
         <item name="colorPrimaryDark">#0288d1</item>
     </style>
 
     <style name="RR.Light.Red" parent="RR.Light.DarkActionBar">
-        <item name="rrActionBarCol">#d32f2f</item>
+        <item name="colorPrimary">#d32f2f</item>
         <item name="colorPrimaryDark">#b52626</item>
     </style>
 
     <style name="RR.Light.Green" parent="RR.Light.DarkActionBar">
-        <item name="rrActionBarCol">#4caf50</item>
+        <item name="colorPrimary">#4caf50</item>
         <item name="colorPrimaryDark">#388e3c</item>
     </style>
 
     <style name="RR.Light.Orange" parent="RR.Light.DarkActionBar">
-        <item name="rrActionBarCol">#ff9800</item>
+        <item name="colorPrimary">#ff9800</item>
         <item name="colorPrimaryDark">#f57c00</item>
     </style>
 

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -46,8 +46,6 @@
         <item name="alertDialogTheme">@style/Theme.AppCompat.Dialog.Alert</item>
 		<item name="rrActionBarPopupThemeStyle">@style/ThemeOverlay.AppCompat.Dark</item>
 
-		<item name="actionBarSize">48dp</item>
-
         <!-- Post -->
 
         <item name="rrPostTitleCol">#DDDDDD</item>
@@ -146,8 +144,6 @@
         <item name="rrListHeaderTextCol">?colorAccent</item>
         <item name="rrListHeaderLineCol">?colorAccent</item>
         <item name="rrListSubtitleCol">#666666</item>
-
-		<item name="actionBarSize">48dp</item>
 
         <!-- Comment -->
 


### PR DESCRIPTION
I removed `OptionsMenuUtility.fixActionBar` as the method name, `fixActionBar` is nonsensical and using this method added an extra layer of complexity whereas using `setTitle` on the support action bar is shorter and already easy to understand.

Also regarding the `rrActionBarCol`, it is generally assumed that it is the primary colour of the app, so setting an extra attribute seemed a bit verbose.