### PR TITLE
Updated deprecated ClipboardManager

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -32,7 +32,7 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
-import android.text.ClipboardManager;
+import android.content.ClipboardManager;
 import android.util.Log;
 import android.util.TypedValue;
 


### PR DESCRIPTION
android.text.ClipboardManager did not meet the minimum API level for the application. Updated it with current 