### PR TITLE
Improve navigation with TalkBack and directional controls

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/ChangelogManager.java
+++ b/src/main/java/org/quantumbadger/redreader/common/ChangelogManager.java
@@ -18,7 +18,12 @@
 package org.quantumbadger.redreader.common;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import android.os.Build;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import org.quantumbadger.redreader.R;
@@ -67,6 +72,16 @@ public class ChangelogManager {
 						.inflate(R.layout.list_sectionheader, items, false);
 					header.setText(curVersionName);
 					header.setTextColor(attr.colorAccent);
+
+					//From https://stackoverflow.com/a/54082384
+					ViewCompat.setAccessibilityDelegate(header, new AccessibilityDelegateCompat() {
+						@Override
+						public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+							super.onInitializeAccessibilityNodeInfo(host, info);
+							info.setHeading(true);
+						}
+					});
+
 					items.addView(header);
 
 				} else {
@@ -74,10 +89,14 @@ public class ChangelogManager {
 					final LinearLayout bulletItem = new LinearLayout(context);
 					final int paddingPx = General.dpToPixels(context, 6);
 					bulletItem.setPadding(paddingPx, paddingPx, paddingPx, 0);
+					bulletItem.setFocusable(true);
 
 					final TextView bullet = new TextView(context);
 					bullet.setText("•  ");
 					bulletItem.addView(bullet);
+					if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+						bullet.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+					}
 
 					final TextView text = new TextView(context);
 					text.setText(line);

--- a/src/main/java/org/quantumbadger/redreader/fragments/PropertiesDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PropertiesDialog.java
@@ -19,6 +19,8 @@ package org.quantumbadger.redreader.fragments;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Bundle;
@@ -98,6 +100,18 @@ public abstract class PropertiesDialog extends AppCompatDialogFragment {
 
 		final LinearLayout prop = new LinearLayout(context);
 		prop.setOrientation(LinearLayout.VERTICAL);
+		prop.setFocusable(true);
+
+		prop.setOnLongClickListener(v -> {
+			ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+			if(clipboardManager != null) {
+				ClipData data = ClipData.newPlainText(title, text);
+				clipboardManager.setPrimaryClip(data);
+
+				General.quickToast(context, R.string.copied_to_clipboard);
+			}
+			return true;
+		});
 
 		if(!firstInList) {
 			final View divider = new View(context);
@@ -118,7 +132,6 @@ public abstract class PropertiesDialog extends AppCompatDialogFragment {
 		textView.setTextColor(rrCommentBodyCol);
 		textView.setTextSize(15.0f);
 		textView.setPadding(paddingPixels, 0, paddingPixels, paddingPixels);
-		textView.setTextIsSelectable(true);
 		prop.addView(textView);
 
 		return prop;

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
@@ -17,6 +17,8 @@
 
 package org.quantumbadger.redreader.fragments;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -102,13 +104,37 @@ public class UserProfileDialog extends PropertiesDialog {
 						final LinearLayout karmaLayout = (LinearLayout) context.getLayoutInflater().inflate(R.layout.karma, null);
 						items.addView(karmaLayout);
 
+						final LinearLayout linkKarmaLayout = karmaLayout.findViewById(R.id.layout_karma_link);
+						final LinearLayout commentKarmaLayout = karmaLayout.findViewById(R.id.layout_karma_comment);
 						final TextView linkKarma = (TextView) karmaLayout.findViewById(R.id.layout_karma_text_link);
 						final TextView commentKarma = (TextView) karmaLayout.findViewById(R.id.layout_karma_text_comment);
 
 						linkKarma.setText(String.valueOf(user.link_karma));
 						commentKarma.setText(String.valueOf(user.comment_karma));
 
+						linkKarmaLayout.setOnLongClickListener(v -> {
+							ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+							if(clipboardManager != null) {
+								ClipData data = ClipData.newPlainText(context.getString(R.string.karma_link), linkKarma.getText());
+								clipboardManager.setPrimaryClip(data);
+
+								General.quickToast(context, R.string.copied_to_clipboard);
+							}
+							return true;
+						});
+						commentKarmaLayout.setOnLongClickListener(v -> {
+							ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+							if(clipboardManager != null) {
+								ClipData data = ClipData.newPlainText(context.getString(R.string.karma_comment), commentKarma.getText());
+								clipboardManager.setPrimaryClip(data);
+
+								General.quickToast(context, R.string.copied_to_clipboard);
+							}
+							return true;
+						});
+
 						items.addView(propView(context, R.string.userprofile_created, RRTime.formatDateTime(user.created_utc * 1000, context), false));
+						items.getChildAt(items.getChildCount() - 1).setNextFocusUpId(R.id.layout_karma_link);
 
 						if(user.has_mail != null) {
 							items.addView(propView(context, R.string.userprofile_hasmail, user.has_mail ? R.string.general_true : R.string.general_false, false));

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -224,6 +224,14 @@ public final class RedditPostView extends FlingableItemView implements RedditPre
 			}
 		});
 
+		thumbnailView = (ImageView) rootView.findViewById(R.id.reddit_post_thumbnail_view);
+		overlayIcon = (ImageView) rootView.findViewById(R.id.reddit_post_overlay_icon);
+
+		title = (TextView) rootView.findViewById(R.id.reddit_post_title);
+		subtitle = (TextView) rootView.findViewById(R.id.reddit_post_subtitle);
+		commentsButton = (LinearLayout) rootView.findViewById(R.id.reddit_post_comments_button);
+		commentsText = (TextView) commentsButton.findViewById(R.id.reddit_post_comments_text);
+
 		if(leftHandedMode) {
 			final ArrayList<View> outerViewElements = new ArrayList<View>(3);
 			for(int i = mOuterView.getChildCount() - 1; i >= 0; i--) {
@@ -234,15 +242,14 @@ public final class RedditPostView extends FlingableItemView implements RedditPre
 			for(int i = 0; i < outerViewElements.size(); i++) {
 				mOuterView.addView(outerViewElements.get(i));
 			}
+
+			mOuterView.setNextFocusLeftId(commentsButton.getId());
+			mOuterView.setNextFocusRightId(NO_ID);
+
+			commentsButton.setNextFocusForwardId(R.id.reddit_post_layout);
+			commentsButton.setNextFocusRightId(R.id.reddit_post_layout);
+			commentsButton.setNextFocusLeftId(NO_ID);
 		}
-
-		thumbnailView = (ImageView) rootView.findViewById(R.id.reddit_post_thumbnail_view);
-		overlayIcon = (ImageView) rootView.findViewById(R.id.reddit_post_overlay_icon);
-
-		title = (TextView) rootView.findViewById(R.id.reddit_post_title);
-		subtitle = (TextView) rootView.findViewById(R.id.reddit_post_subtitle);
-		commentsButton = (LinearLayout) rootView.findViewById(R.id.reddit_post_comments_button);
-		commentsText = (TextView)commentsButton.findViewById(R.id.reddit_post_comments_text);
 
 		commentsButton.setOnClickListener(new OnClickListener() {
 			@Override

--- a/src/main/java/org/quantumbadger/redreader/views/list/GroupedRecyclerViewItemListSectionHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/list/GroupedRecyclerViewItemListSectionHeaderView.java
@@ -18,8 +18,12 @@
 package org.quantumbadger.redreader.views.list;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import org.quantumbadger.redreader.R;
@@ -55,6 +59,15 @@ public class GroupedRecyclerViewItemListSectionHeaderView extends GroupedRecycle
 
 		final TextView view = (TextView)viewHolder.itemView;
 		view.setText(mText);
+
+		//From https://stackoverflow.com/a/54082384
+		ViewCompat.setAccessibilityDelegate(view, new AccessibilityDelegateCompat() {
+			@Override
+			public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+				super.onInitializeAccessibilityNodeInfo(host, info);
+				info.setHeading(true);
+			}
+		});
 	}
 
 	@Override

--- a/src/main/res/layout/karma.xml
+++ b/src/main/res/layout/karma.xml
@@ -23,12 +23,14 @@
               android:layout_height="wrap_content"
               android:baselineAligned="false">
 
-    <LinearLayout android:layout_width="0px"
+    <LinearLayout android:id="@+id/layout_karma_link"
+                  android:layout_width="0px"
                   android:layout_height="wrap_content"
                   android:layout_weight="1"
                   android:layout_gravity="center"
                   android:orientation="vertical"
-        android:padding="10dp">
+                  android:padding="10dp"
+                  android:focusable="true">
 
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
@@ -51,12 +53,14 @@
           android:layout_height="match_parent"
           android:background="?rrListDividerCol"/>
 
-    <LinearLayout android:layout_width="0px"
+    <LinearLayout android:id="@+id/layout_karma_comment"
+                  android:layout_width="0px"
                   android:layout_height="wrap_content"
                   android:layout_weight="1"
                   android:layout_gravity="center"
                   android:orientation="vertical"
-                  android:padding="10dp">
+                  android:padding="10dp"
+                  android:focusable="true">
 
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"

--- a/src/main/res/layout/reddit_post.xml
+++ b/src/main/res/layout/reddit_post.xml
@@ -39,7 +39,8 @@
 			android:background="?rrListItemBackgroundCol"
 			android:orientation="horizontal"
 			android:minHeight="64dp"
-			android:elevation="10dp">
+			android:elevation="10dp"
+			android:nextFocusRight="@id/reddit_post_comments_button">
 
 		<FrameLayout
 				android:layout_width="wrap_content"
@@ -104,7 +105,8 @@
 				android:layout_height="match_parent"
 				android:gravity="center"
 				android:background="?rrPostCommentsButtonBackCol"
-				android:orientation="vertical">
+				android:orientation="vertical"
+				android:nextFocusLeft="@id/reddit_post_layout">
 
 			<ImageView
 					android:layout_height="wrap_content"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1223,4 +1223,7 @@
 	<string name="comment_text_copied_to_clipboard">Comment text copied to clipboard</string>
 	<string name="subreddit_link_copied_to_clipboard">Subreddit link copied to clipboard</string>
 
+	<!-- 2020-07-16 -->
+	<string name="copied_to_clipboard">Copied to clipboard</string>
+
 </resources>


### PR DESCRIPTION
This is a redo of [my earlier pull request](https://github.com/QuantumBadger/RedReader/pull/757) due to utter incompetence with git.

After reviewing your recommendations, I made several changes:

- No heading is created for the **Shortcuts** section. Although I figured out a way to make one that is invisible visually but available to screen readers, it would look very jarring to see focus shift to nowhere for those who use screen readers but have some vision. I considered making an option for it, but it seemed a bit silly to create an entire preference over the display of a single line. Not having a heading at the very top is probably fine.

- The ability to copy text from each entry in the **Properties** dialog (and from every other `propView`) was re-added, by copying the text on a long press. This ability was also added for the karma counts in the **User Profile** dialog, for consistency. To avoid creating a large number of new strings and adding a new parameter to `propView` to figure out which toast to display, all copying done with this new method simply shows a generic "Copied to clipboard" toast.

##### Note
It's possible for there to be a heading at the very top if the user disables all of the **Shortcuts** items. I've attached a screenshot below to illustrate. It might be worth figuring out what heading is at the top (if any), and hiding it or reducing its top padding.

I looked into this, but it's a little more complex than I initially thought because you can't necessarily know at the start what headings will be displayed (e.g. if **Multireddits** would be at the top, you have to find out if the user has any multireddits to show).

![Screenshot_1594881175](https://user-images.githubusercontent.com/44722506/87641998-86027900-c70e-11ea-9b4c-8b03671dcea3.png)