### PR TITLE
Draft feature for postsubmit. Fixes #557

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -237,4 +237,9 @@ public class CommentListingActivity extends RefreshableActivity
 	public void onBackPressed() {
 		if(General.onBackPressed()) super.onBackPressed();
 	}
+
+	@Override
+	public PostCommentListingURL.Sort getCommentSort() {
+		return controller.getSort();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -1055,4 +1055,5 @@ public class MainActivity extends RefreshableActivity
 	public PostCommentListingURL.Sort getCommentSort() {
 		return commentListingController.getSort();
 	}
+
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -1045,4 +1045,14 @@ public class MainActivity extends RefreshableActivity
 			}
 		});
 	}
+
+	@Override
+	public PostSort getPostSort() {
+		return postListingController.getSort();
+	}
+
+	@Override
+	public PostCommentListingURL.Sort getCommentSort() {
+		return commentListingController.getSort();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -196,4 +196,9 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 	public void onBackPressed() {
 		if(General.onBackPressed()) super.onBackPressed();
 	}
+
+	@Override
+	public PostCommentListingURL.Sort getCommentSort() {
+		return null;
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -41,8 +41,6 @@ import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.settings.SettingsActivity;
 
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class OptionsMenuUtility {
 

--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -502,36 +502,20 @@ public final class OptionsMenuUtility {
 			sortPosts.getItem().setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
 		}
 
-		// Store the menu item for each sorting option in a map
-		Map<PostSort, MenuItem> sortingItems = new HashMap<PostSort, MenuItem>();
-
-		sortingItems.put(PostSort.HOT, addSort(activity, sortPosts, R.string.sort_posts_hot, PostSort.HOT));
-		sortingItems.put(PostSort.NEW, addSort(activity, sortPosts, R.string.sort_posts_new, PostSort.NEW));
+		addSort(activity, sortPosts, R.string.sort_posts_hot, PostSort.HOT);
+		addSort(activity, sortPosts, R.string.sort_posts_new, PostSort.NEW);
 		if(includeRising)
-			sortingItems.put(PostSort.RISING, addSort(activity, sortPosts, R.string.sort_posts_rising, PostSort.RISING));
-		sortingItems.put(PostSort.CONTROVERSIAL, addSort(activity, sortPosts, R.string.sort_posts_controversial, PostSort.CONTROVERSIAL));
+			addSort(activity, sortPosts, R.string.sort_posts_rising, PostSort.RISING);
+		addSort(activity, sortPosts, R.string.sort_posts_controversial, PostSort.CONTROVERSIAL);
 		if(includeBest)
-			sortingItems.put(PostSort.BEST, addSort(activity, sortPosts, R.string.sort_posts_best, PostSort.BEST));
+			addSort(activity, sortPosts, R.string.sort_posts_best, PostSort.BEST);
 
 		final SubMenu sortPostsTop = sortPosts.addSubMenu(R.string.sort_posts_top);
-
-		sortingItems.put(PostSort.TOP_HOUR, addSort(activity, sortPostsTop, R.string.sort_posts_top_hour, PostSort.TOP_HOUR));
-		sortingItems.put(PostSort.TOP_DAY, addSort(activity, sortPostsTop, R.string.sort_posts_top_today, PostSort.TOP_DAY));
-		sortingItems.put(PostSort.TOP_WEEK, addSort(activity, sortPostsTop, R.string.sort_posts_top_week, PostSort.TOP_WEEK));
-		sortingItems.put(PostSort.TOP_MONTH, addSort(activity, sortPostsTop, R.string.sort_posts_top_month, PostSort.TOP_MONTH));
-		sortingItems.put(PostSort.TOP_YEAR, addSort(activity, sortPostsTop, R.string.sort_posts_top_year, PostSort.TOP_YEAR));
-		sortingItems.put(PostSort.TOP_ALL, addSort(activity, sortPostsTop, R.string.sort_posts_top_all, PostSort.TOP_ALL));
-
-		// Get the selected sorting method for posts
-		PostSort currentSort = ((OptionsMenuPostsListener) activity).getPostSort();
-		if(sortingItems.containsKey(currentSort)) {
-			// Highlight the corresponding menu item
-			MenuItem toHighlight = sortingItems.get(currentSort);
-
-			SpannableString s = new SpannableString(toHighlight.getTitle());
-			s.setSpan(new ForegroundColorSpan(Color.RED), 0, s.length(), 0);
-			toHighlight.setTitle(s);
-		}
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_hour, PostSort.TOP_HOUR);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_today, PostSort.TOP_DAY);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_week, PostSort.TOP_WEEK);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_month, PostSort.TOP_MONTH);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_year, PostSort.TOP_YEAR);
 	}
 
 	private static void addAllSearchSorts(final AppCompatActivity activity, final Menu menu, final boolean icon) {
@@ -550,7 +534,13 @@ public final class OptionsMenuUtility {
 		addSort(activity, sortPosts, R.string.sort_posts_comments, PostSort.COMMENTS);
 	}
 
-	private static MenuItem addSort(final AppCompatActivity activity, final Menu menu, final int name, final PostSort order) {
+	private static void highlightMenuItem(MenuItem item) {
+		SpannableString s = new SpannableString(item.getTitle());
+		s.setSpan(new ForegroundColorSpan(Color.rgb(200, 70, 70)), 0, s.length(), 0);
+		item.setTitle(s);
+	}
+
+	private static void addSort(final AppCompatActivity activity, final Menu menu, final int name, final PostSort order) {
 		MenuItem item = menu.add(activity.getString(name));
 		item.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
 			public boolean onMenuItemClick(final MenuItem item) {
@@ -558,7 +548,12 @@ public final class OptionsMenuUtility {
 				return true;
 			}
 		});
-		return item;
+
+		// Highlight this item if it is selected
+		if(activity instanceof OptionsMenuPostsListener) {
+			if(((OptionsMenuPostsListener) activity).getPostSort().equals(order))
+				highlightMenuItem(item);
+		}
 	}
 
 	private static void addAllCommentSorts(final AppCompatActivity activity, final Menu menu, final boolean icon) {
@@ -580,13 +575,18 @@ public final class OptionsMenuUtility {
 	}
 
 	private static void addSort(final AppCompatActivity activity, final Menu menu, final int name, final PostCommentListingURL.Sort order) {
-
-		menu.add(activity.getString(name)).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+		MenuItem item = menu.add(activity.getString(name));
+		item.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
 			public boolean onMenuItemClick(final MenuItem item) {
 				((OptionsMenuCommentsListener)activity).onSortSelected(order);
 				return true;
 			}
 		});
+
+		if(activity instanceof OptionsMenuCommentsListener) {
+			if(((OptionsMenuCommentsListener) activity).getCommentSort().equals(order))
+				highlightMenuItem(item);
+		}
 	}
 
 	private static void addAllUserCommentSorts(final AppCompatActivity activity, final Menu menu, final boolean icon) {
@@ -613,7 +613,6 @@ public final class OptionsMenuUtility {
 	}
 
 	private static void addSort(final AppCompatActivity activity, final Menu menu, final int name, final UserCommentListingURL.Sort order) {
-
 		menu.add(activity.getString(name)).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
 			@Override
 			public boolean onMenuItemClick(MenuItem menuItem) {

--- a/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
@@ -429,4 +429,8 @@ public class PostListingActivity extends RefreshableActivity
 			}
 		});
 	}
