### PR TITLE
Add preference for configuring cache location

### DIFF
--- a/assets/changelog.txt
+++ b/assets/changelog.txt
@@ -2,6 +2,7 @@
 Multireddit viewing support
 Ability to view custom user pages
 Preference to use un-shortened link for "Share Comments" (thanks to fhtagn)
+Preference for cache storage location
 
 73/1.9.5.1
 Comment swipe actions

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -33,6 +33,7 @@ import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.things.RedditSubreddit;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -430,6 +431,26 @@ public final class PrefsUtility {
 	///////////////////////////////
 	// pref_cache
 	///////////////////////////////
+
+	// pref_cache_location
+
+	public static String pref_cache_location(final Context context,
+			final SharedPreferences sharedPreferences) {
+		File defaultCacheDir = context.getExternalCacheDir();
+		if (defaultCacheDir == null) {
+			defaultCacheDir = context.getCacheDir();
+		}
+		return getString(R.string.pref_cache_location_key,
+				defaultCacheDir.getAbsolutePath(),
+				context, sharedPreferences);
+	}
+
+	public static void pref_cache_location(Context context,
+			final SharedPreferences sharedPreferences, final String path) {
+		sharedPreferences.edit()
+				.putString(context.getString(R.string.pref_cache_location_key), path)
+				.apply();
+	}
 
 	// pref_cache_maxage
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -95,6 +95,11 @@
 
     <!-- Cache Prefs -->
 
+    <string name="pref_cache_general_header">General</string>
+
+    <string name="pref_cache_location_key">pref_cache_location</string>
+    <string name="pref_cache_location_title">Cache storage location</string>
+
     <string name="pref_cache_pruning">Cache Pruning</string>
 
     <string name="pref_cache_maxage_listing_key">pref_cache_maxage_listing</string>

--- a/src/main/res/xml/prefs_cache.xml
+++ b/src/main/res/xml/prefs_cache.xml
@@ -19,6 +19,13 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <PreferenceCategory android:title="@string/pref_cache_general_header">
+
+        <Preference android:title="@string/pref_cache_location_title"
+                    android:key="@string/pref_cache_location_key"/>
+
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/pref_cache_precache_images_header">
 
     <CheckBoxPreference android:title="@string/pref_cache_precache_images_title"


### PR DESCRIPTION
This allows you to chose from the internal storage and all external storage locations.
Changing the location will not migrate existing cache files, but they will still be
loaded from the old location (and will exentually be pruned).

The AlertDialog-related code is borrowed from [AntennaPod](http://antennapod.org/), which is MIT licensed.

Note: Your XML files (or at least strings.xml) seem to use a mix of tabs and spaces.  The editorconfig suggests that you want tabs, but I set it to spaces in my code, because that was what the majority of the file used and I wanted it to blend in.  You may want to do a conversion to one of the two later though.

Fixes #353.