### PR TITLE
Fix "Skip to Frontpage" disregarding two-panel option

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -134,16 +134,16 @@ public class MainActivity extends RefreshableActivity
 		}
 
 		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+		twoPane = General.isTablet(this, sharedPreferences);
+
+		doRefresh(RefreshableFragment.MAIN_RELAYOUT, false, null);
+
 		if (savedInstanceState == null) {
 			if(PrefsUtility.pref_behaviour_skiptofrontpage(this, sharedPreferences))
 				onSelected(SubredditPostListURL.getFrontPage());
 		}
 
 		setTitle(R.string.app_name);
-
-		twoPane = General.isTablet(this, sharedPreferences);
-
-		doRefresh(RefreshableFragment.MAIN_RELAYOUT, false, null);
 
 		RedditAccountManager.getInstance(this).addUpdateListener(this);
 


### PR DESCRIPTION
This could fix issue #550. It was as easy as setting two panel mode and updating before executing the skipping preference on App startup.
The app now behaves as expected, opening in the two-panel mode while instantly loading the frontpage results in the right panel.
I tested this with:
- Nexus 7 2012 (small Android 7 Tablet device)
- Virtual Android 5 Phone
- Virtual Android 8 Phone
- Virtual Android 9 Tablet