### PR TITLE
Fix image save for some URLs

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/General.java
+++ b/src/main/java/org/quantumbadger/redreader/common/General.java
@@ -360,6 +360,10 @@ public final class General {
 
 	private static final Pattern urlPattern = Pattern.compile("^(https?)://([^/]+)/+([^\\?#]+)((?:\\?[^#]+)?)((?:#.+)?)$");
 
+	public static String filenameFromString(String url) {
+		return uriFromString(url).getPath().replace(File.separator, "");
+	}
+
 	public static URI uriFromString(String url) {
 
 		try {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -395,9 +395,8 @@ public final class RedditPreparedPost {
 											boolean fromCache,
 											String mimetype) {
 
-										File dst = new File(
-											Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
-											General.uriFromString(info.urlOriginal).getPath());
+										String filename = General.filenameFromString(info.urlOriginal);
+										File dst = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), filename);
 
 										if(dst.exists()) {
 											int count = 0;
@@ -406,7 +405,7 @@ public final class RedditPreparedPost {
 												count++;
 												dst = new File(
 													Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
-													count + "_" + General.uriFromString(info.urlOriginal).getPath().substring(1));
+													count + "_" + filename.substring(1));
 											}
 										}
 


### PR DESCRIPTION
`.getPath()` will return`/564x/57/56/e1/5756e17a05d3aeab42c32ebd99898866.jpg` for a URI like `https://s-media-cache-ak0.pinimg.com/564x/57/56/e1/5756e17a05d3aeab42c32ebd99898866.jpga`. (From [here](https://www.reddit.com/r/funny/comments/4sv4ez/aint_no_party_like/?))

This is an invalid filename (containing multiple `/`) and fails at https://github.com/QuantumBadger/RedReader/blob/master/src/main/java/org/quantumbadger/redreader/common/General.java#L114

This will remove all instances of `/` (File separator) from the output of `.getPath()` when being used as a filename.

Test against: https://www.reddit.com/r/funny/comments/4sv4ez/aint_no_party_like/