### PR TITLE
Enable sorting of user comment listing

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -38,6 +38,7 @@ import org.quantumbadger.redreader.listingcontrollers.CommentListingController;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
+import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.views.RedditPostView;
 
 import java.util.UUID;
@@ -133,6 +134,7 @@ public class CommentListingActivity extends RefreshableActivity
 				true,
 				false,
 				false,
+				controller.isUserCommentListing(),
 				false,
 				controller.isSortable(),
 				null,
@@ -175,6 +177,11 @@ public class CommentListingActivity extends RefreshableActivity
 	}
 
 	public void onSortSelected(final PostCommentListingURL.Sort order) {
+		controller.setSort(order);
+		requestRefresh(RefreshableFragment.COMMENTS, false);
+	}
+
+	public void onSortSelected(final UserCommentListingURL.Sort order) {
 		controller.setSort(order);
 		requestRefresh(RefreshableFragment.COMMENTS, false);
 	}

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -66,6 +66,7 @@ import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.PostListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
 import org.quantumbadger.redreader.reddit.url.SubredditPostListURL;
+import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.UserPostListingURL;
 import org.quantumbadger.redreader.reddit.url.UserProfileURL;
 import org.quantumbadger.redreader.views.RedditPostView;
@@ -670,7 +671,7 @@ public class MainActivity extends RefreshableActivity
 				commentsVisible,
 				false,
 				false,
-				postsSortable,
+				false, postsSortable,
 				commentsSortable,
 				subredditSubscriptionState,
 				postsVisible && subredditDescription != null && subredditDescription.length() > 0,
@@ -696,6 +697,11 @@ public class MainActivity extends RefreshableActivity
 	}
 
 	public void onSortSelected(final PostCommentListingURL.Sort order) {
+		commentListingController.setSort(order);
+		requestRefresh(RefreshableFragment.COMMENTS, false);
+	}
+
+	public void onSortSelected(final UserCommentListingURL.Sort order) {
 		commentListingController.setSort(order);
 		requestRefresh(RefreshableFragment.COMMENTS, false);
 	}

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -35,6 +35,7 @@ import org.quantumbadger.redreader.fragments.CommentListingFragment;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
+import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.views.RedditPostView;
 
 import java.util.ArrayList;
