### PR TITLE
Support large (18x9) aspect ratios.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
                  android:largeHeap="true"
                  android:hardwareAccelerated="true"
                  android:allowBackup="true">
+		<meta-data android:name="android.max_aspect" android:value="2.1" />
 
 		<meta-data android:name="com.lge.support.SPLIT_WINDOW" android:value="true" />
 


### PR DESCRIPTION
Hi! Great work, I've been using this app for years. Unfortunately I've noticed an issue, I got a Mi Mix 2 today which is a bit unusual in that it's 18x9 instead of the regular 16x9 and also has an immersive mode. Most apps account for this and take up the full screen size available.

Unfortunately RedReader doesn't, while the top image looks okay, when the nav bar disappears it leaves an empty black space (as you can see in the next one)
<img src='https://user-images.githubusercontent.com/9920871/35934079-75565dfa-0c77-11e8-956b-d948c34b8a9e.png' width=243 height=487 />

<img src='https://user-images.githubusercontent.com/9920871/35934083-7805110e-0c77-11e8-9e06-b15c7d1eaa22.png' width=243 height=487 />


[I found a blog post](https://android-developers.googleblog.com/2017/03/update-your-app-to-take-advantage-of.html) from Google which tells us how to support a larger display format. I added the line from the post into the manifest and rebuilt and it solved the aspect issue for the Mi Mix 2 (and probably other 18x9 phones). - You can see below for the results.

<img src='https://user-images.githubusercontent.com/9920871/35934147-a7d463bc-0c77-11e8-95f8-8777fc8dfbae.png' width=243 height=487 />

