### PR TITLE
Improvements to copying to the clipboard

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -18,6 +18,7 @@
 package org.quantumbadger.redreader.adapters;
 
 import android.app.AlertDialog;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -675,8 +676,13 @@ public class MainMenuListingManager {
 			}
 
 			case COPY_URL: {
-				ClipboardManager manager = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
-				manager.setText(url);
+				ClipboardManager clipboardManager = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
+				if(clipboardManager != null) {
+					ClipData data = ClipData.newRawUri(null, Uri.parse(url));
+					clipboardManager.setPrimaryClip(data);
+
+					General.quickToast(activity.getApplicationContext(), R.string.subreddit_link_copied_to_clipboard);
+				}
 				break;
 			}
 

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -21,6 +21,7 @@ import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -342,8 +343,14 @@ public class LinkHandler {
 				shareText(activity, null, uri);
 				break;
 			case COPY_URL:
-				ClipboardManager manager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-				manager.setText(uri);
+				ClipboardManager clipboardManager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+				if(clipboardManager != null) {
+					//Using newPlainText here instead of newRawUri because links from comments/self-text are often not valid URIs
+					ClipData data = ClipData.newPlainText(null, uri);
+					clipboardManager.setPrimaryClip(data);
+
+					General.quickToast(activity.getApplicationContext(), R.string.link_copied_to_clipboard);
+				}
 				break;
 
 			case EXTERNAL:

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -18,6 +18,7 @@
 package org.quantumbadger.redreader.reddit.api;
 
 import android.app.AlertDialog;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -313,16 +314,25 @@ public class RedditAPICommentAction {
 			}
 
 			case COPY_TEXT: {
-				ClipboardManager manager = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
+				ClipboardManager clipboardManager = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
 				// TODO this currently just dumps the markdown
-				manager.setText(StringEscapeUtils.unescapeHtml4(comment.body));
+				if(clipboardManager != null) {
+					ClipData data = ClipData.newPlainText(null, StringEscapeUtils.unescapeHtml4(comment.body));
+					clipboardManager.setPrimaryClip(data);
+
+					General.quickToast(activity.getApplicationContext(), R.string.comment_text_copied_to_clipboard);
+				}
 				break;
 			}
 
 			case COPY_URL: {
-				ClipboardManager manager = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
-				// TODO this currently just dumps the markdown
-				manager.setText(comment.getContextUrl().context(null).generateNonJsonUri().toString());
+				ClipboardManager clipboardManager = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
+				if(clipboardManager != null) {
+					ClipData data = ClipData.newRawUri(null, comment.getContextUrl().context(null).generateNonJsonUri());
+					clipboardManager.setPrimaryClip(data);
+
+					General.quickToast(activity.getApplicationContext(), R.string.comment_link_copied_to_clipboard);
+				}
 				break;
 			}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -134,7 +134,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		GOTO_SUBREDDIT(R.string.action_gotosubreddit),
 		ACTION_MENU(R.string.action_actionmenu),
 		SAVE_IMAGE(R.string.action_save_image),
-		COPY(R.string.action_copy),
+		COPY(R.string.action_copy_link),
 		COPY_SELFTEXT(R.string.action_copy_selftext),
 		SELFTEXT_LINKS(R.string.action_selftext_links),
 		BACK(R.string.action_back),
@@ -307,8 +307,13 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		if(itemPref.contains(Action.SHARE)) menu.add(new RPVMenuItem(activity, R.string.action_share, Action.SHARE));
 		if(itemPref.contains(Action.SHARE_COMMENTS)) menu.add(new RPVMenuItem(activity, R.string.action_share_comments, Action.SHARE_COMMENTS));
 		if(itemPref.contains(Action.SHARE_IMAGE) && post.mIsProbablyAnImage) menu.add(new RPVMenuItem(activity, R.string.action_share_image, Action.SHARE_IMAGE));
-		if(itemPref.contains(Action.COPY)) menu.add(new RPVMenuItem(activity, R.string.action_copy, Action.COPY));
-		if(itemPref.contains(Action.COPY_SELFTEXT)) menu.add(new RPVMenuItem(activity, R.string.action_copy_selftext, Action.COPY_SELFTEXT));
+		if(itemPref.contains(Action.COPY)) menu.add(new RPVMenuItem(activity, R.string.action_copy_link, Action.COPY));
+		if(itemPref.contains(Action.COPY_SELFTEXT)
+				&& post.src.getRawSelfTextMarkdown() != null
+				&& post.src.getRawSelfTextMarkdown().length() > 1) {
+
+			menu.add(new RPVMenuItem(activity, R.string.action_copy_selftext, Action.COPY_SELFTEXT));
+		}
 		if(itemPref.contains(Action.USER_PROFILE)) menu.add(new RPVMenuItem(activity, R.string.action_user_profile, Action.USER_PROFILE));
 		if(itemPref.contains(Action.PROPERTIES)) menu.add(new RPVMenuItem(activity, R.string.action_properties, Action.PROPERTIES));
 
@@ -509,8 +514,10 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 				ClipboardManager clipboardManager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
 				if(clipboardManager != null) {
-					ClipData data = ClipData.newPlainText(post.src.getAuthor(), post.src.getUrl());
+					ClipData data = ClipData.newRawUri(post.src.getAuthor(), Uri.parse(post.src.getUrl()));
 					clipboardManager.setPrimaryClip(data);
+
+					General.quickToast(activity.getApplicationContext(), R.string.post_link_copied_to_clipboard);
 				}
 				break;
 			}

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -408,7 +408,7 @@
         <item>@string/action_share</item>
         <item>@string/action_share_comments</item>
         <item>@string/action_share_image</item>
