### PR TITLE
Scroll to top when collapsing self-posts

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -478,7 +478,9 @@ public class CommentListingFragment extends RRFragment
 					this.mPost);
 
 			mCommentListingManager.addPostHeader(postHeader);
-			((LinearLayoutManager)mRecyclerView.getLayoutManager()).scrollToPositionWithOffset(0, 0);
+
+			final LinearLayoutManager layoutManager = (LinearLayoutManager)mRecyclerView.getLayoutManager();
+			layoutManager.scrollToPositionWithOffset(0, 0);
 
 			if(post.src.getSelfText() != null) {
 				final ViewGroup selfText = post.src.getSelfText().buildView(
@@ -507,8 +509,8 @@ public class CommentListingFragment extends RRFragment
 							} else {
 								selfText.setVisibility(View.GONE);
 								collapsedView.setVisibility(View.VISIBLE);
+								layoutManager.scrollToPositionWithOffset(0, 0);
 							}
-
 						}
 					});
 				}

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -558,7 +558,7 @@ public class CommentListingFragment extends RRFragment
 
 		mCommentListingManager.addComments(items);
 
-		if(mFloatingToolbar != null) {
+		if(mFloatingToolbar != null && mFloatingToolbar.getVisibility() != View.VISIBLE) {
 			mFloatingToolbar.setVisibility(View.VISIBLE);
 			final Animation animation = AnimationUtils.loadAnimation(getContext(), R.anim.slide_in_from_bottom);
 			animation.setInterpolator(new OvershootInterpolator());


### PR DESCRIPTION
Scroll to position 0 when collapsing self-posts so that it doesn't drop the user in the middle of lower comments when the self-post is long.