### PR TITLE
Add a blocklist to filter posts by (parts of) post.url

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -133,6 +133,13 @@
         <activity android:name=".activities.InboxListingActivity"
                   android:configChanges="orientation|screenSize|keyboardHidden"/>
 
+		<activity android:name=".activities.BlocklistListingActivity">
+			<intent-filter>
+				<action android:name="org.quantumbadger.redreader.activities.BlocklistListingActivity" />
+				<category android:name="android.intent.category.DEFAULT" />
+			</intent-filter>
+		</activity>
+
         <receiver android:name=".receivers.NewMessageChecker"/>
         <receiver android:name=".receivers.RegularCachePruner"/>
         <receiver android:name=".receivers.BootReceiver">

--- a/src/main/java/org/quantumbadger/redreader/activities/BlocklistListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/BlocklistListingActivity.java
@@ -20,19 +20,18 @@ public class BlocklistListingActivity extends BaseActivity {
 
 	private List<String> blockedPostUrls;
 
-	protected ListAdapter mAdapter;
-	protected ListView mList;
+	private ListAdapter mAdapter;
+	private ListView mList;
 
-	private Handler mHandler = new Handler();
 	private boolean mFinishedStart = false;
 
-	private Runnable mRequestFocus = new Runnable() {
+	private final Handler mHandler = new Handler();
+	private final Runnable mRequestFocus = new Runnable() {
 		public void run() {
 			mList.focusableViewAvailable(mList);
 		}
 	};
-
-	private AdapterView.OnItemClickListener mOnClickListener = new AdapterView.OnItemClickListener() {
+	private final AdapterView.OnItemClickListener mOnClickListener = new AdapterView.OnItemClickListener() {
 		public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
 			onListItemClick((ListView) parent, v, position, id);
 		}

--- a/src/main/java/org/quantumbadger/redreader/activities/BlocklistListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/BlocklistListingActivity.java
@@ -1,34 +1,50 @@
 package org.quantumbadger.redreader.activities;
 
 import android.app.AlertDialog;
-import android.app.ListActivity;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.InputType;
 import android.util.Log;
 import android.view.View;
-import android.widget.ArrayAdapter;
-import android.widget.EditText;
-import android.widget.ListView;
+import android.widget.*;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.PrefsUtility;
 
 import java.util.List;
 
-public class BlocklistListingActivity extends ListActivity {
+public class BlocklistListingActivity extends BaseActivity {
 	private static final String TAG = BlocklistListingActivity.class.getSimpleName();
 
 	private List<String> blockedPostUrls;
 
+	protected ListAdapter mAdapter;
+	protected ListView mList;
+
+	private Handler mHandler = new Handler();
+	private boolean mFinishedStart = false;
+
+	private Runnable mRequestFocus = new Runnable() {
+		public void run() {
+			mList.focusableViewAvailable(mList);
+		}
+	};
+
+	private AdapterView.OnItemClickListener mOnClickListener = new AdapterView.OnItemClickListener() {
+		public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
+			onListItemClick((ListView) parent, v, position, id);
+		}
+	};
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-
 		PrefsUtility.applyTheme(this);
 		super.onCreate(savedInstanceState);
 
-		setContentView(R.layout.blocklist_list);
+		setBaseActivityContentView(R.layout.blocklist_list);
+		refresh();
 
 		final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 		blockedPostUrls = PrefsUtility.pref_blocked_post_urls(this, sharedPreferences);
@@ -43,9 +59,9 @@ public class BlocklistListingActivity extends ListActivity {
 		urlEditView.setInputType(InputType.TYPE_CLASS_TEXT);
 
 		final AlertDialog dialog = new AlertDialog.Builder(this)
-				.setTitle("Enter URL")
+				.setTitle(R.string.pref_blocked_post_enter_domain)
 				.setView(urlEditView)
-				.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+				.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
 						final String url = urlEditView.getText().toString();
@@ -57,7 +73,7 @@ public class BlocklistListingActivity extends ListActivity {
 						BlocklistListingActivity.this.onContentChanged();
 					}
 				})
-				.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+				.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
 						dialog.cancel();
@@ -68,6 +84,46 @@ public class BlocklistListingActivity extends ListActivity {
 	}
 
 	@Override
+	protected void onRestoreInstanceState(Bundle state) {
+		ensureList();
+		super.onRestoreInstanceState(state);
+	}
+
+	@Override
+	protected void onDestroy() {
+		mHandler.removeCallbacks(mRequestFocus);
+		super.onDestroy();
+	}
+
+	private void refresh() {
+		super.onContentChanged();
+		final View baseView = getLayoutInflater().inflate(R.layout.blocklist_list, null);
+		final View emptyView = baseView.findViewById(android.R.id.empty);
+		mList = (ListView) baseView.findViewById(R.id.blocklist_list);
+		if (mList == null) {
+			throw new RuntimeException(
+					"Your content must have a ListView whose id attribute is " +
+							"'blocklist_list'");
+		}
+		if (emptyView != null) {
+			mList.setEmptyView(emptyView);
+		}
+		mList.setOnItemClickListener(mOnClickListener);
+		if (mFinishedStart) {
+			setListAdapter(mAdapter);
+		}
+		mHandler.post(mRequestFocus);
+		mFinishedStart = true;
+	}
+
+	public void setListAdapter(ListAdapter adapter) {
+		synchronized (this) {
+			ensureList();
+			mAdapter = adapter;
+			mList.setAdapter(adapter);
+		}
+	}
+
 	protected void onListItemClick(ListView l, View v, int position, long id) {
 		final String url = (String) getListAdapter().getItem(position);
 		Log.d(TAG, "Removed: " + url);
@@ -77,5 +133,33 @@ public class BlocklistListingActivity extends ListActivity {
 
 		blockedPostUrls.remove(url);
 		this.onContentChanged();
+	}
+
+	public void setSelection(int position) {
+		mList.setSelection(position);
+	}
+
+	public int getSelectedItemPosition() {
+		return mList.getSelectedItemPosition();
+	}
+
+	public long getSelectedItemId() {
+		return mList.getSelectedItemId();
+	}
+
+	public ListView getListView() {
+		ensureList();
+		return mList;
+	}
+
+	public ListAdapter getListAdapter() {
+		return mAdapter;
+	}
+
+	private void ensureList() {
+		if (mList != null) {
+			return;
+		}
+		setContentView(android.R.layout.list_content);
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/BlocklistListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/BlocklistListingActivity.java
@@ -1,0 +1,81 @@
+package org.quantumbadger.redreader.activities;
+
+import android.app.AlertDialog;
+import android.app.ListActivity;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.InputType;
+import android.util.Log;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.ListView;
+import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.common.PrefsUtility;
+
+import java.util.List;
+
+public class BlocklistListingActivity extends ListActivity {
+	private static final String TAG = BlocklistListingActivity.class.getSimpleName();
+
+	private List<String> blockedPostUrls;
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+
+		PrefsUtility.applyTheme(this);
+		super.onCreate(savedInstanceState);
+
+		setContentView(R.layout.blocklist_list);
+
+		final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+		blockedPostUrls = PrefsUtility.pref_blocked_post_urls(this, sharedPreferences);
+		setListAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, blockedPostUrls));
+
+		final String title = getString(R.string.pref_blocked_post_urls_title);
+		setTitle(title);
+	}
+
+	public void addItems(View v) {
+		final EditText urlEditView = new EditText(this);
+		urlEditView.setInputType(InputType.TYPE_CLASS_TEXT);
+
+		final AlertDialog dialog = new AlertDialog.Builder(this)
+				.setTitle("Enter URL")
+				.setView(urlEditView)
+				.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						final String url = urlEditView.getText().toString();
+
+						final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(BlocklistListingActivity.this);
+						PrefsUtility.pref_blocked_post_urls_add(BlocklistListingActivity.this, sharedPreferences, url);
+
+						blockedPostUrls.add(url);
+						BlocklistListingActivity.this.onContentChanged();
+					}
+				})
+				.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						dialog.cancel();
+					}
+				})
+				.create();
+		dialog.show();
+	}
+
+	@Override
+	protected void onListItemClick(ListView l, View v, int position, long id) {
+		final String url = (String) getListAdapter().getItem(position);
+		Log.d(TAG, "Removed: " + url);
+
+		final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+		PrefsUtility.pref_blocked_post_urls_remove(this, sharedPreferences, url);
+
+		blockedPostUrls.remove(url);
+		this.onContentChanged();
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -24,7 +24,6 @@ import android.content.res.Resources;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
-
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.OptionsMenuUtility;
 import org.quantumbadger.redreader.adapters.MainMenuListingManager;
@@ -36,14 +35,7 @@ import org.quantumbadger.redreader.reddit.things.RedditSubreddit;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public final class PrefsUtility {
 
@@ -816,6 +808,37 @@ public final class PrefsUtility {
 	public static List<String> pref_blocked_post_urls(final Context context, final SharedPreferences sharedPreferences) {
 		final String value = getString(R.string.pref_blocked_post_urls_key, "", context, sharedPreferences);
 		return WritableHashSet.escapedStringToList(value);
+	}
+
+	public static void pref_blocked_post_urls_add(
+			final Context context,
+			final SharedPreferences sharedPreferences,
+			final String url) {
+
+
+		final String value = getString(R.string.pref_blocked_post_urls_key, "", context, sharedPreferences);
+		final ArrayList<String> list = WritableHashSet.escapedStringToList(value);
+		list.add(url);
+
+		final String result = WritableHashSet.listToEscapedString(list);
+		sharedPreferences.edit().putString(context.getString(R.string.pref_blocked_post_urls_key), result).apply();
+	}
+
+	public static void pref_blocked_post_urls_remove(Context context, SharedPreferences sharedPreferences, String url) {
+		final String value = getString(R.string.pref_blocked_post_urls_key, "", context, sharedPreferences);
+		final ArrayList<String> list = WritableHashSet.escapedStringToList(value);
+		list.add(url);
+
+		final ArrayList<String> result = new ArrayList<>(list.size());
+		for(final String existingUrl : list) {
+			if(!url.equals(existingUrl)) {
+				result.add(existingUrl);
+			}
+		}
+
+		final String resultStr = WritableHashSet.listToEscapedString(result);
+
+		sharedPreferences.edit().putString(context.getString(R.string.pref_blocked_post_urls_key), resultStr).apply();
 	}
 
 	///////////////////////////////

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -24,6 +24,7 @@ import android.content.res.Resources;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.OptionsMenuUtility;
 import org.quantumbadger.redreader.adapters.MainMenuListingManager;
@@ -806,6 +807,15 @@ public final class PrefsUtility {
 		}
 
 		return false;
+	}
+
+	///////////////////////////////
+	// pref_blocked_post_urls
+	///////////////////////////////
+
+	public static List<String> pref_blocked_post_urls(final Context context, final SharedPreferences sharedPreferences) {
+		final String value = getString(R.string.pref_blocked_post_urls_key, "", context, sharedPreferences);
+		return WritableHashSet.escapedStringToList(value);
 	}
 
 	///////////////////////////////

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -34,6 +34,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
@@ -667,6 +668,7 @@ public class PostListingFragment extends RRFragment
 								|| mPostListingURL.asSubredditPostListURL().type == SubredditPostListURL.Type.POPULAR);
 
 				final List<String> blockedSubreddits = PrefsUtility.pref_blocked_subreddits(activity, mSharedPreferences); // Grab this so we don't have to pull from the prefs every post
+				final List<String> blockedPostUrls = PrefsUtility.pref_blocked_post_urls(activity, mSharedPreferences); // Grab this so we don't have to pull from the prefs every post
 
 				Log.i(TAG, "Precaching images: " + (precacheImages ? "ON" : "OFF"));
 				Log.i(TAG, "Precaching comments: " + (precacheComments ? "ON" : "OFF"));
@@ -690,7 +692,8 @@ public class PostListingFragment extends RRFragment
 
 					mAfter = post.name;
 
-					final boolean isPostBlocked = subredditFilteringEnabled && getIsPostBlocked(blockedSubreddits, post);
+					final boolean isPostBlocked = getIsPostUrlBlocked(post, blockedPostUrls)
+							|| (subredditFilteringEnabled && getIsPostBlocked(blockedSubreddits, post));
 
 					if(!isPostBlocked
 							&& (!post.over_18 || isNsfwAllowed)
@@ -885,6 +888,17 @@ public class PostListingFragment extends RRFragment
 			}
 		}
 
