### PR TITLE
Reorganize and reword menu preferences, and a few other preference string changes

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -115,10 +115,10 @@
     <!-- Menu Prefs -->
 
     <string name="pref_menus_post_context_items_key" translatable="false">pref_menus_post_context_items_2</string>
-    <string name="pref_menus_post_context_items_title">Pop-up menu items</string>
+    <string name="pref_menus_post_context_items_title">Long-press menu items</string>
 
     <string name="pref_menus_post_toolbar_items_key" translatable="false">pref_menus_post_toolbar_items</string>
-    <string name="pref_menus_post_toolbar_items_title">Sidebar items</string>
+    <string name="pref_menus_post_toolbar_items_title">Side-toolbar items</string>
 
     <!-- Options Menu -->
 
@@ -654,9 +654,9 @@
     <string name="pref_menus_optionsmenu_items_title">Three-dot menu items</string>
 
     <!-- 2015-07-05 -->
-    <string name="pref_behaviour_bezel_toolbar_header">Post Sidebar</string>
+    <string name="pref_behaviour_bezel_toolbar_header">Post Side-Toolbar</string>
     <string name="pref_behaviour_bezel_toolbar_swipezone_key" translatable="false">pref_behaviour_bezel_toolbar_swipezone</string>
-    <string name="pref_behaviour_bezel_toolbar_swipezone_title">Post sidebar swipe zone size</string>
+    <string name="pref_behaviour_bezel_toolbar_swipezone_title">Post side-toolbar swipe zone size</string>
 
     <string name="pref_behaviour_gifview_mode_title">GIF viewer</string>
     <string name="pref_behaviour_gifview_mode_key" translatable="false">pref_behaviour_gifview_mode</string>
@@ -890,7 +890,7 @@
 	<!-- 2016-09-04 -->
 	<string name="pref_appearance_image_viewer_header">Image Viewer</string>
 
-	<string name="pref_appearance_image_viewer_show_floating_toolbar_title">Show floating buttons over videos</string>
+	<string name="pref_appearance_image_viewer_show_floating_toolbar_title">Show floating buttons over images and videos</string>
 	<string name="pref_appearance_image_viewer_show_floating_toolbar_key" translatable="false">pref_appearance_image_viewer_show_floating_toolbar</string>
 
 	<string name="pref_appearance_link_text_clickable_title">Make link text clickable</string>
@@ -959,13 +959,13 @@
 
 	<!-- 2017-03-02 -->
 	<string name="pref_menus_link_context_items_key" translatable="false">pref_menus_link_context_items</string>
-	<string name="pref_menus_link_context_items_title">Link pop-up menu items</string>
+	<string name="pref_menus_link_context_items_title">Link long-press menu items</string>
 	<string name="lang_eo" translatable="false">Esperanto</string>
 	<string name="lang_pl" translatable="false">Polski</string>
 
 	<!-- 2017-03-07 -->
 	<string name="pref_menus_subreddit_context_items_key" translatable="false">pref_menus_subreddit_context_items</string>
-	<string name="pref_menus_subreddit_context_items_title">Subreddit pop-up menu items</string>
+	<string name="pref_menus_subreddit_context_items_title">Subreddit long-press menu items</string>
 	<string name="mainmenu_toast_not_subscribed">You are not subscribed to this subreddit yet!</string>
 	<string name="mainmenu_toast_subscribed">You are already subscribed to this subreddit!</string>
 	<string name="mainmenu_toast_not_pinned">This subreddit is not pinned to the main menu!</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -115,10 +115,10 @@
     <!-- Menu Prefs -->
 
     <string name="pref_menus_post_context_items_key" translatable="false">pref_menus_post_context_items_2</string>
-    <string name="pref_menus_post_context_items_title">Post context menu items</string>
+    <string name="pref_menus_post_context_items_title">Pop-up menu items</string>
 
     <string name="pref_menus_post_toolbar_items_key" translatable="false">pref_menus_post_toolbar_items</string>
