### PR TITLE
Use strings on Search Results

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
@@ -206,11 +206,8 @@ public class SearchPostListURL extends PostListingURL {
 
 		if(shorter) return context.getString(R.string.search_results_short);
 
-		if(query != null && subreddit != null) {
-			if(context.getString(R.string.search_results_all_query_first).equalsIgnoreCase("true"))
-				return String.format(context.getString(R.string.search_results_all), query, subreddit);
-			else return String.format(context.getString(R.string.search_results_all), subreddit, query);
-		} else if(query != null) return String.format(context.getString(R.string.search_results_query_only), query);
+		if(query != null && subreddit != null) return String.format(context.getString(R.string.search_results_all), query, subreddit);
+		else if(query != null) return String.format(context.getString(R.string.search_results_query_only), query);
 		else if(subreddit != null) return String.format(context.getString(R.string.search_results_subreddit_only), subreddit);
 
 		return context.getString(R.string.action_search);

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.reddit.url;
 
 import android.content.Context;
 import android.net.Uri;
+import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.reddit.PostSort;
@@ -203,20 +204,16 @@ public class SearchPostListURL extends PostListingURL {
 	@Override
 	public String humanReadableName(Context context, boolean shorter) {
 
-		if(shorter) return "Search Results";
+		if(shorter) return context.getString(R.string.search_results_short);
 
-		// TODO strings
-		final StringBuilder builder = new StringBuilder("Search");
+		if(query != null && subreddit != null) {
+			if(context.getString(R.string.search_results_all_query_first).equalsIgnoreCase("true"))
+				return String.format(context.getString(R.string.search_results_all), query, subreddit);
+			else return String.format(context.getString(R.string.search_results_all), subreddit, query);
+		} else if(query != null) return String.format(context.getString(R.string.search_results_query_only), query);
+		else if(subreddit != null) return String.format(context.getString(R.string.search_results_subreddit_only), subreddit);
 
-		if(query != null) {
-			builder.append(" for \"").append(query).append("\"");
-		}
-
-		if(subreddit != null) {
-			builder.append(" on /r/").append(subreddit);
-		}
-
-		return builder.toString();
+		return context.getString(R.string.action_search);
 	}
 
 	@Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1134,4 +1134,11 @@
 	<string name="lang_ja" translatable="false">日本語</string>
 	<string name="lang_lt" translatable="false">lietuvių kalba</string>
 
+	<!-- 2020-02-13 -->
+	<string name="search_results_short">Search Results</string>
+	<string name="search_results_all">Search for \"%s\" on /r/%s</string>
+	<string name="search_results_all_query_first">true</string>
+	<string name="search_results_query_only">Search for \"%s\"</string>
+	<string name="search_results_subreddit_only">Search on /r/%s</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1136,8 +1136,7 @@
 
 	<!-- 2020-02-13 -->
 	<string name="search_results_short">Search Results</string>
-	<string name="search_results_all">Search for \"%s\" on /r/%s</string>
-	<string name="search_results_all_query_first">true</string>
+	<string name="search_results_all">Search for \"%1$s\" on /r/%2$s</string>
 	<string name="search_results_query_only">Search for \"%s\"</string>
 	<string name="search_results_subreddit_only">Search on /r/%s</string>
 


### PR DESCRIPTION
This should allow us to translate the words used on the search results page.
Since there are two strings to format in if both the query and the Subreddit are being printed, I added a string to toggle whether the query or the Subreddit is used first in String.format, in case printing the Subreddit first flows better in the given language. I used a \<string\> instead of a \<bool\> because I think only \<string\>'s will appear on Weblate, and the option should be easily available.