+		return false;
+	}
+
+	private boolean getIsPostUrlBlocked(@NonNull RedditPost post, List<String> blockedUrls) {
+		// check if post should be filtered based on linked URLs
+		for(String blockedUrl : blockedUrls) {
+			if(post.url.contains(blockedUrl)) {
+				Log.d(TAG, "Url '" + post.url + "' is in blocklist");
+				return true;
+			}
+		}
 		return false;
 	}
 }

--- a/src/main/res/layout/blocklist_list.xml
+++ b/src/main/res/layout/blocklist_list.xml
@@ -13,11 +13,17 @@
 			android:orientation="vertical">
 
 		<ListView
-				android:id="@android:id/list"
+				android:id="@+id/blocklist_list"
 				android:layout_width="match_parent"
 				android:layout_height="match_parent"
 				android:choiceMode="singleChoice"
 				android:drawSelectorOnTop="false" />
+
+		<TextView
+				android:id="@android:id/empty"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:text="@string/blocklist_no_entries_found" />
 	</LinearLayout>
 
 	<android.support.design.widget.FloatingActionButton

--- a/src/main/res/layout/blocklist_list.xml
+++ b/src/main/res/layout/blocklist_list.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+
+	<Button
+			android:id="@+id/addBtn"
+			android:text="Add New Item"
+			android:layout_width="fill_parent"
+			android:layout_height="wrap_content"
+			android:onClick="addItems"/>
+
+	<ListView
+			android:id="@android:id/list"
+			android:layout_width="fill_parent"
+			android:layout_height="fill_parent"
+			android:drawSelectorOnTop="false"
+			android:choiceMode="singleChoice"
+			/>
+
+</LinearLayout>

