### PR TITLE
Introduce built-in Share Dialog with prioritization

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/WebViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/WebViewActivity.java
@@ -20,6 +20,7 @@ package org.quantumbadger.redreader.activities;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -135,8 +136,14 @@ public class WebViewActivity extends BaseActivity implements RedditPostView.Post
 						mailer.putExtra(Intent.EXTRA_SUBJECT, mPost.title);
 					}
 					mailer.putExtra(Intent.EXTRA_TEXT, currentUrl);
-//					startActivity(Intent.createChooser(mailer, getString(R.string.action_share)));
-					ShareOrderDialog.newInstance(mailer).show(getSupportFragmentManager(), null);
+
+					if(PrefsUtility.pref_behaviour_sharing_dialog(
+							this,
+							PreferenceManager.getDefaultSharedPreferences(this))){
+						ShareOrderDialog.newInstance(mailer).show(getSupportFragmentManager(), null);
+					} else {
+						startActivity(Intent.createChooser(mailer, getString(R.string.action_share)));
+					}
 				}
 				return true;
 

--- a/src/main/java/org/quantumbadger/redreader/activities/WebViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/WebViewActivity.java
@@ -28,6 +28,7 @@ import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
 import org.quantumbadger.redreader.common.PrefsUtility;
+import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 import org.quantumbadger.redreader.fragments.WebViewFragment;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.things.RedditPost;
@@ -134,7 +135,8 @@ public class WebViewActivity extends BaseActivity implements RedditPostView.Post
 						mailer.putExtra(Intent.EXTRA_SUBJECT, mPost.title);
 					}
 					mailer.putExtra(Intent.EXTRA_TEXT, currentUrl);
-					startActivity(Intent.createChooser(mailer, getString(R.string.action_share)));
+//					startActivity(Intent.createChooser(mailer, getString(R.string.action_share)));
+					ShareOrderDialog.newInstance(mailer).show(getSupportFragmentManager(), null);
 				}
 				return true;
 

