### PR TITLE
Code now has light-grey background color

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/markdown/MarkdownParagraph.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/markdown/MarkdownParagraph.java
@@ -23,12 +23,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
-import android.text.style.ClickableSpan;
-import android.text.style.RelativeSizeSpan;
-import android.text.style.StrikethroughSpan;
-import android.text.style.StyleSpan;
-import android.text.style.SuperscriptSpan;
-import android.text.style.TypefaceSpan;
+import android.text.style.*;
 import android.view.View;
 import org.quantumbadger.redreader.common.LinkHandler;
 import org.quantumbadger.redreader.views.LinkifiedTextView;
@@ -150,6 +145,7 @@ public final class MarkdownParagraph {
 						builder.append((char)tokens[i]);
 					}
 
+					builder.setSpan(new BackgroundColorSpan(0x33333333), codeStart, builder.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 					builder.setSpan(new TypefaceSpan("monospace"), codeStart, builder.length(),
 							Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/markdown/MarkdownParagraphGroup.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/markdown/MarkdownParagraphGroup.java
@@ -103,6 +103,7 @@ public final class MarkdownParagraphGroup {
 
 				case CODE:
 					tv.setTypeface(General.getMonoTypeface(activity));
+					tv.setBackgroundColor(0x33333333);
 					tv.setText(paragraph.raw.arr, paragraph.raw.start, paragraph.raw.length);
 					layout.addView(tv);
 


### PR DESCRIPTION
See #472

Both inline code (\`) and code blocks (introduced with 4 spaces or a tab)
now have a light-grey background color for better distinction.

Ideally, it would be possible to set that color based on the currently selected
theme, but it looks like the code would have to be refactored for that.

For now, I've chosen \#33333333 because it seems to be working in all themes.

A test post can be found [here](https://www.reddit.com/r/test/comments/612w0s/testing_underscore_parsing/).