--- a/src/main/res/layout/blocklist_list.xml
+++ b/src/main/res/layout/blocklist_list.xml
@@ -1,20 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<android.support.design.widget.CoordinatorLayout
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		android:orientation="vertical"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent">
 
-	<Button
+	<LinearLayout
+			android:id="@+id/linearLayout"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:orientation="vertical">
+
+		<ListView
+				android:id="@android:id/list"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:choiceMode="singleChoice"
+				android:drawSelectorOnTop="false" />
+	</LinearLayout>
+
+	<android.support.design.widget.FloatingActionButton
 			android:id="@+id/addBtn"
-			android:text="Add New Item"
-			android:layout_width="fill_parent"
+			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
-			android:onClick="addItems"/>
+			android:layout_margin="16dp"
+			android:onClick="addItems"
+			android:src="@drawable/ic_action_add_dark"
+			app:layout_anchor="@+id/linearLayout"
+			app:layout_anchorGravity="right|bottom" />
 
-	<ListView
-			android:id="@android:id/list"
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"
-			android:drawSelectorOnTop="false"
-			android:choiceMode="singleChoice"
-			/>
-
-</LinearLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1080,4 +1080,8 @@
 
 	<string name="sort_posts_best">Best</string>
 
+	<string name="pref_blocked_post_urls_key" translatable="false">pref_blocked_post_urls_key</string>
+	<string name="pref_blocked_post_urls_title">Blocked URL keywords</string>
+	<string name="pref_blocked_post_urls_dialog_title">Enter a list of blocked URL parts, separated by \';\'</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1081,7 +1081,8 @@
 	<string name="sort_posts_best">Best</string>
 
 	<string name="pref_blocked_post_urls_key" translatable="false">pref_blocked_post_urls_key</string>
