### PR TITLE
WIP: feature: Low bandwidth mode (gfycat/redgifs)

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -246,7 +246,9 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
                 if (lowBwEnabled) {
                     Log.i(TAG, "Updated image URL: " + info.urlLowBw);
                     Log.i(TAG, "Updated image Type: " + info.typeLowBw);
-                    uri = General.uriFromString(info.urlLowBw);
+                    if (info.urlLowBw != null) {
+                        uri = General.uriFromString(info.urlLowBw);
+                    }
                 }
 
                 final URI audioUri;

--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -137,6 +137,8 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 		final int gallerySwipeLengthDp = PrefsUtility.pref_behaviour_gallery_swipe_length_dp(this, sharedPreferences);
 		mGallerySwipeLengthPx = General.dpToPixels(this, gallerySwipeLengthDp);
 
+        final boolean lowBwEnabled = PrefsUtility.network_low_bandwidth(this, sharedPreferences);
+
 		final Intent intent = getIntent();
 
 		mUrl = intent.getDataString();
@@ -234,15 +236,20 @@ public class ImageViewActivity extends BaseActivity implements RedditPostView.Po
 			public void onSuccess(final ImageInfo info) {
 
 				Log.i(TAG, "Got image URL: " + info.urlOriginal);
-
-				Log.i(TAG, "Got image Type: " + info.type);
-
+                Log.i(TAG, "Got image Type: " + info.type);
 				Log.i(TAG, "Got media Type: " + info.mediaType);
 
 				mImageInfo = info;
 
-				final URI uri = General.uriFromString(info.urlOriginal);
-				final URI audioUri;
+                URI uri = General.uriFromString(info.urlOriginal);
+
+                if (lowBwEnabled) {
+                    Log.i(TAG, "Updated image URL: " + info.urlLowBw);
+                    Log.i(TAG, "Updated image Type: " + info.typeLowBw);
+                    uri = General.uriFromString(info.urlLowBw);
+                }
+
+                final URI audioUri;
 
 				if(uri == null) {
 					revertToWeb();

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -771,6 +771,11 @@ public final class PrefsUtility {
 		return getBoolean(R.string.pref_network_tor_key, false, context, sharedPreferences);
 	}
 
+	public static boolean network_low_bandwidth(final Context context, final SharedPreferences sharedPreferences) {
+		return getBoolean(R.string.pref_network_low_bandwidth_key, false, context, sharedPreferences);
+	}
+
+
 	///////////////////////////////
 	// pref_menus
 	///////////////////////////////

--- a/src/main/java/org/quantumbadger/redreader/image/ImageInfo.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ImageInfo.java
@@ -31,6 +31,7 @@ public class ImageInfo implements Parcelable {
 
 	public final String urlOriginal;
 	public final String urlBigSquare;
+	public final String urlLowBw;
 
 	@Nullable public final String urlAudioStream;
 
@@ -38,11 +39,13 @@ public class ImageInfo implements Parcelable {
 	public final String caption;
 
 	public final String type;
+	public final String typeLowBw;
 	public final Boolean isAnimated;
 
 	public final Long width;
 	public final Long height;
 	public final Long size;
+	public final Long sizeLowBw;
 
 	public final MediaType mediaType;
 	@NonNull public final HasAudio hasAudio;
@@ -85,13 +88,16 @@ public class ImageInfo implements Parcelable {
 		this.urlAudioStream = urlAudioStream;
 
 		urlBigSquare = null;
+		urlLowBw = null;
 		title = null;
 		caption = null;
 		type = null;
+		typeLowBw = null;
 		isAnimated = null;
 		width = null;
 		height = null;
 		size = null;
+		sizeLowBw = null;
 		this.mediaType = mediaType;
 		this.hasAudio = hasAudio;
 	}
@@ -99,19 +105,22 @@ public class ImageInfo implements Parcelable {
 	private ImageInfo(final Parcel in) {
 		urlOriginal = ParcelHelper.readNullableString(in);
 		urlBigSquare = ParcelHelper.readNullableString(in);
+		urlLowBw = ParcelHelper.readNullableString(in);
 		urlAudioStream = ParcelHelper.readNullableString(in);
 		title = ParcelHelper.readNullableString(in);
 		caption = ParcelHelper.readNullableString(in);
 		type = ParcelHelper.readNullableString(in);
-		isAnimated = ParcelHelper.readNullableBoolean(in);
+		typeLowBw = ParcelHelper.readNullableString(in);
+        isAnimated = ParcelHelper.readNullableBoolean(in);
 		width = ParcelHelper.readNullableLong(in);
 		height = ParcelHelper.readNullableLong(in);
 		size = ParcelHelper.readNullableLong(in);
+		sizeLowBw = ParcelHelper.readNullableLong(in);
 		mediaType = ParcelHelper.readNullableImageInfoMediaType(in);
 		hasAudio = ParcelHelper.readImageInfoHasAudio(in);
 	}
-
-	public ImageInfo(
+	
+    public ImageInfo(
 			final String urlOriginal,
 			final String urlBigSquare,
 			final String title,
@@ -126,14 +135,50 @@ public class ImageInfo implements Parcelable {
 
 		this.urlOriginal = urlOriginal;
 		this.urlBigSquare = urlBigSquare;
+		this.urlLowBw = null;
 		this.urlAudioStream = null;
 		this.title = title;
 		this.caption = caption;
 		this.type = type;
+		this.typeLowBw = null;
 		this.isAnimated = isAnimated;
 		this.width = width;
 		this.height = height;
 		this.size = size;
+		this.sizeLowBw = null;
+		this.mediaType = mediaType;
+		this.hasAudio = hasAudio;
+	}
+
+	public ImageInfo(
+			final String urlOriginal,
+			final String urlBigSquare,
+			final String urlLowBw,
+			final String title,
+			final String caption,
+			final String type,
+			final String typeLowBw,
+			final Boolean isAnimated,
+			final Long width,
+			final Long height,
+			final Long size,
+			final Long sizeLowBw,
+			final MediaType mediaType,
+			@NonNull final HasAudio hasAudio) {
+
+		this.urlOriginal = urlOriginal;
+		this.urlBigSquare = urlBigSquare;
+        this.urlLowBw = urlLowBw;
+        this.urlAudioStream = null;
+		this.title = title;
+		this.caption = caption;
+		this.type = type;
+		this.typeLowBw = typeLowBw;
+		this.isAnimated = isAnimated;
+		this.width = width;
+		this.height = height;
+		this.size = size;
+		this.sizeLowBw = sizeLowBw;
 		this.mediaType = mediaType;
 		this.hasAudio = hasAudio;
 	}
@@ -145,7 +190,9 @@ public class ImageInfo implements Parcelable {
 		final Long height = object.getLong("height");
 
 		final String urlOriginal = object.getString("mp4Url");
+	    final String urlLowBw = object.getString("webmUrl");
 		final Long size = object.getLong("mp4Size");
+		final Long sizeLowBw = object.getLong("webmSize");
 
 		final String title = object.getString("title");
 
@@ -153,14 +200,17 @@ public class ImageInfo implements Parcelable {
 
 		return new ImageInfo(
 				urlOriginal,
-				null,
+                null,
+                urlLowBw,
 				title,
 				null,
 				"video/mp4",
+                "video/webm",
 				true,
 				width,
 				height,
 				size,
+				sizeLowBw,
 				MediaType.VIDEO,
 				HasAudio.fromBoolean(hasAudio));
 	}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1191,4 +1191,9 @@
 	<string name="error_toast_no_email_apps">No email apps installed!</string>
 	<string name="bug_chooser_title">Email bug report</string>
 
+	<!-- 2020-05-27 -->
+	<string name="pref_network_low_bandwidth_title">Low bandwidth mode</string>
+	<string name="pref_network_low_bandwidth_key" translatable="false">pref_network_low_bandwidth</string>
+	<string name="pref_network_low_bandwidth_summary">Downloads webm instead of mp4 (Gfycat and Redgifs Support only).</string>
+
 </resources>

--- a/src/main/res/xml/prefs_network.xml
+++ b/src/main/res/xml/prefs_network.xml
@@ -25,6 +25,11 @@
 						android:key="@string/pref_network_tor_key"
 						android:summary="@string/pref_network_tor_summary"
         				android:defaultValue="false"/>
+    
+    <CheckBoxPreference android:title="@string/pref_network_low_bandwidth_title"
+						android:key="@string/pref_network_low_bandwidth_key"
+						android:summary="@string/pref_network_low_bandwidth_summary"
+        				android:defaultValue="false"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Reasoning: 
Not everyone has fast internet, so people on slower networks, and smaller devices can benefit from the `.webm` files which are smaller in file size, but still contain the same quality.
Also for the people that utilize reddit over tor, this will result in a better user experience 
This poc has been completed and works, but 

UI Change:
- New menu item under Network, called "Low bandwidth mode"

My Thoughts:
- I'm unsure if adding another constructor is the right way to do this in `ImageInfo.java`. I'm up for some critique on it.
- Because we are now setting the image url in `ImageViewActivity.java` the cache is not shared across a toggle of `lowBwEnabled`. If you download something while `lowBwEnabled = True`, and then toggle it off, you will download the "high quality" version.
- `.webm` files save up to 80+% on file size. (one went from 88mb to 10mb)

Fixes: #436

----

Follow-up items/questions.

I just realized while creating the PR, that Saving & Sharing images as well as ImageInfo always show the `urlOriginal` var.

Currently, we don't have access to the user preferences in the ImageInfo & associated image apis. I followed the execution chain to one of the first places that already dealt with `PrefsUtility`. Unfortunately, for a correct implementation of a Low bandwidth mode, that means that we now need to change the below files, and possibly extend `PrefsUtility` into them, as anywhere that uses urlOriginal needs changing.

```
src/main/java/org/quantumbadger/redreader/image/SaveImageCallback.java
src/main/java/org/quantumbadger/redreader/image/ShareImageCallback.java
src/main/java/org/quantumbadger/redreader/fragments/ImageInfoDialog.java
src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
```

A possible plan of attack is to change everything from urlOriginal to `urlImage`, where its used in the app. Then in ImageViewActivity we set a new variable `urlImage` to either; `Original` or` LowBw`.

That way there would be standardized usage of the image's url across the app, if we are modifying it.

Thoughts?