### PR TITLE
Add video playback controls

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -424,7 +424,10 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 							final MediaVideoView videoView = new MediaVideoView(ImageViewActivity.this);
 
 							videoView.setVideoURI(cacheFile.getUri());
-							videoView.setMediaController(null);
+
+							MediaController mediaController = new MediaController(ImageViewActivity.this);
+							mediaController.setAnchorView(videoView);
+							videoView.setMediaController(mediaController);
 
 							layout.addView(videoView);
 							setMainView(layout);
@@ -701,6 +704,11 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 
 	@Override
 	public void onSingleTap() {
+		if (mImageInfo != null
+				&& mImageInfo.mediaType != null
+				&& mImageInfo.mediaType == ImageInfo.MediaType.VIDEO) {
+			return;
+		}
 		finish();
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -74,6 +74,7 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 
 	private GLSurfaceView surfaceView;
 	private ImageView imageView;
+	private MediaVideoView videoView;
 	private GifDecoderThread gifThread;
 
 	private String mUrl;
@@ -421,7 +422,7 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 							final RelativeLayout layout = new RelativeLayout(ImageViewActivity.this);
 							layout.setGravity(Gravity.CENTER);
 
-							final MediaVideoView videoView = new MediaVideoView(ImageViewActivity.this);
+							videoView = new MediaVideoView(ImageViewActivity.this);
 
 							videoView.setVideoURI(cacheFile.getUri());
 
@@ -710,9 +711,8 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 	@Override
 	public void onSingleTap() {
 		if (PrefsUtility.pref_behaviour_video_playback_controls(this, PreferenceManager.getDefaultSharedPreferences(this))
-				&& mImageInfo != null
-				&& mImageInfo.mediaType != null
-				&& mImageInfo.mediaType == ImageInfo.MediaType.VIDEO) {
+				&& videoView != null) {
+			videoView.performClick();
 			return;
 		}
 		finish();

--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -425,9 +425,14 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 
 							videoView.setVideoURI(cacheFile.getUri());
 
-							MediaController mediaController = new MediaController(ImageViewActivity.this);
-							mediaController.setAnchorView(videoView);
-							videoView.setMediaController(mediaController);
+							if (PrefsUtility.pref_behaviour_video_playback_controls(ImageViewActivity.this,
+																					PreferenceManager.getDefaultSharedPreferences(ImageViewActivity.this))) {
+								MediaController mediaController = new MediaController(ImageViewActivity.this);
+								mediaController.setAnchorView(videoView);
+								videoView.setMediaController(mediaController);
+							} else {
+								videoView.setMediaController(null);
+							}
 
 							layout.addView(videoView);
 							setMainView(layout);
@@ -704,7 +709,8 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 
 	@Override
 	public void onSingleTap() {
-		if (mImageInfo != null
+		if (PrefsUtility.pref_behaviour_video_playback_controls(this, PreferenceManager.getDefaultSharedPreferences(this))
+				&& mImageInfo != null
 				&& mImageInfo.mediaType != null
 				&& mImageInfo.mediaType == ImageInfo.MediaType.VIDEO) {
 			return;

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -324,6 +324,10 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_behaviour_enable_swipe_refresh_key, true, context, sharedPreferences);
 	}
 
+	public static boolean pref_behaviour_video_playback_controls(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_behaviour_video_playback_controls_key, false, context, sharedPreferences);
+	}
+
 	public static int pref_behaviour_bezel_toolbar_swipezone_dp(final Context context, final SharedPreferences sharedPreferences) {
 		try {
 			return Integer.parseInt(getString(R.string.pref_behaviour_bezel_toolbar_swipezone_key, "10", context, sharedPreferences));

--- a/src/main/java/org/quantumbadger/redreader/views/MediaVideoView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/MediaVideoView.java
@@ -52,7 +52,7 @@ import java.util.ArrayList;
  * Created by vishna on 22/07/15.
  */
 public class MediaVideoView extends SurfaceView
-		implements MediaController.MediaPlayerControl {
+		implements MediaController.MediaPlayerControl, View.OnClickListener {
 	// all possible internal states
 	private static final int STATE_ERROR = -1;
 	private static final int STATE_IDLE = 0;
@@ -383,6 +383,7 @@ public class MediaVideoView extends SurfaceView
 		mPendingSubtitleTracks = new ArrayList<>();
 		mCurrentState = STATE_IDLE;
 		mTargetState = STATE_IDLE;
+		setOnClickListener(this);
 	}
 
 	/**
@@ -563,11 +564,11 @@ public class MediaVideoView extends SurfaceView
 	}
 
 	@Override
-	public boolean onTouchEvent(MotionEvent ev) {
+	public void onClick(View view)
+	{
 		if (isInPlaybackState() && mMediaController != null) {
 			toggleMediaControlsVisiblity();
 		}
-		return false;
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/views/imageview/BasicGestureHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/views/imageview/BasicGestureHandler.java
@@ -39,12 +39,10 @@ public class BasicGestureHandler implements View.OnTouchListener, FingerTracker.
 	private final Listener mListener;
 
 	private FingerTracker.Finger mFirstFinger;
-	private View mView;
 	private int mCurrentFingerCount;
 
 	@Override
 	public boolean onTouch(final View v, final MotionEvent event) {
-		this.mView = v;
 		mFingerTracker.onTouchEvent(event);
 		return true;
 	}
@@ -84,7 +82,6 @@ public class BasicGestureHandler implements View.OnTouchListener, FingerTracker.
 					&& mFirstFinger.mPosDifference.y < 20) {
 
 				mListener.onSingleTap();
-				mView.performClick();
 			}
 
 			mFirstFinger = null;

--- a/src/main/java/org/quantumbadger/redreader/views/imageview/BasicGestureHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/views/imageview/BasicGestureHandler.java
@@ -39,12 +39,14 @@ public class BasicGestureHandler implements View.OnTouchListener, FingerTracker.
 	private final Listener mListener;
 
 	private FingerTracker.Finger mFirstFinger;
+	private View mView;
 	private int mCurrentFingerCount;
 
 	@Override
 	public boolean onTouch(final View v, final MotionEvent event) {
+		this.mView = v;
 		mFingerTracker.onTouchEvent(event);
-		return false;
+		return true;
 	}
 
 	@Override
@@ -82,6 +84,7 @@ public class BasicGestureHandler implements View.OnTouchListener, FingerTracker.
 					&& mFirstFinger.mPosDifference.y < 20) {
 
 				mListener.onSingleTap();
+				mView.performClick();
 			}
 
 			mFirstFinger = null;

--- a/src/main/java/org/quantumbadger/redreader/views/imageview/BasicGestureHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/views/imageview/BasicGestureHandler.java
@@ -44,7 +44,7 @@ public class BasicGestureHandler implements View.OnTouchListener, FingerTracker.
 	@Override
 	public boolean onTouch(final View v, final MotionEvent event) {
 		mFingerTracker.onTouchEvent(event);
-		return true;
+		return false;
 	}
 
 	@Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1012,5 +1012,7 @@
 
 	<string name="pref_menus_show_popular_main_menu_key">pref_menus_show_popular_main_menu</string>
 	<string name="pref_menus_show_popular_main_menu_title">Show /r/popular in main menu</string>
+	<string name="pref_behaviour_video_playback_controls_key">pref_behaviour_video_playback_controls</string>
+	<string name="pref_behaviour_video_playback_controls_title">Enable video playback controls</string>
 
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -27,6 +27,10 @@
                         android:key="@string/pref_behaviour_useinternalbrowser_key"
                         android:defaultValue="true"/>
 
+	<CheckBoxPreference android:title="@string/pref_behaviour_video_playback_controls_title"
+						android:key="@string/pref_behaviour_video_playback_controls_key"
+						android:defaultValue="false"/>
+
 	<ListPreference android:title="@string/pref_behaviour_imageview_mode_title"
 					android:key="@string/pref_behaviour_imageview_mode_key"
 					android:entries="@array/pref_behaviour_imageview_mode_array"


### PR DESCRIPTION
Implemented #387. I added a media controller to the video view. Looks like all the playback logic was already in MediaVideoView. I just needed to create and set the media controller. 

This also disables the ability to finish the activity when tapping the video because that is how the playback controls appear and hide. I'm not sure if this should be a preference but my instinct is to tap on the video to bring up playback controls and just pressing the back button to exit.