### PR TITLE
Added checkbox for disabling "replies to inbox" when replying to comm…

### DIFF
--- a/assets/changelog.txt
+++ b/assets/changelog.txt
@@ -2,6 +2,7 @@
 Fix for fullscreen video in internal browser (thanks to Clubfan22)
 Preference to exclude text when sharing comment (thanks to Clubfan22)
 Scroll to top when collapsing self post (thanks to ajgoda90)
+Disable sending replies to inbox for comments (thanks to Clubfan22)
 
 82/1.9.8.3
 Fix for some Gfycat links (thanks to Mark Lee)

--- a/src/main/res/layout/comment_reply.xml
+++ b/src/main/res/layout/comment_reply.xml
@@ -18,29 +18,40 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:orientation="vertical">
 
-    <Spinner android:id="@+id/comment_reply_username"
-             android:layout_width="match_parent"
-             android:layout_height="wrap_content"
-             android:layout_margin="10dp"/>
+	<Spinner
+			android:id="@+id/comment_reply_username"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_margin="10dp" />
 
-    <EditText android:id="@+id/comment_reply_text"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:layout_margin="10dp"
-              android:singleLine="false"
-              android:scrollHorizontally="false"
-              android:scrollbars="none"
-              android:inputType="textCapSentences|textMultiLine"/>
+	<CheckBox
+			android:id="@+id/comment_reply_inbox"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_margin="10dp"
+			android:checked="true"
+			android:visibility="gone"
+			android:text="@string/send_replies_to_inbox" />
+
+	<EditText
+			android:id="@+id/comment_reply_text"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_margin="10dp"
+			android:inputType="textCapSentences|textMultiLine"
+			android:scrollHorizontally="false"
+			android:scrollbars="none"
+			android:singleLine="false" />
 
 	<TextView
 			android:id="@+id/comment_parent_text"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_margin="10dp"
-			android:textIsSelectable="true"/>
+			android:textIsSelectable="true" />
 
 </LinearLayout>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -763,4 +763,5 @@ Thanks to /u/balducien and /u/andiho for this translation!
 	<string name="collapsed_self_post">Text minimiert</string>
 	<string name="pref_behaviour_self_post_tap_actions_title">Auf Self-Post tippen</string>
 	<string name="pref_behaviour_comment_share_text_title">Text des Kommentars teilen</string>
+	<string name="disable_replies_to_infobox_failed">Das Abbestellen der Weiterleitung der Antworten in den Posteingang ist leider fehlgeschlagen.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1021,4 +1021,7 @@
 	<!-- 2017-10-22 -->
 	<string name="pref_behaviour_comment_share_text_key" translatable="false">pref_behaviour_comment_share_text</string>
 	<string name="pref_behaviour_comment_share_text_title">Include text when sharing comment</string>
+
+	<!-- 2017-11-01 -->
+	<string name="disable_replies_to_infobox_failed">Disabling replies to inbox failed</string>
 </resources>


### PR DESCRIPTION
…ents

When replying to comments, it's now possible to disable that replies will be sent to the inbox. (Potential improvement: preference for default behaviour)

Reddit's API endpoint /sendreplies is used for this.
About the actual implementation, I'm not sure if it would be more elegant to move the actual call into CommentReplyActivity, but then we have to escalate the id of the newly created post, which would entail some refactoring.

On another note, Reddit's API responses surely have to be a joke, right? No sane person could do that...

Fixes #286