@@ -97,7 +98,7 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 
 	@Override
 	public boolean onCreateOptionsMenu(final Menu menu) {
-		OptionsMenuUtility.prepare(this, menu, false, false, true, false, false, false, false, null, false, false, null, null);
+		OptionsMenuUtility.prepare(this, menu, false, false, true, false, false, false, false, false, null, false, false, null, null);
 
 		if(mFragment != null) {
 			mFragment.onCreateOptionsMenu(menu);
@@ -139,6 +140,9 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 
 	@Override
 	public void onSortSelected(final PostCommentListingURL.Sort order) {}
+
+	@Override
+	public void onSortSelected(final UserCommentListingURL.Sort order) {}
 
 	@Override
 	public void onSearchComments() {

--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -34,6 +34,7 @@ import org.quantumbadger.redreader.fragments.AccountListDialog;
 import org.quantumbadger.redreader.reddit.PostSort;
 import org.quantumbadger.redreader.reddit.api.RedditSubredditSubscriptionManager;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
+import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.settings.SettingsActivity;
 
 import java.util.EnumSet;
@@ -72,7 +73,7 @@ public final class OptionsMenuUtility {
 			final E activity, final Menu menu,
 			final boolean subredditsVisible, final boolean postsVisible, final boolean commentsVisible,
 			final boolean areSearchResults, final boolean isUserPostListing,
-			final boolean postsSortable, final boolean commentsSortable,
+			final boolean isUserCommentListing, final boolean postsSortable, final boolean commentsSortable,
 			final RedditSubredditSubscriptionManager.SubredditSubscriptionState subredditSubscriptionState,
 			final boolean subredditHasSidebar,
 			final boolean pastCommentsSupported,
@@ -122,7 +123,10 @@ public final class OptionsMenuUtility {
 			if(subredditHasSidebar) add(activity, menu, Option.SIDEBAR, false);
 
 		} else if(!subredditsVisible && !postsVisible && commentsVisible) {
-			if(commentsSortable) addAllCommentSorts(activity, menu, true);
+			if(commentsSortable && !isUserCommentListing)
+				addAllCommentSorts(activity, menu, true);
+			else if(commentsSortable && isUserCommentListing)
+				addAllUserCommentSorts(activity, menu, true);
 			add(activity, menu, Option.REFRESH_COMMENTS, false);
 			if(optionsMenuItemsPrefs.contains(OptionsMenuItemsPref.SEARCH)) add(activity, menu, Option.SEARCH, false);
 			if(pastCommentsSupported) {
@@ -557,6 +561,40 @@ public final class OptionsMenuUtility {
 		});
 	}
 
+	private static void addAllUserCommentSorts(final AppCompatActivity activity, final Menu menu, final boolean icon) {
+
+		final SubMenu sortComments = menu.addSubMenu(R.string.options_sort_comments);
+
+		if(icon) {
+			sortComments.getItem().setIcon(R.drawable.ic_sort_dark);
+			sortComments.getItem().setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+		}
+
+		addSort(activity, sortComments, R.string.sort_comments_hot, UserCommentListingURL.Sort.HOT);
+		addSort(activity, sortComments, R.string.sort_comments_new, UserCommentListingURL.Sort.NEW);
+		addSort(activity, sortComments, R.string.sort_comments_controversial, UserCommentListingURL.Sort.CONTROVERSIAL);
+
+		final SubMenu sortCommentsTop = sortComments.addSubMenu(R.string.sort_comments_top);
+
+		addSort(activity, sortCommentsTop, R.string.sort_posts_top_hour, UserCommentListingURL.Sort.TOP_HOUR);
+		addSort(activity, sortCommentsTop, R.string.sort_posts_top_today, UserCommentListingURL.Sort.TOP_DAY);
+		addSort(activity, sortCommentsTop, R.string.sort_posts_top_week, UserCommentListingURL.Sort.TOP_WEEK);
+		addSort(activity, sortCommentsTop, R.string.sort_posts_top_month, UserCommentListingURL.Sort.TOP_MONTH);
+		addSort(activity, sortCommentsTop, R.string.sort_posts_top_year, UserCommentListingURL.Sort.TOP_YEAR);
+		addSort(activity, sortCommentsTop, R.string.sort_posts_top_all, UserCommentListingURL.Sort.TOP_ALL);
+	}
+
+	private static void addSort(final AppCompatActivity activity, final Menu menu, final int name, final UserCommentListingURL.Sort order) {
+
+		menu.add(activity.getString(name)).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+			@Override
+			public boolean onMenuItemClick(MenuItem menuItem) {
+				((OptionsMenuCommentsListener)activity).onSortSelected(order);
+				return true;
+			}
+		});
+	}
+
 	private interface OptionsMenuListener {
 	}
 
@@ -596,6 +634,8 @@ public final class OptionsMenuUtility {
 		void onPastComments();
 
 		void onSortSelected(PostCommentListingURL.Sort order);
+
+		void onSortSelected(UserCommentListingURL.Sort order);
 
 		void onSearchComments();
 	}

--- a/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
@@ -190,7 +190,7 @@ public class PostListingActivity extends RefreshableActivity
 				false,
 				controller.isSearchResults(),
 				controller.isUserPostListing(),
-				controller.isSortable(),
+				false, controller.isSortable(),
 				true,
 				subredditSubscriptionState,
 				subredditDescription != null && subredditDescription.length() > 0,

--- a/src/main/java/org/quantumbadger/redreader/listingcontrollers/CommentListingController.java
+++ b/src/main/java/org/quantumbadger/redreader/listingcontrollers/CommentListingController.java
@@ -28,6 +28,7 @@ import org.quantumbadger.redreader.fragments.CommentListingFragment;
 import org.quantumbadger.redreader.reddit.url.CommentListingURL;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
+import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 
 import java.util.UUID;
 
@@ -52,6 +53,10 @@ public class CommentListingController {
 			if(url.asPostCommentListURL().order == null) {
 				url = url.asPostCommentListURL().order(defaultOrder(context));
 			}
+		} else if(url.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL) {
+			if(url.asUserCommentListURL().order == null) {
+				url = url.asUserCommentListURL().order(UserCommentListingURL.Sort.NEW);
+			}
 		}
 
 		if(!(url instanceof CommentListingURL)) {
@@ -68,6 +73,12 @@ public class CommentListingController {
 	public void setSort(final PostCommentListingURL.Sort s) {
 		if(mUrl.pathType() == RedditURLParser.POST_COMMENT_LISTING_URL) {
 			mUrl = mUrl.asPostCommentListURL().order(s);
+		}
+	}
+
+	public void setSort(final UserCommentListingURL.Sort s) {
+		if(mUrl.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL) {
+			mUrl = mUrl.asUserCommentListURL().order(s);
 		}
 	}
 
@@ -108,6 +119,11 @@ public class CommentListingController {
 	}
 
 	public boolean isSortable() {
-		return mUrl.pathType() == RedditURLParser.POST_COMMENT_LISTING_URL;
+		return mUrl.pathType() == RedditURLParser.POST_COMMENT_LISTING_URL
+				|| mUrl.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL;
+	}
+
+	public boolean isUserCommentListing() {
+		return mUrl.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL;
 	}
 }


### PR DESCRIPTION
This one was trickier than #440, since user comment listing has a sort similar to `PostSort`. I couldn't use `PostCommentListingUrl.Sort`, so I had to overload some methods so I could use `UserCommentListingUrl.Sort` too.

`OptionsMenuUtility.prepare` just keeps on growing..

Fixes #362.