### PR TITLE
Allow comment and self text to be selected in propView's

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentPropertiesDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentPropertiesDialog.java
@@ -70,14 +70,15 @@ public final class CommentPropertiesDialog extends PropertiesDialog {
 		items.addView(propView(context, R.string.props_subreddit, comment.subreddit, false));
 
 		if(comment.body != null && comment.body.length() > 0) {
-			items.addView(propView(context, R.string.props_body_markdown, StringEscapeUtils.unescapeHtml4(comment.body), false));
+			items.addView(propView(context, R.string.props_body_markdown, StringEscapeUtils.unescapeHtml4(comment.body), false, true));
 
 			if(comment.body_html != null) {
 				items.addView(propView(
 						context,
 						R.string.props_body_html,
 						StringEscapeUtils.unescapeHtml4(comment.body_html),
-						false));
+						false,
+						true));
 			}
 		}
 	}

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostPropertiesDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostPropertiesDialog.java
@@ -65,14 +65,15 @@ public final class PostPropertiesDialog extends PropertiesDialog {
 		items.addView(propView(context, R.string.props_num_comments, String.valueOf(post.num_comments), false));
 
 		if(post.selftext != null && post.selftext.length() > 0) {
-			items.addView(propView(context, R.string.props_self_markdown, StringEscapeUtils.unescapeHtml4(post.selftext), false));
+			items.addView(propView(context, R.string.props_self_markdown, StringEscapeUtils.unescapeHtml4(post.selftext), false, true));
 
 			if(post.selftext_html != null) {
 				items.addView(propView(
 						context,
 						R.string.props_self_html,
 						StringEscapeUtils.unescapeHtml4(post.selftext_html),
-						false));
+						false,
+						true));
 			}
 		}
 	}

--- a/src/main/java/org/quantumbadger/redreader/fragments/PropertiesDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PropertiesDialog.java
@@ -93,16 +93,23 @@ public abstract class PropertiesDialog extends AppCompatDialogFragment {
 		return propView(context, context.getString(titleRes), text, firstInList);
 	}
 
-	// TODO xml?
 	protected final LinearLayout propView(final Context context, final String title, final CharSequence text, final boolean firstInList) {
+		return propView(context, title, text, firstInList, false);
+	}
+
+	protected final LinearLayout propView(final Context context, final int titleRes, final CharSequence text, final boolean firstInList, final boolean isFullySelectable) {
+		return propView(context, context.getString(titleRes), text, firstInList, isFullySelectable);
+	}
+
+	// TODO xml?
+	protected final LinearLayout propView(final Context context, final String title, final CharSequence text, final boolean firstInList, final boolean isFullySelectable) {
 
 		final int paddingPixels = General.dpToPixels(context, 12);
 
 		final LinearLayout prop = new LinearLayout(context);
 		prop.setOrientation(LinearLayout.VERTICAL);
-		prop.setFocusable(true);
 
-		prop.setOnLongClickListener(v -> {
+		View.OnLongClickListener copyListener = v -> {
 			ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
 			if(clipboardManager != null) {
 				ClipData data = ClipData.newPlainText(title, text);
@@ -111,7 +118,12 @@ public abstract class PropertiesDialog extends AppCompatDialogFragment {
 				General.quickToast(context, R.string.copied_to_clipboard);
 			}
 			return true;
-		});
+		};
+
+		if(!isFullySelectable || !prop.isInTouchMode()) {
+			prop.setFocusable(true);
+			prop.setOnLongClickListener(copyListener);
+		}
 
 		if(!firstInList) {
 			final View divider = new View(context);
@@ -132,6 +144,16 @@ public abstract class PropertiesDialog extends AppCompatDialogFragment {
 		textView.setTextColor(rrCommentBodyCol);
 		textView.setTextSize(15.0f);
 		textView.setPadding(paddingPixels, 0, paddingPixels, paddingPixels);
+		if(isFullySelectable && textView.isInTouchMode()) { textView.setTextIsSelectable(true); }
+
+		if(isFullySelectable) {
+			prop.getViewTreeObserver().addOnTouchModeChangeListener(isInTouchMode -> {
+				prop.setFocusable(!isInTouchMode);
+				prop.setOnLongClickListener(!isInTouchMode ? copyListener : null);
+				textView.setTextIsSelectable(isInTouchMode);
+			});
+		}
+
 		prop.addView(textView);
 
 		return prop;


### PR DESCRIPTION
This fixes #781. After looking at the options, this seems to be the best solution that does not require a rework of how we handle the **Properties** dialog, but I'm open to any suggestions.

To summarize how these changes would affect everyone:
- For typical touchscreen users: Comment text and self-text can now be selected as before. All other fields retain the new (1.12) behavior of copying the whole field on a long-press.
- For directional control (e.g. D-Pad) users: No change from the new behavior.
- For TalkBack users: The fields for comment text and self-text return to the old behavior, where two swipes are required to move past them, and copying is done by selecting the text and choosing "Copy". All other fields retain the new (single-swipe and copy on long-press) behavior.