### PR TITLE
Made HTTP backends configurable

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/cache/CacheDownload.java
+++ b/src/main/java/org/quantumbadger/redreader/cache/CacheDownload.java
@@ -22,7 +22,6 @@ import org.quantumbadger.redreader.common.PrioritisedCachedThreadPool;
 import org.quantumbadger.redreader.common.RRTime;
 import org.quantumbadger.redreader.common.TorCommon;
 import org.quantumbadger.redreader.http.HTTPBackend;
-import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
 import org.quantumbadger.redreader.jsonwrap.JsonValue;
 import org.quantumbadger.redreader.reddit.api.RedditOAuth;
 
@@ -58,7 +57,7 @@ public final class CacheDownload extends PrioritisedCachedThreadPool.Task {
 			session = UUID.randomUUID();
 		}
 
-		mRequest = OKHTTPBackend.getHttpBackend().prepareRequest(
+		mRequest = HTTPBackend.getBackend().prepareRequest(
 				initiator.context,
 				new HTTPBackend.RequestDetails(mInitiator.url, mInitiator.postFields));
 	}
@@ -142,7 +141,7 @@ public final class CacheDownload extends PrioritisedCachedThreadPool.Task {
 			@Override
 			public void onError(final @CacheRequest.RequestFailureType int failureType, final Throwable exception, final Integer httpStatus) {
 				if(mInitiator.queueType == CacheRequest.DOWNLOAD_QUEUE_REDDIT_API && TorCommon.isTorEnabled()) {
-					OKHTTPBackend.recreateHttpBackend();
+					HTTPBackend.getBackend().recreateHttpBackend();
 					resetUserCredentialsOnNextRequest();
 				}
 				mInitiator.notifyFailure(failureType, exception, httpStatus, "");

--- a/src/main/java/org/quantumbadger/redreader/common/TorCommon.java
+++ b/src/main/java/org/quantumbadger/redreader/common/TorCommon.java
@@ -25,7 +25,7 @@ import android.preference.PreferenceManager;
 import info.guardianproject.netcipher.proxy.OrbotHelper;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.cache.CacheDownload;
-import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
+import org.quantumbadger.redreader.http.HTTPBackend;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -73,7 +73,7 @@ public class TorCommon {
 		}
 
 		if(torChanged) {
-			OKHTTPBackend.recreateHttpBackend();
+			HTTPBackend.getBackend().recreateHttpBackend();
 			CacheDownload.resetUserCredentialsOnNextRequest();
 		}
 	}

--- a/src/main/java/org/quantumbadger/redreader/http/HTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/HTTPBackend.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.http;
 
 import android.content.Context;
 import org.quantumbadger.redreader.cache.CacheRequest;
+import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
 
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -26,9 +27,18 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.util.List;
 
-public interface HTTPBackend {
+public abstract class HTTPBackend {
 
-	class RequestDetails {
+	private static boolean useJavaBackend = false;
+
+	/**
+	 * Factory method can read configuration information to choose a backend
+	 */
+	public static HTTPBackend getBackend() {
+		return useJavaBackend ? new JavaHTTPBackend() : OKHTTPBackend.getHttpBackend();
+	}
+
+	public static class RequestDetails {
 
 		private final URI mUrl;
 		private final List<PostField> mPostFields;
@@ -47,7 +57,7 @@ public interface HTTPBackend {
 		}
 	}
 
-	class PostField {
+	public static class PostField {
 
 		public final String name;
 		public final String value;
@@ -82,7 +92,7 @@ public interface HTTPBackend {
 		}
 	}
 
-	interface Request {
+	public interface Request {
 		void executeInThisThread(final Listener listener);
 
 		void cancel();
@@ -90,11 +100,14 @@ public interface HTTPBackend {
 		void addHeader(String name, String value);
 	}
 
-	interface Listener {
+	public interface Listener {
 		void onError(@CacheRequest.RequestFailureType int failureType, Throwable exception, Integer httpStatus);
 
 		void onSuccess(String mimetype, Long bodyBytes, InputStream body);
 	}
 
-	Request prepareRequest(Context context, RequestDetails details);
+	public abstract Request prepareRequest(Context context, RequestDetails details);
+
+	public abstract void recreateHttpBackend();
+
 }

--- a/src/main/java/org/quantumbadger/redreader/http/JavaHTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/JavaHTTPBackend.java
@@ -1,3 +1,20 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
 package org.quantumbadger.redreader.http;
 
 import android.content.Context;

--- a/src/main/java/org/quantumbadger/redreader/http/JavaHTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/JavaHTTPBackend.java
@@ -1,0 +1,99 @@
+package org.quantumbadger.redreader.http;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.quantumbadger.redreader.cache.CacheRequest;
+import org.quantumbadger.redreader.common.TorCommon;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.List;
+
+/**
+ * HTTP Backend implementation using standard Java classes.
+ *
+ * Created by Mario Kosmiskas
+ */
+public class JavaHTTPBackend extends HTTPBackend {
+
+    private static final String TAG = "JavaHTTPBackend";
+
+	private List<PostField> postFields;
+
+	@Override
+	public void recreateHttpBackend() {}
+
+	@Override
+    public Request prepareRequest(Context context, RequestDetails details) {
+        HttpURLConnection urlConn;
+        try {
+			if (TorCommon.isTorEnabled()) {
+				Proxy tor = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118));
+				urlConn = (HttpURLConnection) details.getUrl().toURL().openConnection(tor);
+			} else {
+				urlConn = (HttpURLConnection) details.getUrl().toURL().openConnection();
+			}
+
+			postFields = details.getPostFields();
+
+            if (postFields != null) {
+                urlConn.setDoOutput(true);
+                urlConn.setRequestMethod("POST");
+				urlConn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            } else {
+                urlConn.setRequestMethod("GET");
+            }
+        } catch (Exception e) {
+			Log.e(TAG, "Error creating HTTP request for " + details.getUrl(), e);
+            return null;
+        }
+
+        final HttpURLConnection conn = urlConn;
+        return new Request() {
+            @Override
+            public void executeInThisThread(final Listener listener) {
+                try {
+                    try {
+                        conn.connect();
+
+						if (postFields != null) {
+							OutputStream os = conn.getOutputStream();
+							os.write(PostField.encodeList(postFields).getBytes());
+						}
+                    } catch(IOException e) {
+                        listener.onError(CacheRequest.REQUEST_FAILURE_CONNECTION, e, null);
+                        return;
+                    }
+
+                    final int status = conn.getResponseCode();
+                    if (status == 200 || status == 202) {
+                        final InputStream bodyStream = conn.getInputStream();
+                        final Long bodyBytes = Long.valueOf(conn.getContentLength());
+                        final String contentType = conn.getHeaderField("Content-Type");
+
+                        listener.onSuccess(contentType, bodyBytes, bodyStream);
+                    } else {
+                        listener.onError(CacheRequest.REQUEST_FAILURE_REQUEST, null, status);
+                    }
+                } catch(Throwable t) {
+                    listener.onError(CacheRequest.REQUEST_FAILURE_CONNECTION, t, null);
+                }
+            }
+
+            @Override
+            public void cancel() {
+                conn.disconnect();
+            }
+
+            @Override
+            public void addHeader(final String name, final String value) {
+                conn.addRequestProperty(name, value);
+            }
+        };
+    }
+}

--- a/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class OKHTTPBackend implements HTTPBackend {
+public class OKHTTPBackend extends HTTPBackend {
 
 	private final OkHttpClient mClient;
 	private static HTTPBackend httpBackend;
@@ -74,7 +74,8 @@ public class OKHTTPBackend implements HTTPBackend {
 		return httpBackend;
 	}
 
-	public static synchronized void recreateHttpBackend() {
+	@Override
+	public synchronized void recreateHttpBackend() {
 		httpBackend = new OKHTTPBackend();
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditOAuth.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditOAuth.java
@@ -30,7 +30,6 @@ import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.RRError;
 import org.quantumbadger.redreader.http.HTTPBackend;
-import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
 import org.quantumbadger.redreader.jsonwrap.JsonBufferedObject;
 import org.quantumbadger.redreader.jsonwrap.JsonValue;
 
@@ -291,7 +290,7 @@ public final class RedditOAuth {
 		postFields.add(new HTTPBackend.PostField("redirect_uri", REDIRECT_URI));
 
 		try {
-			final HTTPBackend.Request request = OKHTTPBackend.getHttpBackend().prepareRequest(
+			final HTTPBackend.Request request = HTTPBackend.getBackend().prepareRequest(
 					context,
 					new HTTPBackend.RequestDetails(
 							General.uriFromString(uri),
@@ -362,7 +361,7 @@ public final class RedditOAuth {
 
 		try {
 			final HTTPBackend.Request request
-					= OKHTTPBackend.getHttpBackend().prepareRequest(context, new HTTPBackend.RequestDetails(uri, null));
+					= HTTPBackend.getBackend().prepareRequest(context, new HTTPBackend.RequestDetails(uri, null));
 
 			request.addHeader("Authorization", "bearer " + accessToken.token);
 
@@ -596,7 +595,7 @@ public final class RedditOAuth {
 		postFields.add(new HTTPBackend.PostField("refresh_token", refreshToken.token));
 
 		try {
-			final HTTPBackend.Request request = OKHTTPBackend.getHttpBackend().prepareRequest(context, new HTTPBackend.RequestDetails(
+			final HTTPBackend.Request request = HTTPBackend.getBackend().prepareRequest(context, new HTTPBackend.RequestDetails(
 					General.uriFromString(uri),
 					postFields));
 
@@ -671,7 +670,7 @@ public final class RedditOAuth {
 		postFields.add(new HTTPBackend.PostField("device_id", "DO_NOT_TRACK_THIS_DEVICE"));
 
 		try {
-			final HTTPBackend.Request request = OKHTTPBackend.getHttpBackend().prepareRequest(context, new HTTPBackend.RequestDetails(
+			final HTTPBackend.Request request = HTTPBackend.getBackend().prepareRequest(context, new HTTPBackend.RequestDetails(
 					General.uriFromString(uri),
 					postFields));
 


### PR DESCRIPTION
Completely isolated the HTTP backends to allow for other implementations. This change includes a backend using just standard Java HTTP classes.

The original OKHttpBackend is the only one returned by the factory but configuration can be used to allow the user to pick different ones