### PR TITLE
Added an indicator for the aspect ratio of media being loaded.

### DIFF
--- a/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
+++ b/src/main/java/com/github/lzyzsd/circleprogress/DonutProgress.java
@@ -8,23 +8,29 @@ import android.graphics.RectF;
 import android.view.View;
 
 /**
- * Created by bruce on 14-10-30. Edited by QuantumBadger.
+ * Created by bruce on 14-10-30. Edited by QuantumBadger and Cguy7777.
  */
 public class DonutProgress extends View {
 	private Paint finishedPaint;
 	private Paint unfinishedPaint;
+	private Paint aspectIndicatorPaint;
 
 	private RectF finishedOuterRect = new RectF();
 	private RectF unfinishedOuterRect = new RectF();
+	private RectF aspectIndicatorRect = new RectF();
 
 	private boolean indeterminate;
+	private boolean aspectIndicatorDisplay;
 
 	private float progress = 0;
 	private int finishedStrokeColor;
 	private int unfinishedStrokeColor;
+	private int aspectIndicatorStrokeColor;
 	private int startingDegree;
 	private float finishedStrokeWidth;
 	private float unfinishedStrokeWidth;
+	private float aspectIndicatorStrokeWidth;
+	private float imageAspectRatio;
 
 	private final int min_size;
 
@@ -54,6 +60,12 @@ public class DonutProgress extends View {
 		unfinishedPaint.setStyle(Paint.Style.STROKE);
 		unfinishedPaint.setAntiAlias(true);
 		unfinishedPaint.setStrokeWidth(unfinishedStrokeWidth);
+
+		aspectIndicatorPaint = new Paint();
+		aspectIndicatorPaint.setColor(aspectIndicatorStrokeColor);
+		aspectIndicatorPaint.setStyle(Paint.Style.STROKE);
+		aspectIndicatorPaint.setAntiAlias(true);
+		aspectIndicatorPaint.setStrokeWidth(aspectIndicatorStrokeWidth);
 	}
 
 	public void setFinishedStrokeWidth(float finishedStrokeWidth) {
@@ -64,9 +76,17 @@ public class DonutProgress extends View {
 		this.unfinishedStrokeWidth = unfinishedStrokeWidth;
 	}
 
+	public void setAspectIndicatorStrokeWidth(float aspectIndicatorStrokeWidth) {
+		this.aspectIndicatorStrokeWidth = aspectIndicatorStrokeWidth;
+	}
+
 	public void setIndeterminate(boolean value) {
 		indeterminate = value;
 		invalidate();
+	}
+
+	public void setAspectIndicatorDisplay(boolean value) {
+		aspectIndicatorDisplay = value;
 	}
 
 	private float getProgressAngle() {
@@ -90,6 +110,14 @@ public class DonutProgress extends View {
 
 	public void setUnfinishedStrokeColor(int unfinishedStrokeColor) {
 		this.unfinishedStrokeColor = unfinishedStrokeColor;
+	}
+
+	public void setAspectIndicatorStrokeColor(int aspectIndicatorStrokeColor) {
+		this.aspectIndicatorStrokeColor = aspectIndicatorStrokeColor;
+	}
+
+	public void setLoadingImageAspectRatio(float imageAspectRatio) {
+		this.imageAspectRatio = imageAspectRatio;
 	}
 
 	public int getStartingDegree() {
@@ -139,6 +167,25 @@ public class DonutProgress extends View {
 
 		} else {
 			canvas.drawArc(finishedOuterRect, getStartingDegree(), getProgressAngle(), false, finishedPaint);
+		}
+
+		if(aspectIndicatorDisplay) {
+			final float maxRatio = 2.75f;
+			if(imageAspectRatio > maxRatio) {
+				imageAspectRatio = maxRatio;
+			} else if(imageAspectRatio < 1 / maxRatio) {
+				imageAspectRatio = 1 / maxRatio;
+			}
+
+			final float arDeltaMultiplier = 3.5f;
+			float indicatorLeft = delta * arDeltaMultiplier + (delta * (arDeltaMultiplier / 4) * (1 - imageAspectRatio));
+			float indicatorTop = delta * arDeltaMultiplier + (delta * (arDeltaMultiplier / 4) * (1 - 1/imageAspectRatio));
+
+			aspectIndicatorRect.set(indicatorLeft,
+					indicatorTop,
+					getWidth() - indicatorLeft,
+					getHeight() - indicatorTop);
+			canvas.drawRect(aspectIndicatorRect, aspectIndicatorPaint);
 		}
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -185,9 +185,11 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 		progressBar.setIndeterminate(true);
 		progressBar.setFinishedStrokeColor(Color.rgb(200, 200, 200));
 		progressBar.setUnfinishedStrokeColor(Color.rgb(50, 50, 50));
+		progressBar.setAspectIndicatorStrokeColor(Color.rgb(200, 200, 200));
 		final int progressStrokeWidthPx = General.dpToPixels(this, 15);
 		progressBar.setUnfinishedStrokeWidth(progressStrokeWidthPx);
 		progressBar.setFinishedStrokeWidth(progressStrokeWidthPx);
+		progressBar.setAspectIndicatorStrokeWidth(General.dpToPixels(this, 1));
 		progressBar.setStartingDegree(-90);
 		progressBar.initPainters();
 
@@ -924,6 +926,23 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 	}
 
 
+	private void manageAspectRatioIndicator(DonutProgress progressBar) {
+		findAspectRatio:
+		if(PrefsUtility.pref_appearance_show_aspect_ratio_indicator(this, PreferenceManager.getDefaultSharedPreferences(this))) {
+			if(mImageInfo.width != null && mImageInfo.height != null && mImageInfo.width > 0 && mImageInfo.height > 0) {
+				progressBar.setLoadingImageAspectRatio((float) mImageInfo.width / mImageInfo.height);
+			} //TODO Get width and height of loading media when not available from API
+			else {
+				break findAspectRatio;
+			}
+
+			progressBar.setAspectIndicatorDisplay(true);
+			return;
+		}
+
+		progressBar.setAspectIndicatorDisplay(false);
+	}
+
 	private void makeCacheRequest(final DonutProgress progressBar, final URI uri, @Nullable final URI audioUri) {
 
 		final Object resultLock = new Object();
@@ -961,6 +980,7 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 							public void run() {
 								progressBar.setVisibility(View.VISIBLE);
 								progressBar.setIndeterminate(true);
+								manageAspectRatioIndicator(progressBar);
 							}
 						});
 					}
@@ -1002,6 +1022,7 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 								progressBar.setVisibility(View.VISIBLE);
 								progressBar.setIndeterminate(authorizationInProgress);
 								progressBar.setProgress(((float) ((1000 * bytesRead) / totalBytes)) / 1000);
+								manageAspectRatioIndicator(progressBar);
 
 								if(!mProgressTextSet) {
 									mProgressText.setText(General.bytesToMegabytes(totalBytes));

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -295,6 +295,10 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_appearance_image_viewer_show_floating_toolbar_key, true, context, sharedPreferences);
 	}
 
+	public static boolean pref_appearance_show_aspect_ratio_indicator(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_appearance_show_aspect_ratio_indicator_key, false, context, sharedPreferences);
+	}
+
 	public static boolean pref_appearance_comments_show_floating_toolbar(final Context context, final SharedPreferences sharedPreferences) {
 		return getBoolean(R.string.pref_appearance_comments_show_floating_toolbar_key, true, context, sharedPreferences);
 	}