--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -665,8 +665,14 @@ public class MainMenuListingManager {
 					final Intent mailer = new Intent(Intent.ACTION_SEND);
 					mailer.setType("text/plain");
 					mailer.putExtra(Intent.EXTRA_TEXT, url);
-//					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
-					ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+
+					if(PrefsUtility.pref_behaviour_sharing_dialog(
+							activity,
+							PreferenceManager.getDefaultSharedPreferences(activity))){
+						ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+					} else {
+						activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+					}
 					break;
 				case COPY_URL:
 					ClipboardManager manager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -42,6 +42,7 @@ import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.fragments.MainMenuFragment;
+import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 import org.quantumbadger.redreader.reddit.api.RedditSubredditSubscriptionManager;
 import org.quantumbadger.redreader.reddit.things.RedditSubreddit;
 import org.quantumbadger.redreader.reddit.url.MultiredditPostListURL;
@@ -664,7 +665,8 @@ public class MainMenuListingManager {
 					final Intent mailer = new Intent(Intent.ACTION_SEND);
 					mailer.setType("text/plain");
 					mailer.putExtra(Intent.EXTRA_TEXT, url);
-					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+//					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+					ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
 					break;
 				case COPY_URL:
 					ClipboardManager manager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
@@ -1,3 +1,20 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
 package org.quantumbadger.redreader.adapters;
 
 import android.content.Context;

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
@@ -50,12 +50,12 @@ public class ShareOrderAdapter extends BaseAdapter {
 				.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 		View rowView = null;
 		if(inflater != null) {
-			rowView = inflater.inflate(R.layout.list_item, parent, false);
-			TextView label = rowView.findViewById(R.id.list_item_text);
+			rowView = inflater.inflate(R.layout.list_item_share_dialog, parent, false);
+			TextView label = rowView.findViewById(R.id.list_item_share_dialog_text);
 			label.setText(appList.get(position).loadLabel(packageManager).toString());
-			ImageView icon = rowView.findViewById(R.id.list_item_icon);
+			ImageView icon = rowView.findViewById(R.id.list_item_share_dialog_icon);
 			icon.setImageDrawable(appList.get(position).loadIcon(packageManager));
-			View divider = rowView.findViewById(R.id.list_item_divider);
+			View divider = rowView.findViewById(R.id.list_item_share_dialog_divider);
 			divider.setVisibility(View.INVISIBLE);
 
 			rowView.setOnClickListener(new View.OnClickListener(){

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
@@ -3,7 +3,6 @@ package org.quantumbadger.redreader.adapters;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatDialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderAdapter.java
@@ -1,0 +1,73 @@
+package org.quantumbadger.redreader.adapters;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AppCompatDialogFragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import org.quantumbadger.redreader.R;
+
+import java.util.List;
+
+public class ShareOrderAdapter extends BaseAdapter {
+
+	private final Context context;
+	private final List<ResolveInfo> appList;
+	private final PackageManager packageManager;
+	private final AppCompatDialogFragment fragment;
+
+	public ShareOrderAdapter(Context context, List<ResolveInfo> appList, AppCompatDialogFragment fragment) {
+		this.context = context;
+		this.appList = appList;
+		this.packageManager = context.getPackageManager();
+		this.fragment = fragment;
+	}
+
+	@Override
+	public int getCount() {
+		return appList.size();
+	}
+
+	@Override
+	public Object getItem(int position) {
+		return appList.get(position);
+	}
+
+	@Override
+	public long getItemId(int position) {
+		return position;
+	}
+
+	@Override
+	public View getView(final int position, View convertView, ViewGroup parent) {
+		LayoutInflater inflater = (LayoutInflater) context
+				.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+		View rowView = null;
+		if(inflater != null) {
+			rowView = inflater.inflate(R.layout.list_item, parent, false);
+			TextView label = rowView.findViewById(R.id.list_item_text);
+			label.setText(appList.get(position).loadLabel(packageManager).toString());
+			ImageView icon = rowView.findViewById(R.id.list_item_icon);
+			icon.setImageDrawable(appList.get(position).loadIcon(packageManager));
+			View divider = rowView.findViewById(R.id.list_item_divider);
+			divider.setVisibility(View.INVISIBLE);
+
+			rowView.setOnClickListener(new View.OnClickListener(){
+				@Override
+				public void onClick(View v) {
+					((ShareOrderCallbackListener) fragment).onSelectedIntent(position);
+					fragment.dismiss();
+				}
+			});
+		}
+
+		return rowView;
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderCallbackListener.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderCallbackListener.java
@@ -1,3 +1,20 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
 package org.quantumbadger.redreader.adapters;
 
 public interface ShareOrderCallbackListener {

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderCallbackListener.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderCallbackListener.java
@@ -1,13 +1,6 @@
 package org.quantumbadger.redreader.adapters;
 
 public interface ShareOrderCallbackListener {
-
-	enum MediaType{
-		PLAINTEXT,
-		IMAGE,
-		VIDEO
-	}
-
 	void onSelectedIntent(int position);
 
 }

--- a/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderCallbackListener.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/ShareOrderCallbackListener.java
@@ -1,0 +1,13 @@
+package org.quantumbadger.redreader.adapters;
+
+public interface ShareOrderCallbackListener {
+
+	enum MediaType{
+		PLAINTEXT,
+		IMAGE,
+		VIDEO
+	}
+
+	void onSelectedIntent(int position);
+
+}

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -39,6 +39,7 @@ import android.util.TypedValue;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.*;
 import org.quantumbadger.redreader.cache.CacheRequest;
+import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 import org.quantumbadger.redreader.fragments.UserProfileDialog;
 import org.quantumbadger.redreader.image.*;
 import org.quantumbadger.redreader.reddit.things.RedditPost;
@@ -353,7 +354,8 @@ public class LinkHandler {
 				final Intent mailer = new Intent(Intent.ACTION_SEND);
 				mailer.setType("text/plain");
 				mailer.putExtra(Intent.EXTRA_TEXT, uri);
-				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+//				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
 				break;
 			case COPY_URL:
 				ClipboardManager manager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -354,8 +354,14 @@ public class LinkHandler {
 				final Intent mailer = new Intent(Intent.ACTION_SEND);
 				mailer.setType("text/plain");
 				mailer.putExtra(Intent.EXTRA_TEXT, uri);
-//				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
-				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+
+				if(PrefsUtility.pref_behaviour_sharing_dialog(
+						activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))){
+					ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+				} else {
+					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+				}
 				break;
 			case COPY_URL:
 				ClipboardManager manager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -531,7 +531,7 @@ public final class PrefsUtility {
 	}
 
 	public static boolean pref_behaviour_sharing_dialog(final Context context, final SharedPreferences sharedPreferences) {
-		return getBoolean(R.string.pref_behaviour_sharing_share_dialog_key, true, context, sharedPreferences);
+		return getBoolean(R.string.pref_behaviour_sharing_share_dialog_key, false, context, sharedPreferences);
 	}
 
 	public static String pref_behaviour_sharing_dialog_data_get(final Context context, final SharedPreferences sharedPreferences) {

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -534,6 +534,14 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_behaviour_sharing_share_dialog_key, true, context, sharedPreferences);
 	}
 
+	public static String pref_behaviour_sharing_dialog_data_get(final Context context, final SharedPreferences sharedPreferences) {
+		return getString(R.string.pref_behaviour_sharing_share_dialog_data, "", context, sharedPreferences);
+	}
+
+	public static void pref_behaviour_sharing_dialog_data_set(final Context context, final SharedPreferences sharedPreferences, String appNames) {
+		sharedPreferences.edit().putString(context.getString(R.string.pref_behaviour_sharing_share_dialog_data), appNames).apply();
+	}
+
 	public static PostSort pref_behaviour_postsort(final Context context, final SharedPreferences sharedPreferences) {
 		return PostSort.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_postsort_key, "hot", context, sharedPreferences)));
 	}

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -530,6 +530,10 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_behaviour_sharing_include_desc_key, true, context, sharedPreferences);
 	}
 
+	public static boolean pref_behaviour_sharing_dialog(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_behaviour_sharing_share_dialog_key, true, context, sharedPreferences);
+	}
+
 	public static PostSort pref_behaviour_postsort(final Context context, final SharedPreferences sharedPreferences) {
 		return PostSort.valueOf(General.asciiUppercase(getString(R.string.pref_behaviour_postsort_key, "hot", context, sharedPreferences)));
 	}

--- a/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
@@ -8,6 +8,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatDialogFragment;
 import android.widget.ListView;
 
@@ -42,6 +43,7 @@ public class ShareOrderDialog extends AppCompatDialogFragment implements ShareOr
 		shareIntent = getArguments().getParcelable("intent");
 	}
 
+	@NonNull
 	@Override
 	public Dialog onCreateDialog(final Bundle savedInstanceState){
 		super.onCreateDialog(savedInstanceState);
@@ -52,7 +54,7 @@ public class ShareOrderDialog extends AppCompatDialogFragment implements ShareOr
 		final Context context = this.getContext();
 
 		final AlertDialog.Builder builder = new AlertDialog.Builder(context);
-		builder.setTitle(context.getString(R.string.share_order_dialog_title));
+		builder.setTitle(context.getString(R.string.share_dialog_title));
 
 		ListView listView = new ListView(context);
 		builder.setView(listView);

--- a/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
@@ -121,10 +121,11 @@ public class ShareOrderDialog extends AppCompatDialogFragment implements ShareOr
 				PreferenceManager.getDefaultSharedPreferences(context)).split(";")));
 		if(priorityAppList.contains(selectedApplication.name)){
 			priorityAppList.remove(selectedApplication.name);
-		} else {
-			priorityAppList.removeLast();
 		}
 		priorityAppList.add(0, selectedApplication.name);