-    <string name="pref_menus_post_toolbar_items_title">Post toolbar items</string>
+    <string name="pref_menus_post_toolbar_items_title">Sidebar items</string>
 
     <!-- Options Menu -->
 
@@ -561,7 +561,7 @@
     <!-- 2014-04-13 -->
 
     <string name="pref_menus_mainmenu_useritems_key" translatable="false">pref_menus_mainmenu_useritems</string>
-    <string name="pref_menus_mainmenu_useritems_title">Main menu user items</string>
+    <string name="pref_menus_mainmenu_useritems_title">User items</string>
 
     <string name="mainmenu_submitted">Submitted Posts</string>
     <string name="mainmenu_downvoted">Downvoted Posts</string>
@@ -651,12 +651,12 @@
     <string name="options_close_all">Close All</string>
 
     <string name="pref_menus_optionsmenu_items_key" translatable="false">pref_menus_optionsmenu_items_3</string>
-    <string name="pref_menus_optionsmenu_items_title">Options menu items</string>
+    <string name="pref_menus_optionsmenu_items_title">Three-dot menu items</string>
 
     <!-- 2015-07-05 -->
-    <string name="pref_behaviour_bezel_toolbar_header">Bezel Toolbar</string>
+    <string name="pref_behaviour_bezel_toolbar_header">Post Sidebar</string>
     <string name="pref_behaviour_bezel_toolbar_swipezone_key" translatable="false">pref_behaviour_bezel_toolbar_swipezone</string>
-    <string name="pref_behaviour_bezel_toolbar_swipezone_title">Bezel toolbar swipe zone size</string>
+    <string name="pref_behaviour_bezel_toolbar_swipezone_title">Post sidebar swipe zone size</string>
 
     <string name="pref_behaviour_gifview_mode_title">GIF viewer</string>
     <string name="pref_behaviour_gifview_mode_key" translatable="false">pref_behaviour_gifview_mode</string>
@@ -673,7 +673,7 @@
     <string name="delete_success">Successfully deleted. The item will still be visible until you refresh.</string>
 
     <string name="pref_appearance_hide_username_main_menu_key" translatable="false">pref_appearance_hide_username_main_menu</string>
-    <string name="pref_appearance_hide_username_main_menu_title">Hide username in main menu</string>
+    <string name="pref_appearance_hide_username_main_menu_title">Hide username</string>
     <string name="mainmenu_useritems">User Items</string>
 
     <!-- 2015-09-13 -->
@@ -890,7 +890,7 @@
 	<!-- 2016-09-04 -->
 	<string name="pref_appearance_image_viewer_header">Image Viewer</string>
 
-	<string name="pref_appearance_image_viewer_show_floating_toolbar_title">Show floating toolbar over image</string>
+	<string name="pref_appearance_image_viewer_show_floating_toolbar_title">Show floating buttons over videos</string>
 	<string name="pref_appearance_image_viewer_show_floating_toolbar_key" translatable="false">pref_appearance_image_viewer_show_floating_toolbar</string>
 
 	<string name="pref_appearance_link_text_clickable_title">Make link text clickable</string>
@@ -913,7 +913,7 @@
 
 	<!-- 2016-09-21 -->
 	<string name="pref_appearance_show_blocked_subreddits_main_menu_key" translatable="false">pref_appearance_show_blocked_subreddits_main_menu</string>
-	<string name="pref_appearance_show_blocked_subreddits_main_menu_title">Show blocked subreddits in main menu</string>
+	<string name="pref_appearance_show_blocked_subreddits_main_menu_title">Show blocked subreddits</string>
 
 	<!-- 2016-10-02 -->
 	<string name="pref_cache_rerequest_postlist_age_key" translatable="false">pref_cache_rerequest_postlist_age</string>
@@ -959,13 +959,13 @@
 
 	<!-- 2017-03-02 -->
 	<string name="pref_menus_link_context_items_key" translatable="false">pref_menus_link_context_items</string>