--- a/src/main/java/org/quantumbadger/redreader/views/HorizontalSwipeProgressOverlay.java
+++ b/src/main/java/org/quantumbadger/redreader/views/HorizontalSwipeProgressOverlay.java
@@ -57,6 +57,7 @@ public class HorizontalSwipeProgressOverlay extends RelativeLayout {
 		mProgress.getLayoutParams().width = progressDimensionsPx;
 		mProgress.getLayoutParams().height = progressDimensionsPx;
 
+		mProgress.setAspectIndicatorDisplay(false);
 		mProgress.setFinishedStrokeColor(Color.RED);
 		mProgress.setUnfinishedStrokeColor(Color.argb(127, 0, 0, 0));
 		final int progressStrokeWidthPx = General.dpToPixels(context, 15);

--- a/src/main/java/org/quantumbadger/redreader/views/LoadingSpinnerView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/LoadingSpinnerView.java
@@ -44,6 +44,7 @@ public class LoadingSpinnerView extends RelativeLayout {
 		typedArray.recycle();
 
 		mProgressView = new DonutProgress(context);
+		mProgressView.setAspectIndicatorDisplay(false);
 		mProgressView.setIndeterminate(true);
 		mProgressView.setFinishedStrokeColor(foreground);
 		mProgressView.setUnfinishedStrokeColor(background);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1099,4 +1099,9 @@
 	<!-- 2018-11-26 -->
 	<string name="mainmenu_random_nsfw">Random NSFW Subreddit</string>
 
+	<!-- 2019-01-26 -->
+	<string name="pref_appearance_show_aspect_ratio_indicator_key" translatable="false">pref_appearance_show_aspect_ratio_indicator_key</string>
+	<string name="pref_appearance_show_aspect_ratio_indicator_title">Show Aspect Ratio Indicator</string>
+	<string name="pref_appearance_show_aspect_ratio_indicator_summary">Show a visual of loading media when available</string>
+
 </resources>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -81,9 +81,9 @@
 							android:key="@string/pref_appearance_image_viewer_show_floating_toolbar_key"
 							android:defaultValue="true"/>
 
-		<CheckBoxPreference android:title="Show Aspect Ratio Indicator"
-							android:key="pref_appearance_show_aspect_ratio_indicator_key"
-							android:summary="Show a visual of loading media when available"
+		<CheckBoxPreference android:title="@string/pref_appearance_show_aspect_ratio_indicator_title"
+							android:key="@string/pref_appearance_show_aspect_ratio_indicator_key"
+							android:summary="@string/pref_appearance_show_aspect_ratio_indicator_summary"
 							android:defaultValue="false"/>
 
 	</PreferenceCategory>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -81,6 +81,11 @@
 							android:key="@string/pref_appearance_image_viewer_show_floating_toolbar_key"
 							android:defaultValue="true"/>
 
+		<CheckBoxPreference android:title="Show Aspect Ratio Indicator"
+							android:key="pref_appearance_show_aspect_ratio_indicator_key"
+							android:summary="Show a visual of loading media when available"
+							android:defaultValue="false"/>
+
 	</PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_appearance_thumbnails_header">


### PR DESCRIPTION
I decided to take a stab at actually implementing this idea, and was partially able to! The only issue is that as written it only works if the image/GIF/video being loaded has its height and width provided by an API, but that still manages to include a great deal of posts with Imgur, Gifycat, DeviantArt, and Streamable being supported. Partially closes #632.