### PR TITLE
Added preference for sharing comments

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -479,6 +479,10 @@ public final class PrefsUtility {
 		return CommentAction.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_actions_comment_longclick_key, "action_menu", context, sharedPreferences)));
 	}
 
+	public static boolean pref_behaviour_comment_share_text(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_behaviour_comment_share_text_key, true, context, sharedPreferences);
+	}
+
 	public static PostSort pref_behaviour_postsort(final Context context, final SharedPreferences sharedPreferences) {
 		return PostSort.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_postsort_key, "hot", context, sharedPreferences)));
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -21,6 +21,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.text.ClipboardManager;
 import android.widget.Toast;
@@ -35,6 +36,7 @@ import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.common.AndroidCommon;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
+import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRError;
 import org.quantumbadger.redreader.common.RRTime;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
@@ -285,12 +287,17 @@ public class RedditAPICommentAction {
 				final Intent mailer = new Intent(Intent.ACTION_SEND);
 				mailer.setType("text/plain");
 				mailer.putExtra(Intent.EXTRA_SUBJECT, "Comment by " + comment.author + " on Reddit");
+				String body = "";
 
-				// TODO this currently just dumps the markdown
-				mailer.putExtra(Intent.EXTRA_TEXT,
-						StringEscapeUtils.unescapeHtml4(comment.body)
-								+ "\r\n\r\n"
-								+ comment.getContextUrl().generateNonJsonUri().toString());
+				// TODO this currently just dumps the markdown (only if sharing text is enabled)
+				if (PrefsUtility.pref_behaviour_comment_share_text(activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))) {
+					body = StringEscapeUtils.unescapeHtml4(comment.body)
+							+ "\r\n\r\n";
+				}
+
+				body += comment.getContextUrl().generateNonJsonUri().toString();
+				mailer.putExtra(Intent.EXTRA_TEXT, body);
 
 				activity.startActivityForResult(Intent.createChooser(mailer, activity.getString(R.string.action_share)), 1);
 

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -762,4 +762,5 @@ Thanks to /u/balducien and /u/andiho for this translation!
 	<string name="action_block_subreddit">Subreddit blockieren</string>
 	<string name="collapsed_self_post">Text minimiert</string>
 	<string name="pref_behaviour_self_post_tap_actions_title">Auf Self-Post tippen</string>
+	<string name="pref_behaviour_comment_share_text_title">Text des Kommentars teilen</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1018,4 +1018,7 @@
 	<!-- 2017-06-05 -->
 	<string name="error_no_suitable_apps_available">No suitable apps available.</string>
 
+	<!-- 2017-10-22 -->
+	<string name="pref_behaviour_comment_share_text_key" translatable="false">pref_behaviour_comment_share_text</string>
+	<string name="pref_behaviour_comment_share_text_title">Include text when sharing comment</string>
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -151,6 +151,10 @@
 						android:entryValues="@array/pref_behaviour_fling_comment_actions_return"
 						android:defaultValue="upvote"/>
 
+		<CheckBoxPreference android:title="@string/pref_behaviour_comment_share_text_title"
+				android:key="@string/pref_behaviour_comment_share_text_key"
+				android:defaultValue="true"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_behaviour_posts_header">


### PR DESCRIPTION
When sharing comments, it's now possible to specify whether one wants to include the actual comment text along with the url.