### PR TITLE
No longer caching thumbnails in memory

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/image/ImageLoader.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ImageLoader.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.quantumbadger.redreader.image;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+import android.util.Pair;
+import android.widget.ImageView;
+
+import org.quantumbadger.redreader.cache.CacheManager;
+import org.quantumbadger.redreader.common.AndroidApi;
+
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * Created by Mario Kosmiskas on 5/21/17.
+ */
+
+public class ImageLoader {
+
+	private static ImageLoader mInstance = new ImageLoader();
+
+	private final Thread mWorker;
+	private final LinkedBlockingDeque<Pair<CacheManager.ReadableCacheFile,ImageView>> mQueue;
+
+	private final Runnable mTask = new Runnable() {
+		@Override
+		public void run() {
+			while (true) {
+				try {
+					final Pair task = mQueue.take();
+					final Bitmap image = BitmapFactory.decodeStream(((CacheManager.ReadableCacheFile)task.first).getInputStream());
+
+					AndroidApi.UI_THREAD_HANDLER.post(new Runnable() {
+						@Override
+						public void run() {
+							((ImageView)task.second).setImageBitmap(image);
+						}
+					});
+				} catch (Exception e) {
+					Log.e("ImageLoader", "Error loading image from cache", e);
+				}
+
+			}
+		}
+	};
+
+	private ImageLoader() {
+		mQueue = new LinkedBlockingDeque<>();
+
+		mWorker = new Thread(mTask, "Image Loader");
+		mWorker.start();
+	}
+
+	public static void loadImage(CacheManager.ReadableCacheFile imageFile, ImageView target) {
+		mInstance.mQueue.add(new Pair(imageFile, target));
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -74,12 +74,8 @@ public final class RedditPreparedPost {
 	public final boolean hasThumbnail;
 	public final boolean mIsProbablyAnImage;
 
-	// TODO make it possible to turn off in-memory caching when out of memory
 	private volatile CacheManager.ReadableCacheFile thumbnailCache = null;
 
-	private static final Object singleImageDecodeLock = new Object();
-
-	private final int mWidthPixels;
 	private ThumbnailLoadedCallback thumbnailCallback;
 	private int usageId = -1;
 
@@ -152,7 +148,6 @@ public final class RedditPreparedPost {
 
 		mIsProbablyAnImage = LinkHandler.isProbablyAnImage(post.getUrl());
 
-		mWidthPixels = General.dpToPixels(context, 64);
 		hasThumbnail = showThumbnails && hasThumbnail(post);
 
 		if(hasThumbnail && hasThumbnail(post)) {
@@ -776,16 +771,10 @@ public final class RedditPreparedPost {
 	}
 
 	// These operations are ordered so as to avoid race conditions
-	public Bitmap getThumbnail(final ThumbnailLoadedCallback callback, final int usageId) {
+	public CacheManager.ReadableCacheFile getThumbnail(final ThumbnailLoadedCallback callback, final int usageId) {
 		this.thumbnailCallback = callback;
 		this.usageId = usageId;
-		try {
-			return BitmapFactory.decodeStream(thumbnailCache.getInputStream());
-		} catch (Exception e) {
-			Log.e("RedditPreparedPost", "Error loading image from the cache", e);
-		}
-
-		return null;
+		return thumbnailCache;
 	}
 
 	public boolean isSelf() {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -20,8 +20,6 @@ package org.quantumbadger.redreader.views;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.TypedArray;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -39,12 +37,10 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.cache.CacheManager;
-import org.quantumbadger.redreader.common.AndroidApi;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.fragments.PostListingFragment;
+import org.quantumbadger.redreader.image.ImageLoader;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
-
-import java.io.IOException;
 
 public final class RedditPostView extends FlingableItemView implements RedditPreparedPost.ThumbnailLoadedCallback {
 
@@ -200,13 +196,7 @@ public final class RedditPostView extends FlingableItemView implements RedditPre
 				if(usageId != msg.what) return;
 				//Stream Image from cache and assign, old path of bitmap in msg.obj
 				CacheManager.ReadableCacheFile objPath = (CacheManager.ReadableCacheFile)msg.obj;
-				try {
-					Bitmap data = BitmapFactory.decodeStream(objPath.getInputStream());
-					thumbnailView.setImageBitmap(data);
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-
+				ImageLoader.loadImage(objPath, thumbnailView);
 			}
 		};
 
@@ -279,13 +269,7 @@ public final class RedditPostView extends FlingableItemView implements RedditPre
 			usageId++;
 
 			resetSwipeState();
-			AndroidApi.UI_THREAD_HANDLER.post(new Runnable() {
-				@Override
-				public void run() {
-					final Bitmap thumbnail = data.getThumbnail(RedditPostView.this, usageId);
-					thumbnailView.setImageBitmap(thumbnail);
-				}
-			});
+			ImageLoader.loadImage(data.getThumbnail(RedditPostView.this, usageId), thumbnailView);
 
 			title.setText(data.src.getTitle());
 			commentsText.setText(String.valueOf(data.src.getSrc().num_comments));

--- a/src/main/res/layout/reddit_post.xml
+++ b/src/main/res/layout/reddit_post.xml
@@ -48,9 +48,9 @@
 
 			<ImageView
 					android:id="@+id/reddit_post_thumbnail_view"
-					android:layout_width="wrap_content"
+					android:layout_width="64dp"
 					android:layout_height="match_parent"
-					android:scaleType="center"/>
+					android:scaleType="centerCrop"/>
 
 			<ImageView
 					android:id="@+id/reddit_post_overlay_icon"


### PR DESCRIPTION
The RecyclerView takes care of managing posts on the screen. Whenever a
post is shown its thumbnail is loaded from the file cache. Since that's
done asynchronously there is no performace hit.

Images in this patch are resized by the ImageView. This is not stricly
necesary but it makes the display logic simpler and would allow for
the size of thumbnails to be configurable.

This patch reduces memory utilization which is needed by the patch implementing preview images