+		if(priorityAppList.size() > amountOfPrioritizedApps){
+			priorityAppList.removeLast();
+		}
 
 		PrefsUtility.pref_behaviour_sharing_dialog_data_set(context,
 				PreferenceManager.getDefaultSharedPreferences(context),

--- a/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
@@ -1,3 +1,20 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
 package org.quantumbadger.redreader.fragments;
 
 import android.app.AlertDialog;

--- a/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/ShareOrderDialog.java
@@ -1,0 +1,82 @@
+package org.quantumbadger.redreader.fragments;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatDialogFragment;
+import android.widget.ListView;
+
+import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.adapters.ShareOrderAdapter;
+import org.quantumbadger.redreader.adapters.ShareOrderCallbackListener;
+
+import java.util.LinkedList;
+import java.util.List;
+
+
+public class ShareOrderDialog extends AppCompatDialogFragment implements ShareOrderCallbackListener {
+	private PackageManager packageManager;
+	private Intent shareIntent;
+	private List<ResolveInfo> orderedAppList;
+
+	public static ShareOrderDialog newInstance(final Intent shareIntent) {
+		final ShareOrderDialog dialog = new ShareOrderDialog();
+
+		final Bundle args = new Bundle(1);
+		args.putParcelable("intent", shareIntent);
+		dialog.setArguments(args);
+
+		return dialog;
+	}
+
+	@Override
+	public void onCreate(final Bundle savedInstanceState){
+		super.onCreate(savedInstanceState);
+
+		packageManager = getActivity().getPackageManager();
+		shareIntent = getArguments().getParcelable("intent");
+	}
+
+	@Override
+	public Dialog onCreateDialog(final Bundle savedInstanceState){
+		super.onCreateDialog(savedInstanceState);
+
+		List<ResolveInfo> appList = packageManager.queryIntentActivities(shareIntent, 0);
+		orderedAppList = prioritizeTopApps(appList);
+
+		final Context context = this.getContext();
+
+		final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+		builder.setTitle(context.getString(R.string.share_order_dialog_title));
+
+		ListView listView = new ListView(context);
+		builder.setView(listView);
+
+		listView.setAdapter(new ShareOrderAdapter(context, orderedAppList, this));
+
+		return builder.create();
+	}
+
+	private List<ResolveInfo> prioritizeTopApps(List<ResolveInfo> unorderedList){
+		List<ResolveInfo> orderedList = new LinkedList<ResolveInfo>(unorderedList);
+
+		//TODO: implement preference for Order and ordering
+
+		return orderedList;
+	}
+
+
+	@Override
+	public void onSelectedIntent(int position) {
+		ActivityInfo info = orderedAppList.get(position).activityInfo;
+		shareIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+		shareIntent.setClassName(info.applicationInfo.packageName, info.name);
+		shareIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+		startActivity(shareIntent);
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
@@ -34,6 +34,7 @@ import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
 import org.quantumbadger.redreader.common.RRError;
+import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 
 import java.io.File;
 import java.io.IOException;
@@ -156,7 +157,9 @@ public class ShareImageCallback implements BaseActivity.PermissionCallback {
 							shareIntent.setAction(Intent.ACTION_SEND);
 							shareIntent.putExtra(Intent.EXTRA_STREAM, sharedImage);
 							shareIntent.setType(mimetype);
-							activity.startActivity(Intent.createChooser(shareIntent, activity.getString(R.string.action_share_image)));
+//							activity.startActivity(Intent.createChooser(shareIntent, activity.getString(R.string.action_share_image)));
+							ShareOrderDialog.newInstance(shareIntent).show(activity.getSupportFragmentManager(), null);
+
 
 						} catch(IOException e) {
 							notifyFailure(CacheRequest.REQUEST_FAILURE_STORAGE, e, null, "Could not copy file");

--- a/src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
@@ -20,6 +20,7 @@ package org.quantumbadger.redreader.image;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Environment;
+import android.preference.PreferenceManager;
 import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
 import org.quantumbadger.redreader.R;
@@ -33,6 +34,7 @@ import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyIfNotC
 import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
+import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRError;
 import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 
@@ -157,9 +159,14 @@ public class ShareImageCallback implements BaseActivity.PermissionCallback {
 							shareIntent.setAction(Intent.ACTION_SEND);
 							shareIntent.putExtra(Intent.EXTRA_STREAM, sharedImage);
 							shareIntent.setType(mimetype);
-//							activity.startActivity(Intent.createChooser(shareIntent, activity.getString(R.string.action_share_image)));
-							ShareOrderDialog.newInstance(shareIntent).show(activity.getSupportFragmentManager(), null);
 
+							if(PrefsUtility.pref_behaviour_sharing_dialog(
+									activity,
+									PreferenceManager.getDefaultSharedPreferences(activity))){
+								ShareOrderDialog.newInstance(shareIntent).show(activity.getSupportFragmentManager(), null);
+							} else {
+								activity.startActivity(Intent.createChooser(shareIntent, activity.getString(R.string.action_share)));
+							}
 
 						} catch(IOException e) {
 							notifyFailure(CacheRequest.REQUEST_FAILURE_STORAGE, e, null, "Could not copy file");

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -306,8 +306,13 @@ public class RedditAPICommentAction {
 				body += comment.getContextUrl().generateNonJsonUri().toString();
 				mailer.putExtra(Intent.EXTRA_TEXT, body);
 
-//				activity.startActivityForResult(Intent.createChooser(mailer, activity.getString(R.string.action_share)), 1);
-				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+				if(PrefsUtility.pref_behaviour_sharing_dialog(
+						activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))){
+					ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+				} else {
+					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+				}
 
 				break;
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -42,6 +42,7 @@ import org.quantumbadger.redreader.common.RRError;
 import org.quantumbadger.redreader.common.RRTime;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
 import org.quantumbadger.redreader.fragments.CommentPropertiesDialog;
+import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 import org.quantumbadger.redreader.reddit.APIResponseHandler;
 import org.quantumbadger.redreader.reddit.RedditAPI;
 import org.quantumbadger.redreader.reddit.prepared.RedditChangeDataManager;
@@ -305,7 +306,8 @@ public class RedditAPICommentAction {
 				body += comment.getContextUrl().generateNonJsonUri().toString();
 				mailer.putExtra(Intent.EXTRA_TEXT, body);
 
-				activity.startActivityForResult(Intent.createChooser(mailer, activity.getString(R.string.action_share)), 1);
+//				activity.startActivityForResult(Intent.createChooser(mailer, activity.getString(R.string.action_share)), 1);
+				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
 
 				break;
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -47,6 +47,7 @@ import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyIfNotCached;
 import org.quantumbadger.redreader.common.*;
 import org.quantumbadger.redreader.fragments.PostPropertiesDialog;
+import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 import org.quantumbadger.redreader.image.SaveImageCallback;
 import org.quantumbadger.redreader.image.ShareImageCallback;
 import org.quantumbadger.redreader.image.ThumbnailScaler;
@@ -429,7 +430,9 @@ public final class RedditPreparedPost {
 					mailer.putExtra(Intent.EXTRA_SUBJECT, post.src.getTitle());
 				}
 				mailer.putExtra(Intent.EXTRA_TEXT, post.src.getUrl());
-				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+//				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+
 				break;
 			}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -453,7 +453,8 @@ public final class RedditPreparedPost {
 				} else {
 					mailer.putExtra(Intent.EXTRA_TEXT, Constants.Reddit.getNonAPIUri(Constants.Reddit.PATH_COMMENTS + post.src.getIdAlone()).toString());
 				}
-				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share_comments)));
+//				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share_comments)));
+				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
 				break;
 			}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -430,9 +430,14 @@ public final class RedditPreparedPost {
 					mailer.putExtra(Intent.EXTRA_SUBJECT, post.src.getTitle());
 				}
 				mailer.putExtra(Intent.EXTRA_TEXT, post.src.getUrl());
-//				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
-				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
 
+				if(PrefsUtility.pref_behaviour_sharing_dialog(
+						activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))){
+					ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+				} else {
+					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+				}
 				break;
 			}
 
