### PR TITLE
added draft feature on posts

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
@@ -65,6 +65,14 @@ public class PostSubmitActivity extends BaseActivity {
 	private static final int
 			REQUEST_UPLOAD = 1;
 
+	private static int lastType;
+	private static String lastTitle;
+	private static String lastSubreddit;
+	private static String lastText;
+	private static boolean lastNsfw;
+	private static boolean lastSpoiler;
+	private static boolean lastInbox;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 
@@ -124,6 +132,17 @@ public class PostSubmitActivity extends BaseActivity {
 
 		usernameSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, usernames));
 		typeSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, postTypes));
+
+		// Fetch information from draft if a draft exists
+		if ((lastTitle != null || lastText != null)
+				&& subredditEdit.getText().toString().equals(lastSubreddit)) {
+			typeSpinner.setSelection(lastType);
+			titleEdit.setText(lastTitle);
+			textEdit.setText(lastText);
+			sendRepliesToInboxCheckbox.setChecked(lastInbox);
+			markAsSpoilerCheckbox.setChecked(lastSpoiler);
+			markAsNsfwCheckbox.setChecked(lastNsfw);
+		}
 
 		// TODO remove the duplicate code here
 		setHint();
@@ -188,6 +207,16 @@ public class PostSubmitActivity extends BaseActivity {
 		return true;
 	}
 
+	private static void resetDraft() {
+		lastType = 0;
+		lastTitle = null;
+		lastSubreddit = null;
+		lastText = null;
+		lastInbox = true;
+		lastNsfw = false;
+		lastSpoiler = false;
+	}
+
 	@Override
 	public boolean onOptionsItemSelected(final MenuItem item) {
 
@@ -243,6 +272,8 @@ public class PostSubmitActivity extends BaseActivity {
 							public void run() {
 								General.safeDismissDialog(progressDialog);
 								General.quickToast(PostSubmitActivity.this, getString(R.string.post_submit_done));
+
+								resetDraft();
 
 								if(redirectUrl != null) {
 									LinkHandler.onLinkClicked(PostSubmitActivity.this, redirectUrl);
@@ -329,5 +360,21 @@ public class PostSubmitActivity extends BaseActivity {
 	@Override
 	public void onBackPressed() {
 		if(General.onBackPressed()) super.onBackPressed();
+	}
+
+	@Override
+	protected void onDestroy(){
+		super.onDestroy();
+		// Store information for draft
+		if(titleEdit != null){
+			lastType = typeSpinner.getSelectedItemPosition();
+			lastTitle = titleEdit.getText().toString();
+			lastSubreddit = subredditEdit.getText().toString();
+			lastText = textEdit.getText().toString();
+			lastInbox = sendRepliesToInboxCheckbox.isChecked();
+			lastNsfw = markAsNsfwCheckbox.isChecked();
+			lastSpoiler = markAsSpoilerCheckbox.isChecked();
+			General.quickToast(this, "Draft saved", 2000);
+		}
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostSubmitActivity.java
@@ -366,7 +366,7 @@ public class PostSubmitActivity extends BaseActivity {
 	protected void onDestroy(){
 		super.onDestroy();
 		// Store information for draft
-		if(titleEdit != null){
+		if(titleEdit != null || textEdit != null ){
 			lastType = typeSpinner.getSelectedItemPosition();
 			lastTitle = titleEdit.getText().toString();
 			lastSubreddit = subredditEdit.getText().toString();
@@ -374,7 +374,6 @@ public class PostSubmitActivity extends BaseActivity {
 			lastInbox = sendRepliesToInboxCheckbox.isChecked();
 			lastNsfw = markAsNsfwCheckbox.isChecked();
 			lastSpoiler = markAsSpoilerCheckbox.isChecked();
-			General.quickToast(this, "Draft saved", 2000);
 		}
 	}
 }


### PR DESCRIPTION
**Draft feature for postsubmit. Fixes #557**
This feature makes it possible to save a draft for a post with static variables.
The changes are in PostSubmitActivity.java. There are mainly based on the draft functionnality in CommentReplyActivity.java.
The fields stored with static variables are :

- type of post (String)
- post subreddit (String)
- post title (String)
- post content (String)
- if the replies should be sent to inbox (boolean)
- if the post is NSFW (boolean)
- if the post is spoiler (boolean)

**Before :** when a user wrote a post on a subreddit, this post was lost if the user went back to the subreddit page or to another page.

**Benefits :** when a user writes a post on a subreddit, this post is saved for the current subreddit. If the user go to another page, he can get its post back when he hits "Submit Post" on the same subreddit page.

**Limits :**

- If the user goes to another subreddit and hits "Submit Post", then the draft of the previous subreddit is lost.
- If the user quits the application, then the draft is lost.

**Next :**

- Maybe we could use a data class instead of static variables. Using the subreddit as a key, we could save a draft for each subreddit.
- Maybe suggesting draft saving as an option to the user. Indeed, saving drafts automatically can be annoying for some users.
- Use persistence to store the drafts even if the user quits the application.