### PR TITLE
No-wrap gold gilding badge

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/BetterSSB.java
+++ b/src/main/java/org/quantumbadger/redreader/common/BetterSSB.java
@@ -37,6 +37,8 @@ public class BetterSSB {
 			BACKGROUND_COLOR = 1 << 5,
 			SIZE = 1 << 6;
 
+	public static final char NBSP = '\u00A0';
+
 	public BetterSSB() {
 		this.sb = new SpannableStringBuilder();
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -722,7 +722,7 @@ public final class RedditPreparedPost {
 
 		if (src.getGoldAmount() > 0) {
 			postListDescSb.append(" ", 0);
-			postListDescSb.append(" " + context.getString(R.string.gold) + " x" + src.getGoldAmount() + " ",
+			postListDescSb.append(" " + context.getString(R.string.gold) + BetterSSB.NBSP + "x" + src.getGoldAmount() + " ",
 					BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR, rrGoldTextCol, rrGoldBackCol, 1f);
 			postListDescSb.append("  ", 0);
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -176,7 +176,7 @@ public class RedditRenderableComment implements RedditRenderableInboxItem, Reddi
 
 				sb.append(" "
 								+ context.getString(R.string.gold)
-								+ " x"
+								+ BetterSSB.NBSP + "x"
 								+ rawComment.gilded
 								+ " ",
 						BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR,

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
@@ -146,7 +146,7 @@ public class RedditPostHeaderView extends LinearLayout {
 
 		if(post.src.getGoldAmount() > 0) {
 			postListDescSb.append(" ", 0);
-			postListDescSb.append(" " + context.getString(R.string.gold) + " x" + post.src.getGoldAmount() + " ",
+			postListDescSb.append(" " + context.getString(R.string.gold) + BetterSSB.NBSP + "x" + post.src.getGoldAmount() + " ",
 					BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR, rrGoldTextCol, rrGoldBackCol, 1f);
 			postListDescSb.append("  ", 0);
 		}


### PR DESCRIPTION
I noticed today on my phone that the `Gold xN` gilding badge can wrap between the strings `Gold` and `xN`.
Here's an example (I inserted artificial white-space to force it to happen in the emulator):
![before](https://user-images.githubusercontent.com/583503/49781915-6f9a6d00-fce2-11e8-961d-791a3fa2cfcc.png)

This PR replaces the regular space character between those two strings with a non-breakable space, with this as a result:
![after](https://user-images.githubusercontent.com/583503/49781917-71643080-fce2-11e8-8586-85f2a7232406.png)
