### PR TITLE
Add custom header view for search post lists, fixes #496

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/adapters/RedditListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/RedditListingManager.java
@@ -22,7 +22,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.view.View;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.views.LoadingSpinnerView;
-import org.quantumbadger.redreader.views.PostListingHeader;
 import org.quantumbadger.redreader.views.RedditPostHeaderView;
 import org.quantumbadger.redreader.views.liststatus.ErrorView;
 
@@ -79,7 +78,7 @@ public abstract class RedditListingManager {
 		doWorkaround();
 	}
 
-	public void addPostListingHeader(final PostListingHeader view) {
+	public void addPostListingHeader(final View view) {
 		General.checkThisIsUIThread();
 		mAdapter.appendToGroup(GROUP_HEADER, new GroupedRecyclerViewItemFrameLayout(view));
 		doWorkaround();

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -77,10 +77,12 @@ import org.quantumbadger.redreader.reddit.things.RedditThing;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.PostListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
+import org.quantumbadger.redreader.reddit.url.SearchPostListURL;
 import org.quantumbadger.redreader.reddit.url.SubredditPostListURL;
 import org.quantumbadger.redreader.views.PostListingHeader;
 import org.quantumbadger.redreader.views.RedditPostView;
 import org.quantumbadger.redreader.views.ScrollbarRecyclerViewManager;
+import org.quantumbadger.redreader.views.SearchListingHeader;
 import org.quantumbadger.redreader.views.liststatus.ErrorView;
 
 import java.net.URI;
@@ -246,8 +248,12 @@ public class PostListingFragment extends RRFragment
 
 		switch(mPostListingURL.pathType()) {
 
-			case RedditURLParser.USER_POST_LISTING_URL:
 			case RedditURLParser.SEARCH_POST_LISTING_URL:
+				setHeader(new SearchListingHeader(getActivity(), (SearchPostListURL) mPostListingURL));
+				CacheManager.getInstance(context).makeRequest(mRequest);
+				break;
+
+			case RedditURLParser.USER_POST_LISTING_URL:
 			case RedditURLParser.MULTIREDDIT_POST_LISTING_URL:
 				setHeader(mPostListingURL.humanReadableName(getActivity(), true), mPostListingURL.humanReadableUrl());
 				CacheManager.getInstance(context).makeRequest(mRequest);
@@ -388,14 +394,19 @@ public class PostListingFragment extends RRFragment
 	}
 
 	private void setHeader(final String title, final String subtitle) {
+        final PostListingHeader postListingHeader = new PostListingHeader(getActivity(), title, subtitle);
+        setHeader(postListingHeader);
+	}
+
+	private void setHeader(final View view) {
 		getActivity().runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
-				final PostListingHeader postListingHeader = new PostListingHeader(getActivity(), title, subtitle);
-				mPostListingManager.addPostListingHeader(postListingHeader);
+				mPostListingManager.addPostListingHeader(view);
 			}
 		});
 	}
+
 
 	public void onPostSelected(final RedditPreparedPost post) {
 		((RedditPostView.PostSelectionListener)getActivity()).onPostSelected(post);

--- a/src/main/java/org/quantumbadger/redreader/views/SearchListingHeader.java
+++ b/src/main/java/org/quantumbadger/redreader/views/SearchListingHeader.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.quantumbadger.redreader.views;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+
+import org.apache.commons.lang3.StringUtils;
+import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.activities.PostListingActivity;
+import org.quantumbadger.redreader.reddit.url.SearchPostListURL;
+
+
+public final class SearchListingHeader extends FrameLayout implements TextWatcher  {
+
+	SearchPostListURL mUrl;
+	EditText mQuery;
+	EditText mSubreddit;
+	Button mSearchButton;
+
+	public SearchListingHeader(final Activity parentActivity, final SearchPostListURL url) {
+		super(parentActivity);
+		mUrl = url;
+
+		LayoutInflater layoutInflater = (LayoutInflater) parentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+		layoutInflater.inflate(R.layout.search_listing_header, this, true);
+
+		mQuery = (EditText) findViewById(R.id.search_listing_header_query_editText);
+		mQuery.setText(url.query);
+		mQuery.addTextChangedListener(this);
+
+		mSubreddit = (EditText) findViewById(R.id.search_listing_header_sub_editText);
+		// null and "all" are isomorphic; but SearchPostListURL takes null
+        if (url.subreddit == null) {
+			mSubreddit.setText("all");
+		} else {
+			mSubreddit.setText(url.subreddit);
+		}
+		mSubreddit.addTextChangedListener(this);
+
+		mSearchButton = (Button) findViewById(R.id.search_listing_header_search);
+		mSearchButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				String subreddit = mSubreddit.getText().toString().trim();
+				if (StringUtils.isEmpty(subreddit)) {
+					subreddit = null;
+				}
+				SearchPostListURL url = SearchPostListURL.build(subreddit, mQuery.getText().toString().trim());
+
+				final Intent intent = new Intent(parentActivity, PostListingActivity.class);
+				intent.setData(url.generateJsonUri());
+
+				// Use a startActivity/finish combination to replace this activity with the new
+				// search activity
+				parentActivity.startActivity(intent);
+				parentActivity.finish();
+			}
+		});
+		updateSearchButtonEnabled();
+	}
+
+	private void updateSearchButtonEnabled() {
+		String query = mQuery.getText().toString();
+		String subreddit = mSubreddit.getText().toString();
+		boolean isSubredditEqual = mUrl.subreddit == null
+				?  (StringUtils.isEmpty(subreddit) || subreddit.equals("all"))
+				: subreddit.equals(mUrl.subreddit);
+		boolean isSameAsUrl = query.equals(mUrl.query) && isSubredditEqual;
+		mSearchButton.setEnabled(!isSameAsUrl);
+	}
+
+	@Override
+	public void afterTextChanged(Editable editable) {
+		updateSearchButtonEnabled();
+	}
+
+	@Override
+	public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+	@Override
+	public void onTextChanged(CharSequence s, int start, int before, int count) {}
+}

--- a/src/main/res/layout/search_listing_header.xml
+++ b/src/main/res/layout/search_listing_header.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+		android:padding="8dp"
+		android:id="@+id/search_listing_header"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:orientation="vertical">
+
+	<android.support.design.widget.TextInputLayout
+			android:id="@+id/search_listing_header_query"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content">
+
+		<EditText
+				android:id="@+id/search_listing_header_query_editText"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:hint="@string/search_listing_header_query" />
+
+	</android.support.design.widget.TextInputLayout>
+
+	<android.support.design.widget.TextInputLayout
+			android:id="@+id/search_listing_header_sub"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content">
+
+		<EditText
+				android:id="@+id/search_listing_header_sub_editText"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:hint="@string/search_listing_header_sub" />
+
+	</android.support.design.widget.TextInputLayout>
+
+	<Button
+			android:id="@+id/search_listing_header_search"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:text="Search" />
+</LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1045,4 +1045,8 @@
 	<!-- 2018-02-03 -->
 	<string name="mainmenu_custom_empty_search_query">Empty search query.</string>
 
+	<!-- 2018-02-10 -->
+	<string name="search_listing_header_query">Search Query</string>
+	<string name="search_listing_header_sub">Limit to Subreddit</string>
+
 </resources>


### PR DESCRIPTION
Add a different header for search post lists.  This view allows for
the query and subreddit to be edited and searched again.

Screenshot (tablet):

![image](https://user-images.githubusercontent.com/6022042/35765033-fcac7438-0907-11e8-87f6-8e9839c0b35e.png)
