### PR TITLE
Added mininum height to comments in order to prevent odd formatting of HTML entities

### DIFF
--- a/src/main/res/layout/reddit_comment.xml
+++ b/src/main/res/layout/reddit_comment.xml
@@ -64,6 +64,7 @@
 					android:id="@+id/view_reddit_comment_bodyholder"
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
+					android:minHeight="14dp"
 					android:paddingTop="2dp"
 					tools:ignore="UselessLeaf"/>
 


### PR DESCRIPTION
This is a fix for #585 - Comments containing only '&nbsp;' look weird 