### PR TITLE
Added setting for self-post collapse

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -436,6 +436,14 @@ public final class PrefsUtility {
 		return PostFlingAction.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_fling_post_right_key, "upvote", context, sharedPreferences)));
 	}
 
+	public enum SelfpostAction {
+		COLLAPSE, NOTHING
+	}
+
+	public static SelfpostAction pref_behaviour_self_post_tap_actions(final Context context, final SharedPreferences sharedPreferences) {
+		return SelfpostAction.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_self_post_tap_actions_key, "collapse", context, sharedPreferences)));
+	}
+
 	// pref_behaviour_fling_comment
 
 	public enum CommentFlingAction {

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -318,7 +318,6 @@ public class CommentListingFragment extends RRFragment
 		final RedditCommentListItem item = view.getComment();
 
 		if(item.isComment()) {
-
 			final RedditRenderableComment comment = item.asComment();
 
 			changeDataManager.markHidden(
@@ -497,19 +496,22 @@ public class CommentListingFragment extends RRFragment
 				paddingLayout.addView(collapsedView);
 				paddingLayout.setPadding(paddingPx, paddingPx, paddingPx, paddingPx);
 
-				paddingLayout.setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View v) {
-						if (selfText.getVisibility() == View.GONE){
-							selfText.setVisibility(View.VISIBLE);
-							collapsedView.setVisibility(View.GONE);
-						} else {
-							selfText.setVisibility(View.GONE);
-							collapsedView.setVisibility(View.VISIBLE);
-						}
+				PrefsUtility.SelfpostAction actionOnClick = PrefsUtility.pref_behaviour_self_post_tap_actions(context, PreferenceManager.getDefaultSharedPreferences(context));
+				if (actionOnClick == PrefsUtility.SelfpostAction.COLLAPSE) {
+					paddingLayout.setOnClickListener(new View.OnClickListener() {
+						@Override
+						public void onClick(View v) {
+							if (selfText.getVisibility() == View.GONE) {
+								selfText.setVisibility(View.VISIBLE);
+								collapsedView.setVisibility(View.GONE);
+							} else {
+								selfText.setVisibility(View.GONE);
+								collapsedView.setVisibility(View.VISIBLE);
+							}
 
-					}
-				});
+						}
+					});
+				}
 				// TODO mListHeaderNotifications.setBackgroundColor(Color.argb(35, 128, 128, 128));
 
 				mCommentListingManager.addPostSelfText(paddingLayout);

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -69,6 +69,7 @@ public final class SettingsFragment extends PreferenceFragment {
 
 		final int[] listPrefsToUpdate = {
 				R.string.pref_appearance_twopane_key,
+				R.string.pref_behaviour_self_post_tap_actions_key,
 				R.string.pref_behaviour_fling_post_left_key,
 				R.string.pref_behaviour_fling_post_right_key,
 				R.string.pref_behaviour_fling_comment_left_key,

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -761,4 +761,5 @@ Thanks to /u/balducien and /u/andiho for this translation!
 	<string name="action_pin_subreddit">Subreddit an Hauptmenü anheften</string>
 	<string name="action_block_subreddit">Subreddit blockieren</string>
 	<string name="collapsed_self_post">Text minimiert</string>
+	<string name="pref_behaviour_self_post_tap_actions_title">Auf Self-Post tippen</string>
 </resources>

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -58,6 +58,17 @@
         <item>disabled</item>
     </string-array>
 
+	<string-array name="pref_behaviour_self_post_tap_actions">
+		<item>@string/action_collapse</item>
+		<item>@string/action_nothing</item>
+	</string-array>
+
+	<!-- Constants. Do not change. -->
+	<string-array name="pref_behaviour_self_post_tap_actions_return">
+		<item>collapse</item>
+		<item>nothing</item>
+	</string-array>
+
 	<string-array name="pref_behaviour_fling_comment_actions">
 		<item>@string/action_upvote</item>
 		<item>@string/action_downvote</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1003,4 +1003,7 @@
 	<string name="download_link_title">Download File</string>
 	<string name="download_link_message">This is a download link. Do you want to load this in an external browser?</string>
 
+	<!--2017-05-21-->
+	<string name="pref_behaviour_self_post_tap_actions_key" translatable="false">pref_behaviour_self_post_tap_actions</string>
+	<string name="pref_behaviour_self_post_tap_actions_title">Self-Post Tap Action</string>
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -113,6 +113,12 @@
                         android:entryValues="@array/pref_behaviour_fling_post_actions_return"
                         android:defaultValue="upvote"/>
 
+		<ListPreference android:title="@string/pref_behaviour_self_post_tap_actions_title"
+						android:key="@string/pref_behaviour_self_post_tap_actions_key"
+						android:entries="@array/pref_behaviour_self_post_tap_actions"
+						android:entryValues="@array/pref_behaviour_self_post_tap_actions_return"
+						android:defaultValue="collapse"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_behaviour_actions_comment_header">


### PR DESCRIPTION
It was requested on reddit: https://www.reddit.com/r/RedReader/comments/6bv9ma/an_option_to_turn_off_collapsing_of_selfposts_on/

For now, one can choose between collapsing the text or doing nothing, but it can be (almost) trivially extended to support more actions.

One might also want to refactor the self-post code in the future to be treated the same as a comment in some cases.