@@ -453,8 +458,13 @@ public final class RedditPreparedPost {
 				} else {
 					mailer.putExtra(Intent.EXTRA_TEXT, Constants.Reddit.getNonAPIUri(Constants.Reddit.PATH_COMMENTS + post.src.getIdAlone()).toString());
 				}
-//				activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share_comments)));
-				ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+				if(PrefsUtility.pref_behaviour_sharing_dialog(
+						activity,
+						PreferenceManager.getDefaultSharedPreferences(activity))){
+					ShareOrderDialog.newInstance(mailer).show(activity.getSupportFragmentManager(), null);
+				} else {
+					activity.startActivity(Intent.createChooser(mailer, activity.getString(R.string.action_share)));
+				}
 				break;
 			}
 

--- a/src/main/res/layout/list_item_share_dialog.xml
+++ b/src/main/res/layout/list_item_share_dialog.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ This file is part of RedReader.
+  ~
+  ~ RedReader is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ RedReader is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="fill_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
+
+    <View android:id="@+id/list_item_share_dialog_divider"
+          android:layout_width="match_parent"
+          android:layout_height="1dp"
+          android:minHeight="1dp"
+          android:background="?rrListDividerCol"/>
+
+    <LinearLayout android:layout_height="wrap_content"
+                  android:layout_width="match_parent"
+                  android:orientation="horizontal"
+                  android:gravity="center_vertical"
+				  android:background="@drawable/rr_list_item_selector"
+                  android:paddingLeft="16dp"
+                  android:paddingRight="16dp">
+
+        <ImageView android:id="@+id/list_item_share_dialog_icon"
+                   android:layout_height="32dp"
+                   android:layout_width="32dp"
+                   android:layout_marginRight="16dp"
+                   android:scaleType="fitCenter"/>
+
+        <TextView android:id="@+id/list_item_share_dialog_text"
+                  android:layout_width="fill_parent"
+                  android:layout_height="wrap_content"
+                  android:textSize="18sp"
+                  android:gravity="center_vertical"
+                  android:layout_margin="0dp"
+                  android:paddingTop="12dp"
+                  android:paddingBottom="12dp"
+                  android:textColor="?android:textColorPrimary" />
+
+    </LinearLayout>
+
+</LinearLayout>
+

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1115,8 +1115,10 @@
 	<string name="prefs_category_images_video">Images/Video</string>
 
 	<!-- 2018-11-?? -->