-	<string name="pref_menus_link_context_items_title">Link context menu items</string>
+	<string name="pref_menus_link_context_items_title">Link pop-up menu items</string>
 	<string name="lang_eo" translatable="false">Esperanto</string>
 	<string name="lang_pl" translatable="false">Polski</string>
 
 	<!-- 2017-03-07 -->
 	<string name="pref_menus_subreddit_context_items_key" translatable="false">pref_menus_subreddit_context_items</string>
-	<string name="pref_menus_subreddit_context_items_title">Subreddit context menu items</string>
+	<string name="pref_menus_subreddit_context_items_title">Subreddit pop-up menu items</string>
 	<string name="mainmenu_toast_not_subscribed">You are not subscribed to this subreddit yet!</string>
 	<string name="mainmenu_toast_subscribed">You are already subscribed to this subreddit!</string>
 	<string name="mainmenu_toast_not_pinned">This subreddit is not pinned to the main menu!</string>
@@ -991,7 +991,7 @@
 	<string name="button_next_comment_parent">Next Parent Comment</string>
 	<string name="button_prev_comment_parent">Previous Parent Comment</string>
 
-	<string name="pref_appearance_comments_show_floating_toolbar_title">Show floating toolbar over comments</string>
+	<string name="pref_appearance_comments_show_floating_toolbar_title">Show navigation buttons over comments</string>
 	<string name="pref_appearance_comments_show_floating_toolbar_key" translatable="false">pref_appearance_comments_show_floating_toolbar</string>
 
 	<!--2017-05-08-->
@@ -1078,7 +1078,7 @@
 	<string name="pref_behaviour_hide_read_posts_title">Hide read posts</string>
 
 	<!-- 2018-10-06 -->
-	<string name="pref_menus_mainmenu_shortcutitems_title">Main menu shortcuts</string>
+	<string name="pref_menus_mainmenu_shortcutitems_title">Shortcuts</string>
 	<string name="pref_menus_mainmenu_shortcutitems_key" translatable="false">pref_menus_mainmenu_shortcutitems_key</string>
 
 	<string name="pref_menus_show_multireddit_main_menu_title">Show multireddits</string>
@@ -1196,6 +1196,10 @@
 	<string name="unsubscription_successful">Successfully unsubscribed from %s</string>
 	<string name="pin_successful">Pinned %s to main menu</string>
 	<string name="unpin_successful">Unpinned %s from main menu</string>
+
+	<!-- 2020-06-13 -->
+	<string name="pref_menus_mainmenu_header">Main Menu</string>
+	<string name="pref_menus_posts_header">Posts</string>
 
 	<!-- 2020-06-14 -->
 	<string name="spoiler">Spoiler</string>

--- a/src/main/res/xml/prefs_menus.xml
+++ b/src/main/res/xml/prefs_menus.xml
@@ -36,76 +36,84 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <MultiSelectListPreference
-        android:dialogTitle="@string/pref_menus_mainmenu_useritems_title"
-        android:key="@string/pref_menus_mainmenu_useritems_key"
-        android:title="@string/pref_menus_mainmenu_useritems_title"
-        android:entries="@array/pref_menus_mainmenu_useritems_items"
-        android:entryValues="@array/pref_menus_mainmenu_useritems_items_return"
-        android:defaultValue="@array/pref_menus_mainmenu_useritems_items_default" />
+	<MultiSelectListPreference
+		android:dialogTitle="@string/pref_menus_optionsmenu_items_title"
+		android:key="@string/pref_menus_optionsmenu_items_key"
+		android:title="@string/pref_menus_optionsmenu_items_title"
+		android:entries="@array/pref_menus_optionsmenu_items_items"
+		android:entryValues="@array/pref_menus_optionsmenu_items_items_return"
+		android:defaultValue="@array/pref_menus_optionsmenu_items_items_default" />
 
 	<MultiSelectListPreference
