### PR TITLE
feature: redgifs.com support

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -52,6 +52,7 @@ import org.quantumbadger.redreader.image.DeviantArtAPI;
 import org.quantumbadger.redreader.image.GetAlbumInfoListener;
 import org.quantumbadger.redreader.image.GetImageInfoListener;
 import org.quantumbadger.redreader.image.GfycatAPI;
+import org.quantumbadger.redreader.image.RedgifsAPI;
 import org.quantumbadger.redreader.image.ImageInfo;
 import org.quantumbadger.redreader.image.ImgurAPI;
 import org.quantumbadger.redreader.image.ImgurAPIV3;
@@ -444,6 +445,7 @@ public class LinkHandler {
 			qkmePattern2 = Pattern.compile(".*[^A-Za-z]quickmeme\\.com/meme/(\\w+).*"),
 			lvmePattern = Pattern.compile(".*[^A-Za-z]livememe\\.com/(\\w+).*"),
 			gfycatPattern = Pattern.compile(".*[^A-Za-z]gfycat\\.com/(?:gifs/detail/)?(\\w+).*"),
+			redgifsPattern = Pattern.compile(".*[^A-Za-z]redgifs\\.com/watch/(?:gifs/detail/)?(\\w+).*"),
 			streamablePattern = Pattern.compile(".*[^A-Za-z]streamable\\.com/(\\w+).*"),
 			reddituploadsPattern = Pattern.compile(".*[^A-Za-z]i\\.reddituploads\\.com/(\\w+).*"),
 			redditVideosPattern = Pattern.compile(".*[^A-Za-z]v.redd.it/(\\w+).*"),
@@ -469,6 +471,17 @@ public class LinkHandler {
 
 			if(matchGfycat.find()) {
 				final String imgId = matchGfycat.group(1);
+				if(imgId.length() > 5) {
+					return true;
+				}
+			}
+		}
+		
+        {
+			final Matcher matchRedgifs = redgifsPattern.matcher(url);
+
+			if(matchRedgifs.find()) {
+				final String imgId = matchRedgifs.group(1);
 				if(imgId.length() > 5) {
 					return true;
 				}
@@ -687,6 +700,18 @@ public class LinkHandler {
 				final String imgId = matchGfycat.group(1);
 				if(imgId.length() > 5) {
 					GfycatAPI.getImageInfo(context, imgId, priority, listId, listener);
+					return;
+				}
+			}
+		}
+
+		{
+			final Matcher matchRedgifs = redgifsPattern.matcher(url);
+
+			if(matchRedgifs.find()) {
+				final String imgId = matchRedgifs.group(1);
+				if(imgId.length() > 5) {
+					RedgifsAPI.getImageInfo(context, imgId, priority, listId, listener);
 					return;
 				}
 			}

--- a/src/main/java/org/quantumbadger/redreader/image/RedgifsAPI.java
+++ b/src/main/java/org/quantumbadger/redreader/image/RedgifsAPI.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.quantumbadger.redreader.image;
+
+import android.content.Context;
+import org.quantumbadger.redreader.account.RedditAccountManager;
+import org.quantumbadger.redreader.activities.BugReportActivity;
+import org.quantumbadger.redreader.cache.CacheManager;
+import org.quantumbadger.redreader.cache.CacheRequest;
+import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyIfNotCached;
+import org.quantumbadger.redreader.common.Constants;
+import org.quantumbadger.redreader.common.General;
+import org.quantumbadger.redreader.jsonwrap.JsonBufferedObject;
+import org.quantumbadger.redreader.jsonwrap.JsonValue;
+
+import java.util.UUID;
+
+public final class RedgifsAPI {
+
+	public static void getImageInfo(
+			final Context context,
+			final String imageId,
+			final int priority,
+			final int listId,
+			final GetImageInfoListener listener) {
+
+		final String apiUrl = "https://api.redgifs.com/v1/gfycats/" + imageId;
+
+		CacheManager.getInstance(context).makeRequest(new CacheRequest(
+				General.uriFromString(apiUrl),
+				RedditAccountManager.getAnon(),
+				null,
+				priority,
+				listId,
+				DownloadStrategyIfNotCached.INSTANCE,
+				Constants.FileType.IMAGE_INFO,
+				CacheRequest.DOWNLOAD_QUEUE_IMMEDIATE,
+				true,
+				false,
+				context
+		) {
+			@Override
+			protected void onCallbackException(final Throwable t) {
+				BugReportActivity.handleGlobalError(context, t);
+			}
+
+			@Override
+			protected void onDownloadNecessary() {
+			}
+
+			@Override
+			protected void onDownloadStarted() {
+			}
+
+			@Override
+			protected void onFailure(final @CacheRequest.RequestFailureType int type, final Throwable t, final Integer status, final String readableMessage) {
+				listener.onFailure(type, t, status, readableMessage);
+			}
+
+			@Override
+			protected void onProgress(final boolean authorizationInProgress, final long bytesRead, final long totalBytes) {
+			}
+
+			@Override
+			protected void onSuccess(final CacheManager.ReadableCacheFile cacheFile, final long timestamp, final UUID session, final boolean fromCache, final String mimetype) {
+			}
+
+			@Override
+			public void onJsonParseStarted(final JsonValue result, final long timestamp, final UUID session, final boolean fromCache) {
+
+				try {
+					final JsonBufferedObject outer = result.asObject().getObject("gfyItem");
+					listener.onSuccess(ImageInfo.parseGfycat(outer));
+
+				} catch(Throwable t) {
+					listener.onFailure(CacheRequest.REQUEST_FAILURE_PARSE, t, null, "Gfycat data parse failed");
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
This duplicates the gfycat support, for redgifs. 

But I am unsure how to "extend" the GfycatAPI class correctly. So I've left it as its own file, in case their API diverges 

Tested via building, and running on Android 10 Pixel

fixes: #733