-	<string name="share_dialog_title">Select an App for sharing</string>
+	<string name="pref_behaviour_sharing_share_dialog_dialogtitle">Select an App for sharing</string>
 	<string name="pref_behaviour_sharing_share_dialog_key" translatable="false">share_order_preference_key</string>
 	<string name="pref_behaviour_sharing_share_dialog_title">Use built-in share dialog</string>
+	<string name="pref_behaviour_sharing_share_dialog_data" translatable="false">pref_behaviour_sharing_share_dialog_data</string>
+	<string name="error_toast_no_share_app_installed">No suitable app installed to share this.</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1115,6 +1115,8 @@
 	<string name="prefs_category_images_video">Images/Video</string>
 
 	<!-- 2018-11-?? -->
-	<string name="share_order_dialog_title">Select an App for sharing</string>
+	<string name="share_dialog_title">Select an App for sharing</string>
+	<string name="pref_behaviour_sharing_share_dialog_key" translatable="false">share_order_preference_key</string>
+	<string name="pref_behaviour_sharing_share_dialog_title">Use built-in share dialog</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1114,4 +1114,7 @@
 
 	<string name="prefs_category_images_video">Images/Video</string>
 
+	<!-- 2018-11-?? -->
+	<string name="share_order_dialog_title">Select an App for sharing</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1114,7 +1114,7 @@
 
 	<string name="prefs_category_images_video">Images/Video</string>
 
