### PR TITLE
Stop floating comment toolbar from bouncing

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -558,7 +558,7 @@ public class CommentListingFragment extends RRFragment
 
 		mCommentListingManager.addComments(items);
 
-		if(mFloatingToolbar != null) {
+		if(mFloatingToolbar != null && mFloatingToolbar.getVisibility() != View.VISIBLE) {
 			mFloatingToolbar.setVisibility(View.VISIBLE);
 			final Animation animation = AnimationUtils.loadAnimation(getContext(), R.anim.slide_in_from_bottom);
 			animation.setInterpolator(new OvershootInterpolator());


### PR DESCRIPTION
Stop floating comment toolbar from bouncing each time a comment loads.