### PR TITLE
Display gilded amount badge for posts

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
@@ -129,6 +129,10 @@ public class RedditParsedPost implements RedditThingWithIdAndType {
 		return score;
 	}
 
+	public int getGoldAmount() {
+		return mSrc.gilded;
+	}
+
 	public boolean isNsfw() {
 		return mSrc.over_18;
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -664,14 +664,18 @@ public final class RedditPreparedPost {
 				R.attr.rrPostSubtitleUpvoteCol,
 				R.attr.rrPostSubtitleDownvoteCol,
 				R.attr.rrFlairBackCol,
-				R.attr.rrFlairTextCol
+				R.attr.rrFlairTextCol,
+				R.attr.rrGoldTextCol,
+				R.attr.rrGoldBackCol
 		});
 
 		final int boldCol = appearance.getColor(0, 255),
 				rrPostSubtitleUpvoteCol = appearance.getColor(1, 255),
 				rrPostSubtitleDownvoteCol = appearance.getColor(2, 255),
 				rrFlairBackCol = appearance.getColor(3, 255),
-				rrFlairTextCol = appearance.getColor(4, 255);
+				rrFlairTextCol = appearance.getColor(4, 255),
+				rrGoldTextCol = appearance.getColor(5, 255),
+				rrGoldBackCol = appearance.getColor(6, 255);
 
 		appearance.recycle();
 
@@ -715,6 +719,14 @@ public final class RedditPreparedPost {
 
 		postListDescSb.append(String.valueOf(score), BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR, pointsCol, 0, 1f);
 		postListDescSb.append(" " + context.getString(R.string.subtitle_points) + " ", 0);
+
+		if (src.getGoldAmount() > 0) {
+			postListDescSb.append(" ", 0);
+			postListDescSb.append(" " + context.getString(R.string.gold) + " x" + src.getGoldAmount() + " ",
+					BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR, rrGoldTextCol, rrGoldBackCol, 1f);
+			postListDescSb.append("  ", 0);
+		}
+
 		postListDescSb.append(RRTime.formatDurationFrom(context, src.getCreatedTimeSecsUTC() * 1000), BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR, boldCol, 0, 1f);
 		postListDescSb.append(" " + context.getString(R.string.subtitle_by) + " ", 0);
 		postListDescSb.append(src.getAuthor(), BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR, boldCol, 0, 1f);

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -27,7 +27,7 @@ public final class RedditPost implements Parcelable, RedditThingWithIdAndType {
 
 	public String id, name;
 	public String title, url, author, domain, subreddit, subreddit_id;
-	public int num_comments, score, ups, downs;
+	public int num_comments, score, ups, downs, gilded;
 	public boolean archived, over_18, hidden, saved, is_self, clicked, stickied;
 	public Object edited;
 	public Boolean likes;
@@ -85,6 +85,7 @@ public final class RedditPost implements Parcelable, RedditThingWithIdAndType {
 		score = in.readInt();
 		ups = in.readInt();
 		downs = in.readInt();
+		gilded = in.readInt();
 		archived = in.readInt() == 1;
 		over_18 = in.readInt() == 1;
 		hidden = in.readInt() == 1;
@@ -147,6 +148,7 @@ public final class RedditPost implements Parcelable, RedditThingWithIdAndType {
 		parcel.writeInt(score);
 		parcel.writeInt(ups);
 		parcel.writeInt(downs);
+		parcel.writeInt(gilded);
 		parcel.writeInt(archived ? 1 : 0);
 		parcel.writeInt(over_18 ? 1 : 0);
 		parcel.writeInt(hidden ? 1 : 0);

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
@@ -103,16 +103,23 @@ public class RedditPostHeaderView extends LinearLayout {
 		final int boldCol = Color.WHITE;
 		final int rrPostSubtitleUpvoteCol;
 		final int rrPostSubtitleDownvoteCol;
+		final int rrGoldTextCol;
+		final int rrGoldBackCol;
 
 		{
 			final TypedArray appearance = context.obtainStyledAttributes(new int[]{
 					R.attr.rrPostSubtitleBoldCol,
 					R.attr.rrPostSubtitleUpvoteCol,
-					R.attr.rrPostSubtitleDownvoteCol
+					R.attr.rrPostSubtitleDownvoteCol,
+					R.attr.rrGoldTextCol,
+					R.attr.rrGoldBackCol
+
 			});
 
 			rrPostSubtitleUpvoteCol = appearance.getColor(1, 255);
 			rrPostSubtitleDownvoteCol = appearance.getColor(2, 255);
+			rrGoldTextCol = appearance.getColor(3, 255);
+			rrGoldBackCol = appearance.getColor(4, 255);
 
 			appearance.recycle();
 		}
@@ -136,6 +143,14 @@ public class RedditPostHeaderView extends LinearLayout {
 
 		postListDescSb.append(String.valueOf(post.computeScore()), BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR, pointsCol, 0, 1f);
 		postListDescSb.append(" " + context.getString(R.string.subtitle_points) + " ", 0);
+
+		if(post.src.getGoldAmount() > 0) {
+			postListDescSb.append(" ", 0);
+			postListDescSb.append(" " + context.getString(R.string.gold) + " x" + post.src.getGoldAmount() + " ",
+					BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR, rrGoldTextCol, rrGoldBackCol, 1f);
+			postListDescSb.append("  ", 0);
+		}
+
 		postListDescSb.append(RRTime.formatDurationFrom(context, post.src.getCreatedTimeSecsUTC() * 1000), BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR, boldCol, 0, 1f);
 		postListDescSb.append(" " + context.getString(R.string.subtitle_by) + " ", 0);
 		postListDescSb.append(post.src.getAuthor(), BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR, boldCol, 0, 1f);


### PR DESCRIPTION
Addresses #622 

This PR extracts the gilded property from the Reddit post object and displays a badge for gilded posts displaying the number of golds it receives. The badge is identical to the badge used for comments and is displayed in the subtitle on both the post list view and the post header. 
This badge is placed directly after the points span in the subtitle as shown below. 

![image](https://user-images.githubusercontent.com/14969987/47797036-9e621280-dd36-11e8-8ebe-925312ad175a.png)