-	<!-- 2019-10-10 -->
+	<!-- 2020-01-11 -->
 	<string name="pref_behaviour_sharing_share_dialog_dialogtitle">Select an App for sharing</string>
 	<string name="pref_behaviour_sharing_share_dialog_key" translatable="false">share_order_preference_key</string>
 	<string name="pref_behaviour_sharing_share_dialog_title">Use built-in share dialog</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1114,7 +1114,7 @@
 
 	<string name="prefs_category_images_video">Images/Video</string>
 
-	<!-- 2018-11-?? -->
+	<!-- 2019-10-10 -->
 	<string name="pref_behaviour_sharing_share_dialog_dialogtitle">Select an App for sharing</string>
 	<string name="pref_behaviour_sharing_share_dialog_key" translatable="false">share_order_preference_key</string>
 	<string name="pref_behaviour_sharing_share_dialog_title">Use built-in share dialog</string>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -167,6 +167,10 @@
 				android:key="@string/pref_behaviour_sharing_share_text_key"
 				android:defaultValue="true"/>
 
+		<CheckBoxPreference android:title="@string/pref_behaviour_sharing_share_dialog_title"
+				android:key="@string/pref_behaviour_sharing_share_dialog_key"
+				android:defaultValue="true"/>
+
 	</PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/pref_behaviour_bezel_toolbar_header">

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -169,7 +169,7 @@
 
 		<CheckBoxPreference android:title="@string/pref_behaviour_sharing_share_dialog_title"
 				android:key="@string/pref_behaviour_sharing_share_dialog_key"
-				android:defaultValue="true"/>
+				android:defaultValue="false"/>
 
 	</PreferenceCategory>
 


### PR DESCRIPTION
As mentioned earlier this month, I somewhat finished implementing an own Share Dialog. This should close #581 if it suffices.
The new share dialog reuses the list_item.xml to build a List of Applications that can share the selected content and prioritizes three recently (within RedReader) used Apps.
The edge-cases of having less than three and no available Application to share the content with are handled.
This solution as is should be able to handle a variable amount of prioritized Apps and can be changed through the static Int in ShareOrderDialog. That's something I could imagine to be a configurable option, too.

I'm aware that doing this with that many Lists is not performant, though there is no way to persist the ResolveInfo without relying on external library like GSON. This is why I persist a concatenated String with the Intent names and go through the list, pulling out the prioritized Apps through their Intent name and later re-add them in their respective order to the beginning of the list.
I'm open for suggestions on how to improve it.

Here's an example picture;
![image](https://user-images.githubusercontent.com/20663728/66562328-bb64af80-eb5b-11e9-9cca-ac12e49288a3.png)
