### PR TITLE
Fixed bug where download links show blank webpage in internal browser

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -39,6 +39,7 @@ import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import android.widget.Toast;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.cache.CacheManager;
 import org.quantumbadger.redreader.common.AndroidApi;
@@ -56,8 +57,6 @@ import org.quantumbadger.redreader.views.bezelmenu.SideToolbarOverlay;
 import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
-
-import static org.quantumbadger.redreader.common.General.onBackPressed;
 
 public class WebViewFragment extends Fragment implements RedditPostView.PostSelectionListener {
 
@@ -78,7 +77,7 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 
 		final Bundle bundle = new Bundle(1);
 		bundle.putString("url", url);
-		if(post != null) bundle.putParcelable("post", post);
+		if (post != null) bundle.putParcelable("post", post);
 		f.setArguments(bundle);
 
 		return f;
@@ -107,16 +106,16 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 	@Override
 	public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
 
-		mActivity = (AppCompatActivity)getActivity();
+		mActivity = (AppCompatActivity) getActivity();
 
 		CookieSyncManager.createInstance(mActivity);
 
-		outer = (FrameLayout)inflater.inflate(R.layout.web_view_fragment, null);
+		outer = (FrameLayout) inflater.inflate(R.layout.web_view_fragment, null);
 
 		final RedditPost src_post = getArguments().getParcelable("post");
 		final RedditPreparedPost post;
 
-		if(src_post != null) {
+		if (src_post != null) {
 
 			final RedditParsedPost parsedPost = new RedditParsedPost(src_post, false);
 
@@ -133,8 +132,8 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 			post = null;
 		}
 
-		webView = (WebViewFixed)outer.findViewById(R.id.web_view_fragment_webviewfixed);
-		final FrameLayout loadingViewFrame = (FrameLayout)outer.findViewById(R.id.web_view_fragment_loadingview_frame);
+		webView = (WebViewFixed) outer.findViewById(R.id.web_view_fragment_webviewfixed);
+		final FrameLayout loadingViewFrame = (FrameLayout) outer.findViewById(R.id.web_view_fragment_loadingview_frame);
 
 		/*handle download links show an alert box to load this outside the internal browser*/
 		webView.setDownloadListener(new DownloadListener() {
@@ -166,7 +165,7 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 
 		progressView = new ProgressBar(mActivity, null, android.R.attr.progressBarStyleHorizontal);
 		loadingViewFrame.addView(progressView);
-		loadingViewFrame.setPadding(General.dpToPixels(mActivity, 10), 0,  General.dpToPixels(mActivity, 10), 0);
+		loadingViewFrame.setPadding(General.dpToPixels(mActivity, 10), 0, General.dpToPixels(mActivity, 10), 0);
 
 		final WebSettings settings = webView.getSettings();
 
@@ -200,7 +199,7 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 		});
 
 
-		if(mUrl != null) {
+		if (mUrl != null) {
 			webView.loadUrl(mUrl);
 		} else {
 			webView.loadDataWithBaseURL("https://reddit.com/", html, "text/html; charset=UTF-8", null, null);
@@ -210,15 +209,15 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 			@Override
 			public boolean shouldOverrideUrlLoading(final WebView view, final String url) {
 
-				if(url == null) return false;
+				if (url == null) return false;
 
-				if(url.startsWith("data:")) {
+				if (url.startsWith("data:")) {
 					// Prevent imgur bug where we're directed to some random data URI
 					return true;
 				}
 
 				// Go back if loading same page to prevent redirect loops.
-				if(goingBack && currentUrl != null && url.equals(currentUrl)) {
+				if (goingBack && currentUrl != null && url.equals(currentUrl)) {
 
 					General.quickToast(mActivity,
 							String.format(Locale.US, "Handling redirect loop (level %d)", -lastBackDepthAttempt), Toast.LENGTH_SHORT);
@@ -230,9 +229,9 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 					} else {
 						mActivity.finish();
 					}
-				} else  {
+				} else {
 
-					if(RedditURLParser.parse(Uri.parse(url)) != null) {
+					if (RedditURLParser.parse(Uri.parse(url)) != null) {
 						LinkHandler.onLinkClicked(mActivity, url, false);
 					} else {
 						webView.loadUrl(url);
@@ -247,11 +246,11 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 			public void onPageStarted(WebView view, String url, Bitmap favicon) {
 				super.onPageStarted(view, url, favicon);
 
-				if(mUrl != null && url != null) {
+				if (mUrl != null && url != null) {
 
 					final AppCompatActivity activity = mActivity;
 
-					if(activity != null) {
+					if (activity != null) {
 						activity.setTitle(url);
 					}
 				}
@@ -269,18 +268,18 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 							@Override
 							public void run() {
 
-								if(currentUrl == null || url == null) return;
+								if (currentUrl == null || url == null) return;
 
-								if(!url.equals(view.getUrl())) return;
+								if (!url.equals(view.getUrl())) return;
 
-								if(goingBack && url.equals(currentUrl)) {
+								if (goingBack && url.equals(currentUrl)) {
 
 									General.quickToast(mActivity,
 											String.format(Locale.US, "Handling redirect loop (level %d)", -lastBackDepthAttempt));
 
 									lastBackDepthAttempt--;
 
-									if(webView.canGoBackOrForward(lastBackDepthAttempt)) {
+									if (webView.canGoBackOrForward(lastBackDepthAttempt)) {
 										webView.goBackOrForward(lastBackDepthAttempt);
 									} else {
 										mActivity.finish();
@@ -304,7 +303,7 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 		final FrameLayout outerFrame = new FrameLayout(mActivity);
 		outerFrame.addView(outer);
 
-		if(post != null) {
+		if (post != null) {
 
 			final SideToolbarOverlay toolbarOverlay = new SideToolbarOverlay(mActivity);
 
@@ -321,7 +320,7 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 				@Override
 				public boolean onTap() {
 
-					if(toolbarOverlay.isShown()) {
+					if (toolbarOverlay.isShown()) {
 						toolbarOverlay.hide();
 						return true;
 					}
@@ -361,7 +360,7 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 
 	public boolean onBackButtonPressed() {
 
-		if(webView.canGoBack()) {
+		if (webView.canGoBack()) {
 			goingBack = true;
 			lastBackDepthAttempt = -1;
 			webView.goBack();
@@ -372,11 +371,11 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 	}
 
 	public void onPostSelected(final RedditPreparedPost post) {
-		((RedditPostView.PostSelectionListener)mActivity).onPostSelected(post);
+		((RedditPostView.PostSelectionListener) mActivity).onPostSelected(post);
 	}
 
 	public void onPostCommentsSelected(final RedditPreparedPost post) {
-		((RedditPostView.PostSelectionListener)mActivity).onPostCommentsSelected(post);
+		((RedditPostView.PostSelectionListener) mActivity).onPostCommentsSelected(post);
 	}
 
 	public String getCurrentUrl() {

--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -18,16 +18,20 @@
 package org.quantumbadger.redreader.fragments;
 
 import android.annotation.SuppressLint;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
+import android.webkit.DownloadListener;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -52,6 +56,8 @@ import org.quantumbadger.redreader.views.bezelmenu.SideToolbarOverlay;
 import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
+
+import static org.quantumbadger.redreader.common.General.onBackPressed;
 
 public class WebViewFragment extends Fragment implements RedditPostView.PostSelectionListener {
 
@@ -129,6 +135,34 @@ public class WebViewFragment extends Fragment implements RedditPostView.PostSele
 
 		webView = (WebViewFixed)outer.findViewById(R.id.web_view_fragment_webviewfixed);
 		final FrameLayout loadingViewFrame = (FrameLayout)outer.findViewById(R.id.web_view_fragment_loadingview_frame);
+
+		/*handle download links show an alert box to load this outside the internal browser*/
+		webView.setDownloadListener(new DownloadListener() {
+			@Override
+			public void onDownloadStart(final String url, String userAgent, String contentDisposition, String mimetype, long contentLength) {
+				{
+					new AlertDialog.Builder(mActivity)
+							.setTitle(R.string.download_link_title)
+							.setMessage(R.string.download_link_message)
+							.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+								public void onClick(DialogInterface dialog, int which) {
+									Intent i = new Intent(Intent.ACTION_VIEW);
+									i.setData(Uri.parse(url));
+									getContext().startActivity(i);
+									mActivity.onBackPressed(); //get back from internal browser
+								}
+							})
+							.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+								public void onClick(DialogInterface dialog, int which) {
+									mActivity.onBackPressed(); //get back from internal browser
+								}
+							})
+							.setIcon(android.R.drawable.ic_dialog_alert)
+							.show();
+				}
+			}
+		});
+		/*handle download links end*/
 
 		progressView = new ProgressBar(mActivity, null, android.R.attr.progressBarStyleHorizontal);
 		loadingViewFrame.addView(progressView);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -999,4 +999,9 @@
 	<string name="pref_appearance_comments_show_floating_toolbar_title">Show floating toolbar over comments</string>
 	<string name="pref_appearance_comments_show_floating_toolbar_key" translatable="false">pref_appearance_comments_show_floating_toolbar</string>
 
+
+	<!--2017-05-08-->
+	<string name="download_link_title">Download File</string>
+	<string name="download_link_message">This is a download link. Do you want to load this in external browser?</string>
+
 </resources>


### PR DESCRIPTION
In reference to https://github.com/QuantumBadger/RedReader/issues/456

I modified WebViewFragment.java where in onCreateView after the webView is initialised, I am calling setDownloadListener. I am showing an alert box to let the user know if he or she is willing to load the download link in an external browser. Links to websites load normally. 

Tested on Android  4.4
