### PR TITLE
Allow video to be scrubbed with single taps

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -207,9 +207,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 				}
 
 				@Override
-				public void onScrubStop(TimeBar timeBar, long position, boolean canceled) {
-
-				}
+				public void onScrubStop(TimeBar timeBar, long position, boolean canceled) { mVideoPlayer.seekTo(position); }
 			});
 
 			final Runnable updateProgressRunnable = new Runnable() {


### PR DESCRIPTION
I thought it was a bit odd how you can only scrub a video with a drag motion, and not by simply tapping on the desired spot on the seek bar. This allows that.