### PR TITLE
Introduced FileProvider to fix #627

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -148,7 +148,17 @@
         <meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_H" android:resource="@dimen/app_defaultsize_h" />
         <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_W" android:resource="@dimen/app_minimumsize_w" />
         <meta-data android:name="com.sec.android.multiwindow.MINIMUM_SIZE_H" android:resource="@dimen/app_minimumsize_h" />
-
+		
+		<provider
+				android:name="android.support.v4.content.FileProvider"
+				android:authorities="org.quantumbadger.redreader.provider"
+				android:exported="false"
+				android:grantUriPermissions="true">
+			<meta-data
+					android:name="android.support.FILE_PROVIDER_PATHS"
+					android:resource="@xml/file_paths">
+			</meta-data>
+		</provider>
     </application>
 
 </manifest>

--- a/src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
@@ -20,6 +20,7 @@ package org.quantumbadger.redreader.image;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Environment;
+import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
@@ -135,6 +136,12 @@ public class ShareImageCallback implements BaseActivity.PermissionCallback {
 							}
 						}
 
+						Uri sharedImage = FileProvider.getUriForFile(
+								context,
+								"org.quantumbadger.redreader.provider",
+								dst
+						);
+
 						try {
 							final InputStream cacheFileInputStream = cacheFile.getInputStream();
 
@@ -147,7 +154,7 @@ public class ShareImageCallback implements BaseActivity.PermissionCallback {
 
 							Intent shareIntent = new Intent();
 							shareIntent.setAction(Intent.ACTION_SEND);
-							shareIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse("file://" + dst.getAbsolutePath()));
+							shareIntent.putExtra(Intent.EXTRA_STREAM, sharedImage);
 							shareIntent.setType(mimetype);
 							activity.startActivity(Intent.createChooser(shareIntent, activity.getString(R.string.action_share_image)));
 
@@ -157,7 +164,7 @@ public class ShareImageCallback implements BaseActivity.PermissionCallback {
 						}
 
 						activity.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE,
-								Uri.parse("file://" + dst.getAbsolutePath()))
+								sharedImage)
 						);
 
 						General.quickToast(context, context.getString(R.string.action_save_image_success) + " " + dst.getAbsolutePath());

--- a/src/main/res/xml/file_paths.xml
+++ b/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+	<external-path name="external_files" path="." />
+</paths>


### PR DESCRIPTION
This is the code that can fix #627.
It uses the FileProvider class to build an URI for the just downloaded Image when sharing one.

Please ignore the first commit that's in the issue, Android Studio decided to push into the master branch instead of a new branch. :^)