### PR TITLE
Display list of blocked subreddits on main menu

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/RefreshableActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/RefreshableActivity.java
@@ -58,8 +58,11 @@ public abstract class RefreshableActivity extends BaseActivity {
 			return;
 		}
 
-		if(this instanceof MainActivity && key.equals(getString(R.string.pref_pinned_subreddits_key))) {
-			requestRefresh(RefreshableFragment.MAIN, false);
+		if(this instanceof MainActivity) {
+			if(key.equals(getString(R.string.pref_pinned_subreddits_key)) ||
+					key.equals(getString(R.string.pref_blocked_subreddits_key))) {
+				requestRefresh(RefreshableFragment.MAIN, false);
+			}
 		}
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -57,13 +57,14 @@ public class MainMenuListingManager {
 			GROUP_USER_ITEMS 				= 3,
 			GROUP_PINNED_SUBREDDITS_HEADER 	= 4,
 			GROUP_PINNED_SUBREDDITS_ITEMS 	= 5,
-			GROUP_MULTIREDDITS_HEADER 		= 6,
-			GROUP_MULTIREDDITS_ITEMS 		= 7,
-			GROUP_SUBREDDITS_HEADER 		= 8,
-			GROUP_SUBREDDITS_ITEMS 			= 9;
+			GROUP_BLOCKED_SUBREDDITS_HEADER	= 6,
+			GROUP_BLOCKED_SUBREDDITS_ITEMS  = 7,
+			GROUP_MULTIREDDITS_HEADER 		= 8,
+			GROUP_MULTIREDDITS_ITEMS 		= 9,
+			GROUP_SUBREDDITS_HEADER 		= 10,
+			GROUP_SUBREDDITS_ITEMS 			= 11;
 
-
-	@NonNull private final GroupedRecyclerViewAdapter mAdapter = new GroupedRecyclerViewAdapter(10);
+	@NonNull private final GroupedRecyclerViewAdapter mAdapter = new GroupedRecyclerViewAdapter(12);
 	@NonNull private final Context mContext;
 
 	@NonNull private final MainMenuSelectionListener mListener;
@@ -223,7 +224,26 @@ public class MainMenuListingManager {
 			}
 		}
 
+		final List<String> blockedSubreddits
+				= PrefsUtility.pref_blocked_subreddits(context, PreferenceManager.getDefaultSharedPreferences(context));
+		final PrefsUtility.BlockedSubredditSort blockedSubredditsSort = PrefsUtility.pref_behaviour_blocked_subredditsort(context, PreferenceManager.getDefaultSharedPreferences(context));
+		if (!blockedSubreddits.isEmpty()) {
+			mAdapter.appendToGroup(
+					GROUP_BLOCKED_SUBREDDITS_HEADER,
+					new GroupedRecyclerViewItemListSectionHeaderView(
+							context.getString(R.string.mainmenu_header_subreddits_blocked)));
 
+			switch (blockedSubredditsSort){
+				case NAME: Collections.sort(blockedSubreddits); break;
+				case DATE: /*noop*/break;
+			}
+
+			boolean isFirst = true;
+			for(final String sr : blockedSubreddits) {
+				mAdapter.appendToGroup(GROUP_BLOCKED_SUBREDDITS_ITEMS, makeSubredditItem(sr, isFirst));
+				isFirst = false;
+			}
+		}
 
 		if(!user.isAnonymous()) {
 			showMultiredditsHeader(context);

--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -224,24 +224,31 @@ public class MainMenuListingManager {
 			}
 		}
 
-		final List<String> blockedSubreddits
-				= PrefsUtility.pref_blocked_subreddits(context, PreferenceManager.getDefaultSharedPreferences(context));
-		final PrefsUtility.BlockedSubredditSort blockedSubredditsSort = PrefsUtility.pref_behaviour_blocked_subredditsort(context, PreferenceManager.getDefaultSharedPreferences(context));
-		if (!blockedSubreddits.isEmpty()) {
-			mAdapter.appendToGroup(
-					GROUP_BLOCKED_SUBREDDITS_HEADER,
-					new GroupedRecyclerViewItemListSectionHeaderView(
-							context.getString(R.string.mainmenu_header_subreddits_blocked)));
+		if(PrefsUtility.pref_appearance_show_blocked_subreddits_main_menu(
+				context,
+				PreferenceManager.getDefaultSharedPreferences(context))) {
+			final List<String> blockedSubreddits
+					= PrefsUtility.pref_blocked_subreddits(context, PreferenceManager.getDefaultSharedPreferences(context));
+			final PrefsUtility.BlockedSubredditSort blockedSubredditsSort = PrefsUtility.pref_behaviour_blocked_subredditsort(context, PreferenceManager.getDefaultSharedPreferences(context));
+			if (!blockedSubreddits.isEmpty()) {
+				mAdapter.appendToGroup(
+						GROUP_BLOCKED_SUBREDDITS_HEADER,
+						new GroupedRecyclerViewItemListSectionHeaderView(
+								context.getString(R.string.mainmenu_header_subreddits_blocked)));
 
-			switch (blockedSubredditsSort){
-				case NAME: Collections.sort(blockedSubreddits); break;
-				case DATE: /*noop*/break;
-			}
+				switch (blockedSubredditsSort) {
+					case NAME:
+						Collections.sort(blockedSubreddits);
+						break;
+					case DATE: /*noop*/
+						break;
+				}
 
-			boolean isFirst = true;
-			for(final String sr : blockedSubreddits) {
-				mAdapter.appendToGroup(GROUP_BLOCKED_SUBREDDITS_ITEMS, makeSubredditItem(sr, isFirst));
-				isFirst = false;
+				boolean isFirst = true;
+				for (final String sr : blockedSubreddits) {
+					mAdapter.appendToGroup(GROUP_BLOCKED_SUBREDDITS_ITEMS, makeSubredditItem(sr, isFirst));
+					isFirst = false;
+				}
 			}
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -231,6 +231,10 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_appearance_hide_username_main_menu_key, false, context, sharedPreferences);
 	}
 
+	public static boolean pref_appearance_show_blocked_subreddits_main_menu(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_appearance_show_blocked_subreddits_main_menu_key, false, context, sharedPreferences);
+	}
+
 	public static boolean pref_appearance_linkbuttons(final Context context, final SharedPreferences sharedPreferences) {
 		return getBoolean(R.string.pref_appearance_linkbuttons_key, true, context, sharedPreferences);
 	}

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -80,7 +80,8 @@ public final class PrefsUtility {
 				|| key.equals(context.getString(R.string.pref_behaviour_nsfw_key))
 				|| key.equals(context.getString(R.string.pref_behaviour_postcount_key))
 				|| key.equals(context.getString(R.string.pref_behaviour_comment_min_key))
-				|| key.equals(context.getString(R.string.pref_behaviour_pinned_subredditsort_key));
+				|| key.equals(context.getString(R.string.pref_behaviour_pinned_subredditsort_key))
+				|| key.equals(context.getString(R.string.pref_behaviour_blocked_subredditsort_key));
 	}
 
 	public static boolean isRestartRequired(Context context, String key) {
@@ -429,6 +430,14 @@ public final class PrefsUtility {
 
 	public static PinnedSubredditSort pref_behaviour_pinned_subredditsort(final Context context, final SharedPreferences sharedPreferences) {
 		return PinnedSubredditSort.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_pinned_subredditsort_key, "name", context, sharedPreferences)));
+	}
+
+	public enum BlockedSubredditSort {
+		NAME, DATE
+	}
+
+	public static BlockedSubredditSort pref_behaviour_blocked_subredditsort(final Context context, final SharedPreferences sharedPreferences) {
+		return BlockedSubredditSort.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_blocked_subredditsort_key, "name", context, sharedPreferences)));
 	}
 
 	public static boolean pref_behaviour_nsfw(final Context context, final SharedPreferences sharedPreferences) {

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -95,7 +95,8 @@ public final class SettingsFragment extends PreferenceFragment {
 				R.string.pref_behaviour_videoview_mode_key,
 				R.string.pref_behaviour_screenorientation_key,
 				R.string.pref_behaviour_gallery_swipe_length_key,
-				R.string.pref_behaviour_pinned_subredditsort_key
+				R.string.pref_behaviour_pinned_subredditsort_key,
+				R.string.pref_behaviour_blocked_subredditsort_key
 		};
 
 		final int[] editTextPrefsToUpdate = {

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -141,6 +141,17 @@
 		<item>date</item>
 	</string-array>
 
+	<string-array name="pref_behaviour_blocked_subredditsort_array">
+		<item>@string/sort_blocked_subreddit_name</item>
+		<item>@string/sort_blocked_subreddit_date</item>
+	</string-array>
+
+	<!-- Constants. Do not change. -->
+	<string-array name="pref_behaviour_blocked_subredditsort_array_return">
+		<item>name</item>
+		<item>date</item>
+	</string-array>
+
     <string-array name="pref_behaviour_actions_comment">
         <item>@string/action_collapse</item>
         <item>@string/action_actionmenu</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -915,4 +915,8 @@
 	<string name="pref_behaviour_blocked_subredditsort">Blocked Subreddit Sort</string>
 	<string name="sort_blocked_subreddit_name">By Name</string>
 	<string name="sort_blocked_subreddit_date">By Added Date</string>
+
+	<!-- 2016-09-21 -->
+	<string name="pref_appearance_show_blocked_subreddits_main_menu_key">pref_appearance_show_blocked_subreddits_main_menu</string>
+	<string name="pref_appearance_show_blocked_subreddits_main_menu_title">Show blocked subreddits in main menu</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -908,4 +908,11 @@
 	<!-- 2016-09-08 -->
 	<string name="pref_behaviour_enable_swipe_refresh_title">Swipe down to refresh</string>
 	<string name="pref_behaviour_enable_swipe_refresh_key">pref_behaviour_enable_swipe_refresh</string>
+
+	<!-- 2016-09-10 -->
+	<string name="mainmenu_header_subreddits_blocked">Blocked Subreddits</string>
+	<string name="pref_behaviour_blocked_subredditsort_key">pref_behaviour_blocked_subreddit_sort</string>
+	<string name="pref_behaviour_blocked_subredditsort">Blocked Subreddit Sort</string>
+	<string name="sort_blocked_subreddit_name">By Name</string>
+	<string name="sort_blocked_subreddit_date">By Added Date</string>
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -91,6 +91,12 @@
 						android:entryValues="@array/pref_behaviour_pinned_subredditsort_array_return"
 						android:defaultValue="name"/>
 
+		<ListPreference android:title="@string/pref_behaviour_blocked_subredditsort"
+						android:key="@string/pref_behaviour_blocked_subredditsort_key"
+						android:entries="@array/pref_behaviour_blocked_subredditsort_array"
+						android:entryValues="@array/pref_behaviour_blocked_subredditsort_array_return"
+						android:defaultValue="name"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_behaviour_actions_post_header">

--- a/src/main/res/xml/prefs_menus.xml
+++ b/src/main/res/xml/prefs_menus.xml
@@ -48,6 +48,10 @@
                         android:key="@string/pref_appearance_hide_username_main_menu_key"
                         android:defaultValue="false"/>
 
+	<CheckBoxPreference android:title="@string/pref_appearance_show_blocked_subreddits_main_menu_title"
+						android:key="@string/pref_appearance_show_blocked_subreddits_main_menu_key"
+						android:defaultValue="false"/>
+
     <MultiSelectListPreference
         android:dialogTitle="@string/pref_menus_post_context_items_title"
         android:key="@string/pref_menus_post_context_items_key"


### PR DESCRIPTION
Hi, QuantumBadger!

This pull request is related to issue #313 (being able to view blocked subreddits). The blocked subreddits are listed in their own section on the main menu (akin to the pinned subreddits).

Concerning the removal of blocked subreddits: One way to implement this could be by left/right swiping the subreddit list item. The same approach could also be applied to unpinning or unsubscribing subreddits. What do you think?

Last but not least: I really enjoy using RedReader and very much appreciate the open source aspect and GPL licensing! Thank you for creating it!