-		android:dialogTitle="@string/pref_menus_mainmenu_shortcutitems_title"
-		android:key="@string/pref_menus_mainmenu_shortcutitems_key"
-		android:title="@string/pref_menus_mainmenu_shortcutitems_title"
-		android:entries="@array/pref_menus_mainmenu_shortcutitems_items"
-		android:entryValues="@array/pref_menus_mainmenu_shortcutitems_items_return"
-		android:defaultValue="@array/pref_menus_mainmenu_shortcutitems_items_default" />
-
-    <CheckBoxPreference android:title="@string/pref_appearance_hide_username_main_menu_title"
-                        android:key="@string/pref_appearance_hide_username_main_menu_key"
-                        android:defaultValue="false"/>
-
-	<CheckBoxPreference android:title="@string/pref_appearance_show_blocked_subreddits_main_menu_title"
-						android:key="@string/pref_appearance_show_blocked_subreddits_main_menu_key"
-						android:defaultValue="false"/>
-
-	<CheckBoxPreference android:title="@string/pref_menus_show_multireddit_main_menu_title"
-						android:key="@string/pref_menus_show_multireddit_main_menu_key"
-						android:defaultValue="true"/>
-
-	<CheckBoxPreference android:title="@string/pref_menus_show_subscribed_subreddits_main_menu_title"
-						android:key="@string/pref_menus_show_subscribed_subreddits_main_menu_key"
-						android:defaultValue="true"/>
-
-    <MultiSelectListPreference
-        android:dialogTitle="@string/pref_menus_post_context_items_title"
-        android:key="@string/pref_menus_post_context_items_key"
-        android:title="@string/pref_menus_post_context_items_title"
-        android:entries="@array/pref_menus_post_context_items"
-        android:entryValues="@array/pref_menus_post_context_items_return"
-        android:defaultValue="@array/pref_menus_post_context_items_return" />
-
-    <MultiSelectListPreference
-        android:dialogTitle="@string/pref_menus_post_toolbar_items_title"
-        android:key="@string/pref_menus_post_toolbar_items_key"
-        android:title="@string/pref_menus_post_toolbar_items_title"
-        android:entries="@array/pref_menus_post_toolbar_items"
-        android:entryValues="@array/pref_menus_post_toolbar_items_return"
-        android:defaultValue="@array/pref_menus_post_toolbar_items_return" />
-
-    <MultiSelectListPreference
-        android:dialogTitle="@string/pref_menus_optionsmenu_items_title"
-        android:key="@string/pref_menus_optionsmenu_items_key"
-        android:title="@string/pref_menus_optionsmenu_items_title"
-        android:entries="@array/pref_menus_optionsmenu_items_items"
-        android:entryValues="@array/pref_menus_optionsmenu_items_items_return"
-        android:defaultValue="@array/pref_menus_optionsmenu_items_items_default" />
+		android:dialogTitle="@string/pref_menus_link_context_items_title"
+		android:key="@string/pref_menus_link_context_items_key"
+		android:title="@string/pref_menus_link_context_items_title"
+		android:entries="@array/pref_menus_link_context_items"
+		android:entryValues="@array/pref_menus_link_context_items_return"
+		android:defaultValue="@array/pref_menus_link_context_items_default" />
 
 	<MultiSelectListPreference
-			android:dialogTitle="@string/pref_menus_link_context_items_title"
-			android:key="@string/pref_menus_link_context_items_key"
-			android:title="@string/pref_menus_link_context_items_title"
-			android:entries="@array/pref_menus_link_context_items"
-			android:entryValues="@array/pref_menus_link_context_items_return"
-			android:defaultValue="@array/pref_menus_link_context_items_default" />
+		android:dialogTitle="@string/pref_menus_subreddit_context_items_title"
+		android:key="@string/pref_menus_subreddit_context_items_key"
+		android:title="@string/pref_menus_subreddit_context_items_title"
+		android:entries="@array/pref_menus_subreddit_context_items"
+		android:entryValues="@array/pref_menus_subreddit_context_items_return"
+		android:defaultValue="@array/pref_menus_subreddit_context_items_default" />
 