-	<string name="pref_blocked_post_urls_title">Blocked URL keywords</string>
-	<string name="pref_blocked_post_urls_dialog_title">Enter a list of blocked URL parts, separated by \';\'</string>
+	<string name="pref_blocked_post_urls_title">Blocked domain keywords</string>
+	<string name="pref_blocked_post_enter_domain">Enter domain keyword</string>
+	<string name="blocklist_no_entries_found">No entries found</string>
 
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -165,6 +165,12 @@
                         android:entryValues="@array/pref_behaviour_postcount_items_return"
                         android:defaultValue="ALL"/>
 
+		<!-- TODO make this a real list where users can add/remove entries -->
+		<EditTextPreference android:title="@string/pref_blocked_post_urls_title"
+				android:key="@string/pref_blocked_post_urls_key"
+				android:dialogTitle="@string/pref_blocked_post_urls_dialog_title"
+				android:inputType="textNoSuggestions" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_behaviour_comments_header">

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -165,11 +165,11 @@
                         android:entryValues="@array/pref_behaviour_postcount_items_return"
                         android:defaultValue="ALL"/>
 
-		<!-- TODO make this a real list where users can add/remove entries -->
-		<EditTextPreference android:title="@string/pref_blocked_post_urls_title"
+		<Preference android:title="@string/pref_blocked_post_urls_title"
 				android:key="@string/pref_blocked_post_urls_key"
-				android:dialogTitle="@string/pref_blocked_post_urls_dialog_title"
-				android:inputType="textNoSuggestions" />
+				android:summary="@string/pref_blocked_post_urls_title">
+			<intent android:action="org.quantumbadger.redreader.activities.BlocklistListingActivity" />
+		</Preference>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
This allows users to hide post based on their URLs, to filter out unwanted content sources. The blocklist can be edited via preferences.

During my usage of reddit I often want to filter out memes, for example. And those tend to come from certain hoster URLs and I just want to get rid of all of them. With this change I can add (for example) `"gfycat.com"` to the blocklist and get rid of all of them at once.

This is my first attempt at a new feature for *RedReader*. I tried to keep the change as small as possible and follow the general layout of the code. If there is anything wrong with the code or someone can give me tips how to improve, I appreciate all comments.

I only do Android development occasionally, so I couldn't really figure out how to have a nice preferences screen, where the user can add/remove entries to the blocklist, so I added the preferences value as a simple `EditTextPreference` where I can at least enter the blocklist entries separated with `;`... I'd like to improve this, maybe someone can give me a link to the Android docs or into existing *RedReader* code.