### PR TITLE
Replaced thumbnails with previews

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile 'com.android.support:design:25.0.1'
     compile 'com.squareup.okhttp3:okhttp:3.6.0'
     compile 'info.guardianproject.netcipher:netcipher:1.2.1'
+	compile 'com.android.support.constraint:constraint-layout:+'
 
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
@@ -23,6 +23,8 @@ import org.quantumbadger.redreader.reddit.prepared.markdown.MarkdownParser;
 import org.quantumbadger.redreader.reddit.things.RedditPost;
 import org.quantumbadger.redreader.reddit.things.RedditThingWithIdAndType;
 
+import java.util.List;
+
 public class RedditParsedPost implements RedditThingWithIdAndType {
 
 	private final RedditPost mSrc;
@@ -93,6 +95,10 @@ public class RedditParsedPost implements RedditThingWithIdAndType {
 
 	public String getThumbnailUrl() {
 		return mSrc.thumbnail;
+	}
+
+	public List<RedditPost.PreviewImage> getPreview() {
+		return mSrc.images;
 	}
 
 	public boolean isArchived() {

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -20,8 +20,25 @@ package org.quantumbadger.redreader.reddit.things;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.Html;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class RedditPost implements Parcelable, RedditThingWithIdAndType {
+
+	public static class PreviewImage {
+		public final long mWidth;
+		public final long mHeight;
+		public final URI mUri;
+
+		public PreviewImage(long w, long h, String url) {
+			mWidth = w;
+			mHeight = h;
+			mUri = URI.create(Html.fromHtml(url).toString());
+		}
+	}
 
 	public String id, name;
 	public String title, url, author, domain, subreddit, subreddit_id;
@@ -35,6 +52,7 @@ public final class RedditPost implements Parcelable, RedditThingWithIdAndType {
 
 	public String selftext, permalink, link_flair_text, author_flair_text;
 	public String thumbnail; // an image URL
+	public List<PreviewImage> images = new ArrayList<>();
 
 	public RedditPost() {}
 

--- a/src/main/java/org/quantumbadger/redreader/views/PreviewView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/PreviewView.java
@@ -1,0 +1,60 @@
+package org.quantumbadger.redreader.views;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.View;
+
+import org.quantumbadger.redreader.R;
+
+/**
+ * Created by Mario Kosmiskas on 4/28/17.
+ */
+
+public class PreviewView extends android.support.v7.widget.AppCompatImageView {
+
+	public PreviewView(Context context) {
+		super(context, null);
+	}
+
+	public PreviewView(Context context, AttributeSet attrs) {
+		this(context, attrs, 0);
+	}
+
+	public PreviewView(Context context, AttributeSet attrs, int defStyleAttr) {
+		super(context, attrs, defStyleAttr);
+	}
+
+	/**
+	 * Cap the height of the preview image to fit on the screen
+	 *
+	 * @param widthMeasureSpec
+	 * @param heightMeasureSpec
+	 */
+	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+		Drawable d = getDrawable();
+
+		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+		// Container for posts
+		// TODO: Find a better way to locate this view, this is too brittle
+		View allPostsContainer = (View)this.getParent().getParent().getParent();
+
+		// Get the height of the post description
+		int postHeight = 0;
+		if (getContext() instanceof Activity) {
+			Activity activity = (Activity)getContext();
+			View postView = activity.findViewById(R.id.reddit_post_layout);
+			postHeight = postView.getHeight();
+		}
+
+		// Calculate the desired preview height maintaining the aspect ratio
+		int parentWidth = MeasureSpec.getSize(widthMeasureSpec);
+		int newH = (int)((float)parentWidth * d.getIntrinsicHeight() / d.getIntrinsicWidth());
+
+		int maxHeight = allPostsContainer.getHeight() - postHeight;
+		this.setMeasuredDimension(parentWidth, Math.min(newH, maxHeight));
+	}
+
+}

--- a/src/main/res/layout/reddit_post.xml
+++ b/src/main/res/layout/reddit_post.xml
@@ -17,72 +17,61 @@
   ~ along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<LinearLayout
-		xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
 		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical"
-		android:baselineAligned="false">
+		android:layout_height="wrap_content">
 
 	<View
 			android:id="@+id/view_reddit_post_divider_top"
-			android:layout_width="match_parent"
+			android:layout_width="0dp"
 			android:layout_height="1dp"
-			android:background="?rrListDividerCol"/>
+			android:background="?rrListDividerCol"
+			app:layout_constraintTop_toTopOf="parent"
+			app:layout_constraintLeft_toLeftOf="@+id/reddit_post_thumbnail_view"
+			app:layout_constraintRight_toRightOf="@+id/reddit_post_thumbnail_view" />
 
 	<LinearLayout
 			android:id="@+id/reddit_post_layout"
-			android:layout_width="match_parent"
+			android:layout_width="0dp"
 			android:layout_height="wrap_content"
-			android:gravity="center_vertical"
 			android:background="?rrListItemBackgroundCol"
-			android:orientation="horizontal"
+			android:gravity="center_vertical"
 			android:minHeight="64dp"
-			android:elevation="10dp">
+			android:orientation="horizontal"
+			app:layout_constraintLeft_toLeftOf="parent"
+			app:layout_constraintRight_toRightOf="parent"
+			app:layout_constraintTop_toBottomOf="@+id/reddit_post_thumbnail_view">
 
-		<FrameLayout
-				android:layout_width="wrap_content"
+		<ImageView
+				android:id="@+id/reddit_post_overlay_icon"
+				android:layout_width="64dp"
 				android:layout_height="match_parent"
-				android:baselineAligned="false"
-				android:background="?rrPostThumbnailBackground">
-
-			<ImageView
-					android:id="@+id/reddit_post_thumbnail_view"
-					android:layout_width="wrap_content"
-					android:layout_height="match_parent"
-					android:scaleType="center"/>
-
-			<ImageView
-					android:id="@+id/reddit_post_overlay_icon"
-					android:layout_width="64dp"
-					android:layout_height="match_parent"
-					android:scaleType="center"
-					android:visibility="gone"
-					android:background="#99000000"/>
-
-		</FrameLayout>
+				android:background="#99000000"
+				android:scaleType="center"
+				android:visibility="gone" />
 
 		<LinearLayout
 				android:id="@+id/reddit_post_textLayout"
-				android:layout_height="wrap_content"
 				android:layout_width="0px"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:gravity="center_vertical"
 				android:orientation="vertical"
 				android:paddingLeft="2dp"
-				android:paddingRight="2dp"
-				android:gravity="center_vertical"
-				android:layout_weight="1">
+				android:paddingRight="2dp">
 
 			<!-- todo theme color -->
 			<TextView
 					android:id="@+id/reddit_post_title"
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
-					android:textColor="?rrPostTitleCol"
+					android:paddingBottom="0dp"
 					android:paddingLeft="10dp"
 					android:paddingRight="5dp"
 					android:paddingTop="5dp"
-					android:paddingBottom="0dp"
-					android:textSize="14sp"/>
+					android:textColor="?rrPostTitleCol"
+					android:textSize="14sp" />
 
 			<!-- todo theme color -->
 			<TextView
@@ -90,12 +79,12 @@
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
 					android:gravity="center_vertical"
-					android:textColor="#909090"
+					android:paddingBottom="5dp"
 					android:paddingLeft="10dp"
 					android:paddingRight="5dp"
 					android:paddingTop="1dp"
-					android:paddingBottom="5dp"
-					android:textSize="11sp"/>
+					android:textColor="#909090"
+					android:textSize="11sp" />
 
 		</LinearLayout>
 
@@ -103,31 +92,42 @@
 				android:id="@+id/reddit_post_comments_button"
 				android:layout_width="50dp"
 				android:layout_height="match_parent"
-				android:gravity="center"
 				android:background="?rrPostCommentsButtonBackCol"
+				android:gravity="center"
 				android:orientation="vertical">
 
 			<ImageView
-					android:layout_height="wrap_content"
 					android:layout_width="match_parent"
-					android:src="?rrIconComments"
-					android:scaleType="fitCenter"
+					android:layout_height="wrap_content"
+					android:layout_marginBottom="2dp"
 					android:layout_marginLeft="8dp"
 					android:layout_marginRight="8dp"
 					android:layout_marginTop="4dp"
-					android:layout_marginBottom="2dp"
-					android:contentDescription="Comments"/> <!-- TODO string -->
+					android:contentDescription="Comments"
+					android:scaleType="fitCenter"
+					android:src="?rrIconComments" /> <!-- TODO string -->
 
 			<TextView
 					android:id="@+id/reddit_post_comments_text"
-					android:layout_height="wrap_content"
 					android:layout_width="fill_parent"
+					android:layout_height="wrap_content"
 					android:gravity="center"
-					android:textSize="11sp"
-					android:textColor="?rrPostCommentsButtonTextCol"/>
+					android:textColor="?rrPostCommentsButtonTextCol"
+					android:textSize="11sp" />
 
 		</LinearLayout>
 
 	</LinearLayout>
 
-</LinearLayout>
+	<org.quantumbadger.redreader.views.PreviewView
+			android:id="@+id/reddit_post_thumbnail_view"
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:paddingTop="10dp"
+			android:scaleType="centerCrop"
+			android:adjustViewBounds="true"
+			app:layout_constraintLeft_toLeftOf="parent"
+			app:layout_constraintRight_toRightOf="parent"
+			app:layout_constraintTop_toBottomOf="@+id/view_reddit_post_divider_top" />
+
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
This change replaces the small thumbnails with large previews. Previews fill the entire column and are height capped to make sure the entire image for a post is visible without scrolling.

The preview images are not tap or fling aware, only the post title is to maintain the original feel of the app.

This is a big design change, I understand if you rather not change the app so dramatically. Another option is to allow users to select between thumbnail and previews. I personally really like the large previews, especially for subreddits like aww and pics.

This is how it looks on the front page

<img width="526" alt="screen shot 2017-04-29 at 5 14 24 pm" src="https://cloud.githubusercontent.com/assets/26751219/25560152/f66084ea-2d00-11e7-95e9-20625e02158b.png">

Even subreddits like gadgets look great using previews

<img width="526" alt="screen shot 2017-04-29 at 5 15 07 pm" src="https://cloud.githubusercontent.com/assets/26751219/25560156/0cb5d77c-2d01-11e7-9e0f-ce6e321b549e.png">

If no images are allowed the subreddit looks just like it does today

<img width="512" alt="screen shot 2017-04-29 at 5 18 56 pm" src="https://cloud.githubusercontent.com/assets/26751219/25560157/21a65ff8-2d01-11e7-824a-1c4560edca2c.png">

