### PR TITLE
Fix Gfycat API URL

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/image/GfycatAPI.java
+++ b/src/main/java/org/quantumbadger/redreader/image/GfycatAPI.java
@@ -39,7 +39,7 @@ public final class GfycatAPI {
 			final int listId,
 			final GetImageInfoListener listener) {
 
-		final String apiUrl = "https://gfycat.com/cajax/get/" + imageId;
+		final String apiUrl = "https://api.gfycat.com/v1/gfycats/" + imageId;
 
 		CacheManager.getInstance(context).makeRequest(new CacheRequest(
 				General.uriFromString(apiUrl),


### PR DESCRIPTION
The cajax URL now returns 404 for all calls.

Changed the URL base to the one referenced in https://developers.gfycat.com/api/#getting-gfycats, which has the same payload as the old URL.