### PR TITLE
Improvements to the sharing system.

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -492,8 +492,12 @@ public final class PrefsUtility {
 		return CommentAction.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_actions_comment_longclick_key, "action_menu", context, sharedPreferences)));
 	}
 
-	public static boolean pref_behaviour_comment_share_text(final Context context, final SharedPreferences sharedPreferences) {
-		return getBoolean(R.string.pref_behaviour_comment_share_text_key, true, context, sharedPreferences);
+	public static boolean pref_behaviour_sharing_share_text(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_behaviour_sharing_share_text_key, true, context, sharedPreferences);
+	}
+
+	public static boolean pref_behaviour_sharing_include_desc(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_behaviour_sharing_include_desc_key, true, context, sharedPreferences);
 	}
 
 	public static PostSort pref_behaviour_postsort(final Context context, final SharedPreferences sharedPreferences) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -283,17 +283,22 @@ public class RedditAPICommentAction {
 				break;
 
 			case SHARE:
-
 				final Intent mailer = new Intent(Intent.ACTION_SEND);
 				mailer.setType("text/plain");
-				mailer.putExtra(Intent.EXTRA_SUBJECT, "Comment by " + comment.author + " on Reddit");
-				String body = "";
 
-				// TODO this currently just dumps the markdown (only if sharing text is enabled)
-				if (PrefsUtility.pref_behaviour_comment_share_text(activity,
+				String body = "";
+				if (PrefsUtility.pref_behaviour_sharing_include_desc(activity,
 						PreferenceManager.getDefaultSharedPreferences(activity))) {
-					body = StringEscapeUtils.unescapeHtml4(comment.body)
-							+ "\r\n\r\n";
+					mailer.putExtra(Intent.EXTRA_SUBJECT,
+							String.format(activity.getText(R.string.share_comment_by_on_reddit).toString(), comment.author)
+					);
+
+					// TODO this currently just dumps the markdown (only if sharing text is enabled)
+					if (PrefsUtility.pref_behaviour_sharing_share_text(activity,
+							PreferenceManager.getDefaultSharedPreferences(activity))) {
+						body = StringEscapeUtils.unescapeHtml4(comment.body)
+								+ "\r\n\r\n";
+					}
 				}
 
 				body += comment.getContextUrl().generateNonJsonUri().toString();

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -423,7 +423,10 @@ public final class RedditPreparedPost {
 
 				final Intent mailer = new Intent(Intent.ACTION_SEND);
 				mailer.setType("text/plain");
-				mailer.putExtra(Intent.EXTRA_SUBJECT, post.src.getTitle());
+				if (PrefsUtility.pref_behaviour_sharing_include_desc(activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))) {
+					mailer.putExtra(Intent.EXTRA_SUBJECT, post.src.getTitle());
+				}
 				mailer.putExtra(Intent.EXTRA_TEXT, post.src.getUrl());
 				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
 				break;
@@ -435,7 +438,12 @@ public final class RedditPreparedPost {
 
 				final Intent mailer = new Intent(Intent.ACTION_SEND);
 				mailer.setType("text/plain");
-				mailer.putExtra(Intent.EXTRA_SUBJECT, "Comments for " + post.src.getTitle());
+				if (PrefsUtility.pref_behaviour_sharing_include_desc(activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))) {
+					mailer.putExtra(Intent.EXTRA_SUBJECT,
+							String.format(activity.getText(R.string.share_comments_for).toString(), post.src.getTitle())
+					);
+				}
 				if (shareAsPermalink) {
 					mailer.putExtra(Intent.EXTRA_TEXT, Constants.Reddit.getNonAPIUri(post.src.getPermalink()).toString());
 				} else {

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -764,6 +764,6 @@ Thanks to /u/balducien and /u/andiho for this translation!
 	<string name="action_block_subreddit">Subreddit blockieren</string>
 	<string name="collapsed_self_post">Text minimiert</string>
 	<string name="pref_behaviour_self_post_tap_actions_title">Auf Self-Post tippen</string>
-	<string name="pref_behaviour_comment_share_text_title">Text des Kommentars teilen</string>
+	<string name="pref_behaviour_sharing_share_text_title">Text des Kommentars teilen</string>
 	<string name="disable_replies_to_infobox_failed">Das Abbestellen der Weiterleitung der Antworten in den Posteingang ist leider fehlgeschlagen.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1023,8 +1023,8 @@
 	<string name="error_no_suitable_apps_available">No suitable apps available.</string>
 
 	<!-- 2017-10-22 -->
-	<string name="pref_behaviour_comment_share_text_key" translatable="false">pref_behaviour_comment_share_text</string>
-	<string name="pref_behaviour_comment_share_text_title">Include text when sharing comment</string>
+	<string name="pref_behaviour_sharing_share_text_key" translatable="false">pref_behaviour_comment_share_text</string>
+	<string name="pref_behaviour_sharing_share_text_title">Include text when sharing comment</string>
 
 	<!-- 2017-11-01 -->
 	<string name="disable_replies_to_infobox_failed">Disabling replies to inbox failed</string>
@@ -1044,5 +1044,12 @@
 
 	<!-- 2018-02-03 -->
 	<string name="mainmenu_custom_empty_search_query">Empty search query.</string>
+
+	<!-- 2018-02-11 -->
+	<string name="pref_behaviour_sharing_header">Sharing</string>
+	<string name="pref_behaviour_sharing_include_desc_key" translatable="false">pref_behaviour_sharing_include_desc</string>
+	<string name="pref_behaviour_sharing_include_desc_title">Include title/description when sharing</string>
+	<string name="share_comments_for">Comments for %s</string>
+	<string name="share_comment_by_on_reddit">Comment by %s on Reddit</string>
 
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -151,10 +151,6 @@
 						android:entryValues="@array/pref_behaviour_fling_comment_actions_return"
 						android:defaultValue="upvote"/>
 
-		<CheckBoxPreference android:title="@string/pref_behaviour_comment_share_text_title"
-				android:key="@string/pref_behaviour_comment_share_text_key"
-				android:defaultValue="true"/>
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_behaviour_posts_header">
@@ -162,10 +158,6 @@
         <CheckBoxPreference android:title="@string/pref_behaviour_nsfw_title"
                             android:key="@string/pref_behaviour_nsfw_key"
                             android:defaultValue="false"/>
-
-		<CheckBoxPreference android:title="@string/pref_behaviour_share_permalink_title"
-				android:key="@string/pref_behaviour_share_permalink_key"
-				android:defaultValue="false"/>
 
         <ListPreference android:title="@string/pref_behaviour_postcount_title"
                         android:key="@string/pref_behaviour_postcount_key"
@@ -186,15 +178,31 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/pref_behaviour_bezel_toolbar_header">
+	<PreferenceCategory android:title="@string/pref_behaviour_sharing_header">
 
-        <ListPreference android:title="@string/pref_behaviour_bezel_toolbar_swipezone_title"
-                        android:key="@string/pref_behaviour_bezel_toolbar_swipezone_key"
-                        android:entries="@array/pref_behaviour_bezel_toolbar_swipe_zone_array"
-                        android:entryValues="@array/pref_behaviour_bezel_toolbar_swipe_zone_array_return"
-                        android:defaultValue="10"/>
+		<CheckBoxPreference android:title="@string/pref_behaviour_share_permalink_title"
+				android:key="@string/pref_behaviour_share_permalink_key"
+				android:defaultValue="false"/>
 
-    </PreferenceCategory>
+		<CheckBoxPreference android:title="@string/pref_behaviour_sharing_include_desc_title"
+				android:key="@string/pref_behaviour_sharing_include_desc_key"
+				android:defaultValue="true"/>
+
+		<CheckBoxPreference android:title="@string/pref_behaviour_sharing_share_text_title"
+				android:key="@string/pref_behaviour_sharing_share_text_key"
+				android:defaultValue="true"/>
+
+	</PreferenceCategory>
+
+	<PreferenceCategory android:title="@string/pref_behaviour_bezel_toolbar_header">
+
+		<ListPreference android:title="@string/pref_behaviour_bezel_toolbar_swipezone_title"
+				android:key="@string/pref_behaviour_bezel_toolbar_swipezone_key"
+				android:entries="@array/pref_behaviour_bezel_toolbar_swipe_zone_array"
+				android:entryValues="@array/pref_behaviour_bezel_toolbar_swipe_zone_array_return"
+				android:defaultValue="10"/>
+
+	</PreferenceCategory>
 
 
 </PreferenceScreen>


### PR DESCRIPTION
As the message says, this commit adds a new "Sharing" category under "Behaviour" in settings, moves two of the sharing options to the new category ("Share as permalink" and "Include text when sharing comment"), and introduces a new "Include title/description when sharing" option, which allows easy link-only sharing by optionally (instead of the default, as it was previously) including the "Comments for <post name>" etc text when shared. Also localized the hardcoded "Comments for <post name>" and "Comment by <author> on Reddit" strings.