### PR TITLE
Add Custom Tab support

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -262,6 +262,8 @@ public class LinkHandler {
 			Bundle bundle = new Bundle();
 			bundle.putBinder("android.support.customtabs.extra.SESSION", null);
 			intent.putExtras(bundle);
+
+			intent.putExtra("android.support.customtabs.extra.SHARE_MENU_ITEM", true);
 		} else {
 			intent.setClass(activity, WebViewActivity.class);
 			intent.putExtra("url", url);

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -182,6 +182,15 @@ public class LinkHandler {
 						Bundle bundle = new Bundle();
 						bundle.putBinder("android.support.customtabs.extra.SESSION", null);
 						intent.putExtras(bundle);
+
+						intent.putExtra("android.support.customtabs.extra.SHARE_MENU_ITEM", true);
+
+						TypedValue typedValue = new TypedValue();
+						activity.getTheme().resolveAttribute(R.attr.colorPrimary, typedValue, true);
+
+						intent.putExtra("android.support.customtabs.extra.TOOLBAR_COLOR", typedValue.data);
+
+						intent.putExtra("android.support.customtabs.extra.ENABLE_URLBAR_HIDING", true);
 					} else {
 						intent.setClass(activity, WebViewActivity.class);
 						intent.putExtra("url", url);
@@ -271,6 +280,8 @@ public class LinkHandler {
 			activity.getTheme().resolveAttribute(R.attr.colorPrimary, typedValue, true);
 
 			intent.putExtra("android.support.customtabs.extra.TOOLBAR_COLOR", typedValue.data);
+
+			intent.putExtra("android.support.customtabs.extra.ENABLE_URLBAR_HIDING", true);
 		} else {
 			intent.setClass(activity, WebViewActivity.class);
 			intent.putExtra("url", url);

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -34,6 +34,8 @@ import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.text.ClipboardManager;
 import android.util.Log;
+import android.util.TypedValue;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.*;
 import org.quantumbadger.redreader.cache.CacheRequest;
@@ -264,6 +266,11 @@ public class LinkHandler {
 			intent.putExtras(bundle);
 
 			intent.putExtra("android.support.customtabs.extra.SHARE_MENU_ITEM", true);
+
+			TypedValue typedValue = new TypedValue();
+			activity.getTheme().resolveAttribute(R.attr.colorPrimary, typedValue, true);
+
+			intent.putExtra("android.support.customtabs.extra.TOOLBAR_COLOR", typedValue.data);
 		} else {
 			intent.setClass(activity, WebViewActivity.class);
 			intent.putExtra("url", url);

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -26,6 +26,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
@@ -168,9 +170,21 @@ public class LinkHandler {
 				}
 
 				case INTERNAL_BROWSER: {
-					final Intent intent = new Intent(activity, WebViewActivity.class);
-					intent.putExtra("url", url);
-					intent.putExtra("post", post);
+					final Intent intent = new Intent();
+					if (PrefsUtility.pref_behaviour_usecustomtabs(activity, sharedPreferences) &&
+							Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+						intent.setAction(Intent.ACTION_VIEW);
+						intent.setData(Uri.parse(url));
+						intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+						Bundle bundle = new Bundle();
+						bundle.putBinder("android.support.customtabs.extra.SESSION", null);
+						intent.putExtras(bundle);
+					} else {
+						intent.setClass(activity, WebViewActivity.class);
+						intent.putExtra("url", url);
+						intent.putExtra("post", post);
+					}
 					activity.startActivity(intent);
 					return;
 				}
@@ -238,9 +252,22 @@ public class LinkHandler {
 			}
 		}
 
-		final Intent intent = new Intent(activity, WebViewActivity.class);
-		intent.putExtra("url", url);
-		intent.putExtra("post", post);
+		final Intent intent = new Intent();
+		if (PrefsUtility.pref_behaviour_usecustomtabs(activity, sharedPreferences)
+				&& Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+			intent.setAction(Intent.ACTION_VIEW);
+			intent.setData(Uri.parse(url));
+			intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+			Bundle bundle = new Bundle();
+			bundle.putBinder("android.support.customtabs.extra.SESSION", null);
+			intent.putExtras(bundle);
+		} else {
+			intent.setClass(activity, WebViewActivity.class);
+			intent.putExtra("url", url);
+			intent.putExtra("post", post);
+		}
+
 		activity.startActivity(intent);
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -333,6 +333,10 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_behaviour_useinternalbrowser_key, true, context, sharedPreferences);
 	}
 
+	public static boolean pref_behaviour_usecustomtabs(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_behaviour_usecustomtabs_key, false, context, sharedPreferences);
+	}
+
 	public static boolean pref_behaviour_notifications(final Context context, final SharedPreferences sharedPreferences) {
 		return getBoolean(R.string.pref_behaviour_notifications_key, true, context, sharedPreferences);
 	}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1080,4 +1080,9 @@
 
 	<string name="sort_posts_best">Best</string>
 
+	<!-- 2018-07-08 -->
+	<string name="pref_behaviour_usecustomtabs_key" translatable="false">pref_behaviour_usecustomtabs_key</string>
+	<string name="pref_behaviour_usecustomtabs_title">Use Custom Tabs</string>
+	<string name="pref_behaviour_usecustomtabs_summary">Use Custom Tabs when available</string>
+
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -27,6 +27,11 @@
                         android:key="@string/pref_behaviour_useinternalbrowser_key"
                         android:defaultValue="true"/>
 
+	<CheckBoxPreference android:title="@string/pref_behaviour_usecustomtabs_title"
+                        android:key="@string/pref_behaviour_usecustomtabs_key"
+                        android:summary="@string/pref_behaviour_usecustomtabs_summary"
+                        android:defaultValue="false"/>
+
 	<CheckBoxPreference android:title="@string/pref_behaviour_video_playback_controls_title"
 						android:key="@string/pref_behaviour_video_playback_controls_key"
 						android:defaultValue="false"/>


### PR DESCRIPTION
Implements Custom Tabs under a pref (`pref_behaviour_usecustomtabs_key`), this pref requires that internal browser is also enabled (`pref_behaviour_useinternalbrowser_key`).

I've tested this in Firefox for Android where it works correctly, I had hoped this would allow Smart HTTPs and uBlock Origin integration but unfortunately Firefox Custom Tabs does not support add-ons leaving Custom Tabs less privacy friendly than WebViewActivity.

https://github.com/QuantumBadger/RedReader/issues/368