### PR TITLE
Show error and stop loading NSFW subs if NSFW content is disabled

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -280,8 +280,17 @@ public class PostListingFragment extends RRFragment
 									@Override
 									public void run() {
 										mSubreddit = result;
-										onSubredditReceived();
-										CacheManager.getInstance(context).makeRequest(mRequest);
+
+										if(mSubreddit.over18 && ! PrefsUtility.pref_behaviour_nsfw(context, mSharedPreferences)) {
+											mPostListingManager.setLoadingVisible(false);
+											mPostListingManager.addFooterError(
+													new ErrorView(getActivity(), new RRError(
+															context.getString(R.string.error_nsfw_subreddits_disabled_title),
+															context.getString(R.string.error_nsfw_subreddits_disabled_message))));
+										} else {
+											onSubredditReceived();
+											CacheManager.getInstance(context).makeRequest(mRequest);
+										}
 									}
 								});
 							}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1134,4 +1134,8 @@
 	<string name="lang_ja" translatable="false">日本語</string>
 	<string name="lang_lt" translatable="false">lietuvių kalba</string>
 
+	<!-- 2020-02-08 -->
+	<string name="error_nsfw_subreddits_disabled_title">Disabled</string>
+	<string name="error_nsfw_subreddits_disabled_message">This Subreddit is not displayed because it is flagged NSFW, and NSFW content is disabled in settings.</string>
+
 </resources>


### PR DESCRIPTION
This should make it more obvious what's happening when RedReader won't load NSFW Subreddits. Since there's no point in downloading the data if every post is guaranteed to be blocked, this should also stop requests after getting the Subreddit's info.
Closes #691 