-        <item>@string/action_copy</item>
+        <item>@string/action_copy_link</item>
 		<item>@string/action_copy_selftext</item>
         <item>@string/action_user_profile</item>
         <item>@string/action_properties</item>
@@ -480,7 +480,7 @@
         <item>@string/action_external</item>
         <item>@string/action_save_image</item>
         <item>@string/action_share</item>
-        <item>@string/action_copy</item>
+        <item>@string/action_copy_link</item>
         <item>@string/action_user_profile</item>
         <item>@string/action_properties</item>
     </string-array>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1108,7 +1108,7 @@
 	<string name="notification_channel_name_reddit_messages">Incoming Reddit Messages</string>
 	
 	<!-- 2019-10-05 -->
-	<string name="post_text_copied_to_clipboard">Post copied to clipboard</string>
+	<string name="post_text_copied_to_clipboard">Post self-text copied to clipboard</string>
 	<string name="action_copy_selftext">Copy Self-Text</string>
 
 	<!-- 2020-01-11 -->
@@ -1215,5 +1215,12 @@
 
 	<string name="pref_appearance_hide_headertoolbar_commentlist_key" translatable="false">pref_appearance_hide_headertoolbar_commentlist</string>
 	<string name="pref_appearance_hide_headertoolbar_commentlist_title">Hide comment list header toolbar</string>
+
+	<!-- 2020-07-11 -->
+	<string name="post_link_copied_to_clipboard">Post link copied to clipboard</string>
+	<string name="link_copied_to_clipboard">Link copied to clipboard</string>
+	<string name="comment_link_copied_to_clipboard">Comment link copied to clipboard</string>
+	<string name="comment_text_copied_to_clipboard">Comment text copied to clipboard</string>
+	<string name="subreddit_link_copied_to_clipboard">Subreddit link copied to clipboard</string>
 
 </resources>


### PR DESCRIPTION
I made a few improvements to how copying is handled:
- Every instance of the deprecated **setText()** method was replaced with **ClipData**-based methods
- An informative toast is always displayed when copying
- The **Copy Self-Text** option in the post context menu is not shown if there is no self-text in that post
- Minor string changes for clarity