+
+	public PostSort getPostSort() {
+		return controller.getSort();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
@@ -51,7 +51,7 @@ import org.quantumbadger.redreader.reddit.RedditAPI;
 
 import java.util.ArrayList;
 
-// TODO save draft as static var (as in comments)
+
 public class PostSubmitActivity extends BaseActivity {
 
 	private Spinner typeSpinner, usernameSpinner;
@@ -64,6 +64,14 @@ public class PostSubmitActivity extends BaseActivity {
 
 	private static final int
 			REQUEST_UPLOAD = 1;
+
+	private static int lastType;
+	private static String lastTitle;
+	private static String lastSubreddit;
+	private static String lastText;
+	private static boolean lastNsfw;
+	private static boolean lastSpoiler;
+	private static boolean lastInbox;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -124,6 +132,16 @@ public class PostSubmitActivity extends BaseActivity {
 
 		usernameSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, usernames));
 		typeSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, postTypes));
+
+		if ((lastTitle != null || lastText != null)
+				&& subredditEdit.getText().toString().equals(lastSubreddit)) {
+			typeSpinner.setSelection(lastType);
+			titleEdit.setText(lastTitle);
+			textEdit.setText(lastText);
+			sendRepliesToInboxCheckbox.setChecked(lastInbox);
+			markAsSpoilerCheckbox.setChecked(lastSpoiler);
+			markAsNsfwCheckbox.setChecked(lastNsfw);
+		}
 
 		// TODO remove the duplicate code here
 		setHint();
@@ -244,6 +262,14 @@ public class PostSubmitActivity extends BaseActivity {
 								General.safeDismissDialog(progressDialog);
 								General.quickToast(PostSubmitActivity.this, getString(R.string.post_submit_done));
 
+								lastType = 0;
+								lastTitle = null;
+								lastSubreddit = null;
+								lastText = null;
+								lastInbox = true;
+								lastNsfw = false;
+								lastSpoiler = false;
+
 								if(redirectUrl != null) {
 									LinkHandler.onLinkClicked(PostSubmitActivity.this, redirectUrl);
 								}
@@ -329,5 +355,20 @@ public class PostSubmitActivity extends BaseActivity {
 	@Override
 	public void onBackPressed() {
 		if(General.onBackPressed()) super.onBackPressed();
+	}
+
+	@Override
+	protected void onDestroy(){
+		super.onDestroy();
+		if(titleEdit != null){
+			lastType = typeSpinner.getSelectedItemPosition();
+			lastTitle = titleEdit.getText().toString();
+			lastSubreddit = subredditEdit.getText().toString();
+			lastText = textEdit.getText().toString();
+			lastInbox = sendRepliesToInboxCheckbox.isChecked();
+			lastNsfw = markAsNsfwCheckbox.isChecked();
+			lastSpoiler = markAsSpoilerCheckbox.isChecked();
+			General.quickToast(this, "Draft saved", 2000);
+		}
 	}
 }


### PR DESCRIPTION
This feature makes it possible to save a draft for a post with static variables. 
The changes are in PostSubmitActivity.java. There are mainly based on the draft functionnality in CommentReplyActivity.java.
The fields stored in this simple draft are : 
- type of post (String)
- post subreddit (String)
- post title (String)
- post content (String)
- if the replies should be sent to inbox (boolean)
- if the post is NSFW (boolean)
- if the post is spoiler (boolean)


**Before** : when a user wrote a post on a subreddit, this post was lost if the user went back to the subreddit page or to another page.

**Benefits** : when a user writes a post on a subreddit, this post is saved for the current subreddit. If the user go to another page, he can get its post back when he hits "Submit Post" on the same subreddit page. 

**Limits** : 
- If the user goes to another subreddit and hits "Submit Post", then the draft of the previous subreddit is lost. 
- If the user quits the application, then the draft is lost.

**Next** : 
- Maybe we could use a data class instead of static variables. Using the subreddit as a key, we could save a draft for each subreddit.  
- Maybe suggesting draft saving as an option to the user. Indeed, saving drafts automatically can be annoying for some users.
- Use persistence to store the drafts even if the user quits the application. 