### PR TITLE
Record lastVersion on first application launch

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -173,6 +173,7 @@ public class MainActivity extends RefreshableActivity
 
 			final SharedPreferences.Editor edit = sharedPreferences.edit();
 			edit.putString("firstRunMessageShown", "true");
+			edit.putInt("lastVersion", appVersion);
 			edit.apply();
 
 		} else if(sharedPreferences.contains("lastVersion")) {


### PR DESCRIPTION
While I was testing #702 I discovered that RedReader does not record its current version into the preferences file on its very first launch, which awkwardly results in the changelog being shown on the app's second launch even if the app hasn't been updated.
More importantly, it means that if an update that performs a one-time change to make new preferences match the user's current settings is installed, the change will not be performed.
This PR will prevent this on all future releases after its implementation.