### PR TITLE
Return to origin from side toolbar

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -542,12 +542,10 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 				break;
 
 			case COMMENTS_SWITCH:
-				if(!(activity instanceof MainActivity)) activity.finish();
 				((RedditPostView.PostSelectionListener)activity).onPostCommentsSelected(post);
 				break;
 
 			case LINK_SWITCH:
-				if(!(activity instanceof MainActivity)) activity.finish();
 				((RedditPostView.PostSelectionListener)activity).onPostSelected(post);
 				break;
 


### PR DESCRIPTION
This should fix #677. I'm not very familiar with activities, but it looks to me like the activity you came from should be finished by simply going back again once you return to it. But maybe I'm wrong and this would cause memory issues?
Closes #677 