-	<MultiSelectListPreference
-			android:dialogTitle="@string/pref_menus_subreddit_context_items_title"
-			android:key="@string/pref_menus_subreddit_context_items_key"
-			android:title="@string/pref_menus_subreddit_context_items_title"
-			android:entries="@array/pref_menus_subreddit_context_items"
-			android:entryValues="@array/pref_menus_subreddit_context_items_return"
-			android:defaultValue="@array/pref_menus_subreddit_context_items_default" />
+	<PreferenceCategory android:title="@string/pref_menus_mainmenu_header" >
+
+		<MultiSelectListPreference
+			android:dialogTitle="@string/pref_menus_mainmenu_shortcutitems_title"
+			android:key="@string/pref_menus_mainmenu_shortcutitems_key"
+			android:title="@string/pref_menus_mainmenu_shortcutitems_title"
+			android:entries="@array/pref_menus_mainmenu_shortcutitems_items"
+			android:entryValues="@array/pref_menus_mainmenu_shortcutitems_items_return"
+			android:defaultValue="@array/pref_menus_mainmenu_shortcutitems_items_default" />
+
+    	<MultiSelectListPreference
+			android:dialogTitle="@string/pref_menus_mainmenu_useritems_title"
+			android:key="@string/pref_menus_mainmenu_useritems_key"
+			android:title="@string/pref_menus_mainmenu_useritems_title"
+			android:entries="@array/pref_menus_mainmenu_useritems_items"
+        	android:entryValues="@array/pref_menus_mainmenu_useritems_items_return"
+        	android:defaultValue="@array/pref_menus_mainmenu_useritems_items_default" />
+
+    	<CheckBoxPreference android:title="@string/pref_appearance_hide_username_main_menu_title"
+							android:key="@string/pref_appearance_hide_username_main_menu_key"
+							android:defaultValue="false"/>
+
+		<CheckBoxPreference android:title="@string/pref_appearance_show_blocked_subreddits_main_menu_title"
+							android:key="@string/pref_appearance_show_blocked_subreddits_main_menu_key"
+							android:defaultValue="false"/>
+
+		<CheckBoxPreference android:title="@string/pref_menus_show_multireddit_main_menu_title"
+							android:key="@string/pref_menus_show_multireddit_main_menu_key"
+							android:defaultValue="true"/>
+
+		<CheckBoxPreference android:title="@string/pref_menus_show_subscribed_subreddits_main_menu_title"
+							android:key="@string/pref_menus_show_subscribed_subreddits_main_menu_key"
+							android:defaultValue="true"/>
+
+	</PreferenceCategory>
+
+	<PreferenceCategory android:title="@string/pref_menus_posts_header">
+
+    	<MultiSelectListPreference
+        	android:dialogTitle="@string/pref_menus_post_context_items_title"
+        	android:key="@string/pref_menus_post_context_items_key"
+        	android:title="@string/pref_menus_post_context_items_title"
+        	android:entries="@array/pref_menus_post_context_items"
+        	android:entryValues="@array/pref_menus_post_context_items_return"
+        	android:defaultValue="@array/pref_menus_post_context_items_return" />
+
+    	<MultiSelectListPreference
+        	android:dialogTitle="@string/pref_menus_post_toolbar_items_title"
+        	android:key="@string/pref_menus_post_toolbar_items_key"
+        	android:title="@string/pref_menus_post_toolbar_items_title"
+        	android:entries="@array/pref_menus_post_toolbar_items"
+        	android:entryValues="@array/pref_menus_post_toolbar_items_return"
+        	android:defaultValue="@array/pref_menus_post_toolbar_items_return" />
+
+	</PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
The **Menus** preferences and a few others struck me as a bit difficult to understand, especially for non-developers unfamiliar with terms like "context menu", so I took a stab at rewording and reorganizing them to make them easier to understand and more consistent with Material Design.

Two notes:
- I moved **Shortcuts** to the top of the proposed **Main Menu** section because on the main menu they are above the **User Items** (which is currently the first preference). Every other main  menu preference seems to have already been in order.
- I changed the string of **Show floating toolbar over image** to **Show floating buttons over videos** because, as far as I could tell in my testing, that toolbar will only appear over videos. I'm not 100% sure if that is always the case, but I think "buttons" would be a better term than "toolbar" regardless.