### PR TITLE
Make age display customizable

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/adapters/SessionListAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/SessionListAdapter.java
@@ -112,7 +112,13 @@ public class SessionListAdapter extends HeaderRecyclerAdapter<RecyclerView.ViewH
 		final BetterSSB name = new BetterSSB();
 
 		if(RRTime.utcCurrentTimeMillis() - session.timestamp < 1000 * 120) {
-			name.append(RRTime.formatDurationFrom(context, session.timestamp), 0);
+			name.append(
+					RRTime.formatDurationFrom(
+							context,
+							session.timestamp,
+							R.string.time_ago,
+							2),
+					0);
 		} else {
 			name.append(RRTime.formatDateTime(session.timestamp, context), 0);
 		}

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -812,6 +812,20 @@ public final class PrefsUtility {
 				sharedPreferences)));
 	}
 
+	public static int appearance_inbox_age_units(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		try {
+			return Integer.parseInt(getString(
+					R.string.pref_appearance_inbox_age_units_key,
+					"2",
+					context,
+					sharedPreferences));
+		} catch(final Throwable e) {
+			return 2;
+		}
+	}
+
 	///////////////////////////////
 	// pref_behaviour
 	///////////////////////////////

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -658,6 +658,20 @@ public final class PrefsUtility {
 		return result;
 	}
 
+	public static int appearance_post_age_units(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		try {
+			return Integer.parseInt(getString(
+					R.string.pref_appearance_post_age_units_key,
+					"2",
+					context,
+					sharedPreferences));
+		} catch(final Throwable e) {
+			return 2;
+		}
+	}
+
 	public static boolean appearance_post_subtitle_items_use_different_settings(
 			final Context context,
 			final SharedPreferences sharedPreferences) {
@@ -685,6 +699,20 @@ public final class PrefsUtility {
 		}
 
 		return result;
+	}
+
+	public static int appearance_post_header_age_units(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		try {
+			return Integer.parseInt(getString(
+					R.string.pref_appearance_post_header_age_units_key,
+					"2",
+					context,
+					sharedPreferences));
+		} catch(final Throwable e) {
+			return 2;
+		}
 	}
 
 	public static boolean appearance_post_show_comments_button(
@@ -727,6 +755,34 @@ public final class PrefsUtility {
 		}
 
 		return result;
+	}
+
+	public static int appearance_comment_age_units(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		try {
+			return Integer.parseInt(getString(
+					R.string.pref_appearance_comment_age_units_key,
+					"2",
+					context,
+					sharedPreferences));
+		} catch(final Throwable e) {
+			return 2;
+		}
+	}
+
+	public enum CommentAgeMode {
+		ABSOLUTE, RELATIVE_POST, RELATIVE_PARENT
+	}
+
+	public static CommentAgeMode appearance_comment_age_mode(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		return CommentAgeMode.valueOf(StringUtils.asciiUppercase(getString(
+				R.string.pref_appearance_comment_age_mode_key,
+				"absolute",
+				context,
+				sharedPreferences)));
 	}
 
 	///////////////////////////////

--- a/src/main/java/org/quantumbadger/redreader/common/RRTime.java
+++ b/src/main/java/org/quantumbadger/redreader/common/RRTime.java
@@ -56,12 +56,30 @@ public class RRTime {
 		}
 	}
 
-	public static String formatDurationFrom(final Context context, final long startTime) {
+	public static String formatDurationFrom(
+			final Context context,
+			final long startTime,
+			final int timeStringRes,
+			final int unitsToDisplay) {
+		return formatDurationFrom(
+				context,
+				startTime,
+				utcCurrentTimeMillis(),
+				timeStringRes,
+				unitsToDisplay);
+	}
+
+	public static String formatDurationFrom(
+			final Context context,
+			final long startTime,
+			final long endTime,
+			final int timeStringRes,
+			final int unitsToDisplay) {
+
 		final String space = " ";
 		final String comma = ",";
 		final String separator = comma + space;
 
-		final long endTime = utcCurrentTimeMillis();
 		final DateTime dateTime = new DateTime(endTime);
 		final DateTime localDateTime = dateTime.withZone(DateTimeZone.getDefault());
 		final Period period = new Duration(startTime, endTime).toPeriodTo(localDateTime);
@@ -108,15 +126,20 @@ public class RRTime {
 				.appendSuffix(context.getString(R.string.time_ms))
 				.toFormatter();
 
-		String duration
-				= periodFormatter.print(period.normalizedStandard(PeriodType.yearMonthDayTime()));
+		StringBuilder duration
+				= new StringBuilder(periodFormatter.print(
+						period.normalizedStandard(PeriodType.yearMonthDayTime())));
 
-		final List<String> parts = Arrays.asList(duration.split(comma));
-		if(parts.size() >= 2) {
-			duration = parts.get(0) + comma + parts.get(1);
+		final List<String> parts = Arrays.asList(duration.toString().split(comma));
+		if(parts.size() >= unitsToDisplay) {
+			duration = new StringBuilder(parts.get(0));
+
+			for(int i = 1; i < unitsToDisplay; i ++) {
+				duration.append(comma).append(parts.get(i));
+			}
 		}
 
-		return String.format(context.getString(R.string.time_ago), duration);
+		return String.format(context.getString(timeStringRes), duration.toString());
 	}
 
 	public static long since(final long timestamp) {

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -395,6 +395,10 @@ public class CommentListingFragment extends RRFragment
 		return mOuterFrame;
 	}
 
+	public RedditPreparedPost getPost() {
+		return mPost;
+	}
+
 	@Override
 	public Bundle onSaveInstanceState() {
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedMessage.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedMessage.java
@@ -32,6 +32,8 @@ import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.BaseActivity;
 import org.quantumbadger.redreader.activities.CommentReplyActivity;
 import org.quantumbadger.redreader.common.BetterSSB;
+import org.quantumbadger.redreader.common.General;
+import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRThemeAttributes;
 import org.quantumbadger.redreader.common.RRTime;
 import org.quantumbadger.redreader.reddit.prepared.bodytext.BodyElement;
@@ -99,7 +101,9 @@ public final class RedditPreparedMessage implements RedditRenderableInboxItem {
 						applicationContext,
 						src.created_utc * 1000L,
 						R.string.time_ago,
-						2),
+						PrefsUtility.appearance_inbox_age_units(
+								applicationContext,
+								General.getSharedPrefs(applicationContext))),
 				BetterSSB.FOREGROUND_COLOR | BetterSSB.BOLD,
 				rrCommentHeaderBoldCol,
 				0,
@@ -140,6 +144,7 @@ public final class RedditPreparedMessage implements RedditRenderableInboxItem {
 			final RRThemeAttributes theme,
 			final RedditChangeDataManager changeDataManager,
 			final Context context,
+			final int commentAgeUnits,
 			final long postCreated,
 			final long parentCommentCreated) {
 		return header;

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedMessage.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedMessage.java
@@ -54,7 +54,6 @@ public final class RedditPreparedMessage implements RedditRenderableInboxItem {
 
 		this.src = message;
 
-		// TODO custom time
 		// TODO respect RRTheme
 
 		final int rrCommentHeaderBoldCol;
@@ -96,7 +95,11 @@ public final class RedditPreparedMessage implements RedditRenderableInboxItem {
 
 		sb.append("   ", 0);
 		sb.append(
-				RRTime.formatDurationFrom(applicationContext, src.created_utc * 1000L),
+				RRTime.formatDurationFrom(
+						applicationContext,
+						src.created_utc * 1000L,
+						R.string.time_ago,
+						2),
 				BetterSSB.FOREGROUND_COLOR | BetterSSB.BOLD,
 				rrCommentHeaderBoldCol,
 				0,
@@ -136,7 +139,9 @@ public final class RedditPreparedMessage implements RedditRenderableInboxItem {
 	public CharSequence getHeader(
 			final RRThemeAttributes theme,
 			final RedditChangeDataManager changeDataManager,
-			final Context context) {
+			final Context context,
+			final long postCreated,
+			final long parentCommentCreated) {
 		return header;
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -914,17 +914,17 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 				General.getSharedPrefs(context))) {
 			mPostSubtitleItems = PrefsUtility.appearance_post_header_subtitle_items(
 					context,
-					PreferenceManager.getDefaultSharedPreferences(context));
+					General.getSharedPrefs(context));
 			mPostAgeUnits = PrefsUtility.appearance_post_header_age_units(
 					context,
-					PreferenceManager.getDefaultSharedPreferences(context));
+					General.getSharedPrefs(context));
 		} else {
 			mPostSubtitleItems = PrefsUtility.appearance_post_subtitle_items(
 					context,
-					PreferenceManager.getDefaultSharedPreferences(context));
+					General.getSharedPrefs(context));
 			mPostAgeUnits = PrefsUtility.appearance_post_age_units(
 					context,
-					PreferenceManager.getDefaultSharedPreferences(context));
+					General.getSharedPrefs(context));
 		}
 
 		final TypedArray appearance = context.obtainStyledAttributes(new int[] {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -924,9 +924,8 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			final Context context,
 			final boolean headerMode) {
 
-		// TODO preference for the X days, X hours thing
-
 		final EnumSet<PrefsUtility.AppearancePostSubtitleItem> mPostSubtitleItems;
+		final int mPostAgeUnits;
 		if(headerMode
 				&& PrefsUtility.appearance_post_subtitle_items_use_different_settings(
 				context,
@@ -934,8 +933,14 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			mPostSubtitleItems = PrefsUtility.appearance_post_header_subtitle_items(
 					context,
 					PreferenceManager.getDefaultSharedPreferences(context));
+			mPostAgeUnits = PrefsUtility.appearance_post_header_age_units(
+					context,
+					PreferenceManager.getDefaultSharedPreferences(context));
 		} else {
 			mPostSubtitleItems = PrefsUtility.appearance_post_subtitle_items(
+					context,
+					PreferenceManager.getDefaultSharedPreferences(context));
+			mPostAgeUnits = PrefsUtility.appearance_post_age_units(
 					context,
 					PreferenceManager.getDefaultSharedPreferences(context));
 		}
@@ -1075,7 +1080,9 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			postListDescSb.append(
 					RRTime.formatDurationFrom(
 							context,
-							src.getCreatedTimeSecsUTC() * 1000),
+							src.getCreatedTimeSecsUTC() * 1000,
+							R.string.time_ago,
+							mPostAgeUnits),
 					BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR,
 					boldCol,
 					0,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -234,7 +234,6 @@ public class RedditRenderableComment
 								commentTime,
 								R.string.time_after_reply,
 								commentAgeUnits);
-						android.util.Log.i("lol","" + parentCommentCreated * 1000L);
 						break;
 					}
 					//Top-level comment (or unable to get the parent comment's creation time)

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.reddit.prepared;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.preference.PreferenceManager;
 import android.view.View;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccountManager;
@@ -43,6 +44,8 @@ public class RedditRenderableComment
 	private final String mParentPostAuthor;
 	private final Integer mMinimumCommentScore;
 	private final boolean mShowScore;
+
+	public final static int NO_TIMESTAMP = -1;
 
 	public RedditRenderableComment(
 			final RedditParsedComment comment,
@@ -82,7 +85,16 @@ public class RedditRenderableComment
 	public CharSequence getHeader(
 			final RRThemeAttributes theme,
 			final RedditChangeDataManager changeDataManager,
-			final Context context) {
+			final Context context,
+			final long postCreated,
+			final long parentCommentCreated) {
+
+		final int commentAgeUnits = PrefsUtility.appearance_comment_age_units(
+				context,
+				PreferenceManager.getDefaultSharedPreferences(context));
+		final PrefsUtility.CommentAgeMode commentAgeMode = PrefsUtility.appearance_comment_age_mode(
+				context,
+				PreferenceManager.getDefaultSharedPreferences(context));
 
 		final BetterSSB sb = new BetterSSB();
 
@@ -209,8 +221,47 @@ public class RedditRenderableComment
 		}
 
 		if(theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.AGE)) {
+			final long commentTime = rawComment.created_utc * 1000L;
+			final String formattedAge;
+
+			//In addition to enforcing the user's prefs, the lower mode cases also act as fallbacks
+			switch(commentAgeMode) {
+				case RELATIVE_PARENT:
+					if(parentCommentCreated != NO_TIMESTAMP) {
+						formattedAge = RRTime.formatDurationFrom(
+								context,
+								parentCommentCreated * 1000L,
+								commentTime,
+								R.string.time_after_reply,
+								commentAgeUnits);
+						android.util.Log.i("lol","" + parentCommentCreated * 1000L);
+						break;
+					}
+					//Top-level comment (or unable to get the parent comment's creation time)
+				case RELATIVE_POST:
+					if(postCreated != NO_TIMESTAMP) {
+						formattedAge = RRTime.formatDurationFrom(
+								context,
+								postCreated * 1000L,
+								commentTime,
+								R.string.time_after,
+								commentAgeUnits);
+						break;
+					}
+					//Unable to get post creation date, resorting to absolute age
+				case ABSOLUTE:
+					formattedAge = RRTime.formatDurationFrom(
+							context,
+							commentTime,
+							R.string.time_ago,
+							commentAgeUnits);
+					break;
+				default:
+					throw new IllegalStateException("Unexpected value: " + commentAgeMode);
+			}
+
 			sb.append(
-					RRTime.formatDurationFrom(context, rawComment.created_utc * 1000L),
+					formattedAge,
 					BetterSSB.FOREGROUND_COLOR | BetterSSB.BOLD,
 					theme.rrCommentHeaderBoldCol,
 					0,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -19,7 +19,6 @@ package org.quantumbadger.redreader.reddit.prepared;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.preference.PreferenceManager;
 import android.view.View;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccountManager;
@@ -91,10 +90,10 @@ public class RedditRenderableComment
 
 		final int commentAgeUnits = PrefsUtility.appearance_comment_age_units(
 				context,
-				PreferenceManager.getDefaultSharedPreferences(context));
+				General.getSharedPrefs(context));
 		final PrefsUtility.CommentAgeMode commentAgeMode = PrefsUtility.appearance_comment_age_mode(
 				context,
-				PreferenceManager.getDefaultSharedPreferences(context));
+				General.getSharedPrefs(context));
 
 		final BetterSSB sb = new BetterSSB();
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -85,12 +85,10 @@ public class RedditRenderableComment
 			final RRThemeAttributes theme,
 			final RedditChangeDataManager changeDataManager,
 			final Context context,
+			final int commentAgeUnits,
 			final long postCreated,
 			final long parentCommentCreated) {
 
-		final int commentAgeUnits = PrefsUtility.appearance_comment_age_units(
-				context,
-				General.getSharedPrefs(context));
 		final PrefsUtility.CommentAgeMode commentAgeMode = PrefsUtility.appearance_comment_age_mode(
 				context,
 				General.getSharedPrefs(context));

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableCommentListItem.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableCommentListItem.java
@@ -27,7 +27,9 @@ public interface RedditRenderableCommentListItem {
 	CharSequence getHeader(
 			final RRThemeAttributes theme,
 			final RedditChangeDataManager changeDataManager,
-			final Context context);
+			final Context context,
+			final long postCreated,
+			final long parentCommentCreated);
 
 	View getBody(
 			final BaseActivity activity,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableCommentListItem.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableCommentListItem.java
@@ -28,6 +28,7 @@ public interface RedditRenderableCommentListItem {
 			final RRThemeAttributes theme,
 			final RedditChangeDataManager changeDataManager,
 			final Context context,
+			final int commentAgeUnits,
 			final long postCreated,
 			final long parentCommentCreated);
 

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -125,7 +125,11 @@ public final class SettingsFragment extends PreferenceFragment {
 				R.string.pref_menus_appbar_settings_key,
 				R.string.pref_menus_appbar_close_all_key,
 				R.string.pref_menus_appbar_reply_key,
-				R.string.pref_menus_appbar_search_key
+				R.string.pref_menus_appbar_search_key,
+				R.string.pref_appearance_post_age_units_key,
+				R.string.pref_appearance_post_header_age_units_key,
+				R.string.pref_appearance_comment_age_units_key,
+				R.string.pref_appearance_comment_age_mode_key
 		};
 
 		final int[] editTextPrefsToUpdate = {

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -127,7 +127,8 @@ public final class SettingsFragment extends PreferenceFragment {
 				R.string.pref_appearance_post_age_units_key,
 				R.string.pref_appearance_post_header_age_units_key,
 				R.string.pref_appearance_comment_age_units_key,
-				R.string.pref_appearance_comment_age_mode_key
+				R.string.pref_appearance_comment_age_mode_key,
+				R.string.pref_appearance_inbox_age_units_key
 		};
 
 		final int[] editTextPrefsToUpdate = {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -381,7 +381,14 @@ public class RedditCommentView extends FlingableItemView
 		final CharSequence headerText = renderableComment.getHeader(
 				mTheme,
 				mChangeDataManager,
-				activity);
+				activity,
+				(mFragment != null && mFragment.getPost() != null)
+					? mFragment.getPost().src.getCreatedTimeSecsUTC()
+					: RedditRenderableComment.NO_TIMESTAMP,
+				mComment.getParent() != null
+						? mComment.getParent()
+							.asComment().getParsedComment().getRawComment().created_utc
+						: RedditRenderableComment.NO_TIMESTAMP);
 
 		if(mComment.isCollapsed(mChangeDataManager)) {
 			setFlingingEnabled(false);

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -373,6 +373,9 @@ public class RedditCommentView extends FlingableItemView
 				mTheme,
 				mChangeDataManager,
 				activity,
+				PrefsUtility.appearance_comment_age_units(
+						activity,
+						General.getSharedPrefs(activity)),
 				(mFragment != null && mFragment.getPost() != null)
 					? mFragment.getPost().src.getCreatedTimeSecsUTC()
 					: RedditRenderableComment.NO_TIMESTAMP,

--- a/src/main/java/org/quantumbadger/redreader/views/RedditInboxItemView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditInboxItemView.java
@@ -29,6 +29,7 @@ import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRThemeAttributes;
 import org.quantumbadger.redreader.reddit.prepared.RedditChangeDataManager;
+import org.quantumbadger.redreader.reddit.prepared.RedditRenderableComment;
 import org.quantumbadger.redreader.reddit.prepared.RedditRenderableInboxItem;
 
 public class RedditInboxItemView extends LinearLayout {
@@ -111,7 +112,12 @@ public class RedditInboxItemView extends LinearLayout {
 		currentItem = item;
 
 		mDivider.setVisibility(showDividerAtTop ? VISIBLE : GONE);
-		mHeader.setText(item.getHeader(theme, changeDataManager, context));
+		mHeader.setText(item.getHeader(
+				theme,
+				changeDataManager,
+				context,
+				RedditRenderableComment.NO_TIMESTAMP,
+				RedditRenderableComment.NO_TIMESTAMP));
 
 		final View body = item.getBody(
 				context,

--- a/src/main/java/org/quantumbadger/redreader/views/RedditInboxItemView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditInboxItemView.java
@@ -115,6 +115,7 @@ public class RedditInboxItemView extends LinearLayout {
 				theme,
 				changeDataManager,
 				context,
+				PrefsUtility.appearance_inbox_age_units(context, General.getSharedPrefs(context)),
 				RedditRenderableComment.NO_TIMESTAMP,
 				RedditRenderableComment.NO_TIMESTAMP));
 

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1036,4 +1036,29 @@
 		<item>edit</item>
 	</string-array>
 
+	<!-- 2020-10-31 -->
+
+	<string-array name="pref_appearance_age_units_items">
+		<item>1</item>
+		<item>2</item>
+		<item>3</item>
+		<item>4</item>
+		<item>5</item>
+		<item>6</item>
+		<item>7</item>
+	</string-array>
+
+	<string-array name="pref_appearance_comment_age_mode_items">
+		<item>@string/pref_appearance_comment_age_mode_absolute</item>
+		<item>@string/pref_appearance_comment_age_mode_relative_post</item>
+		<item>@string/pref_appearance_comment_age_mode_relative_parent</item>
+	</string-array>
+
+	<!-- Constants. Do not change. -->
+	<string-array name="pref_appearance_comment_age_mode_return">
+		<item>absolute</item>
+		<item>relative_post</item>
+		<item>relative_parent</item>
+	</string-array>
+
 </resources>

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1039,13 +1039,15 @@
 	<!-- 2020-10-31 -->
 
 	<string-array name="pref_appearance_age_units_items">
+		<item>@string/pref_appearance_age_units_1</item>
+		<item>@string/pref_appearance_age_units_2</item>
+		<item>@string/pref_appearance_age_units_3</item>
+	</string-array>
+
+	<string-array name="pref_appearance_age_units_return">
 		<item>1</item>
 		<item>2</item>
 		<item>3</item>
-		<item>4</item>
-		<item>5</item>
-		<item>6</item>
-		<item>7</item>
 	</string-array>
 
 	<string-array name="pref_appearance_comment_age_mode_items">

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1319,6 +1319,9 @@
 	<string name="pref_appearance_post_header_age_units_title">Opened post age precision</string>
 	<string name="pref_appearance_comment_age_units_key" translatable="false">pref_appearance_comment_age_units</string>
 	<string name="pref_appearance_comment_age_units_title">Comment age precision</string>
+	<string name="pref_appearance_inbox_header">Inbox</string>
+	<string name="pref_appearance_inbox_age_units_key" translatable="false">pref_appearance_inbox_age_units</string>
+	<string name="pref_appearance_inbox_age_units_title">Inbox entry age precision</string>
 	<string name="pref_appearance_age_units_1">One unit (\"x hours\")</string>
 	<string name="pref_appearance_age_units_2">Two units (\"x hours, x mins\")</string>
 	<string name="pref_appearance_age_units_3">Three units (\"x hours, x mins, x secs\")</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1312,18 +1312,21 @@
 
 	<!-- 2020-10-31 -->
 	<string name="time_after">after %s</string>
-	<string name="time_after_reply">replying %s later</string>
+	<string name="time_after_reply">replied %s later</string>
 	<string name="pref_appearance_post_age_units_key" translatable="false">pref_appearance_post_age_units</string>
-	<string name="pref_appearance_post_age_units_title">Post maximum age units</string>
+	<string name="pref_appearance_post_age_units_title">Post age precision</string>
 	<string name="pref_appearance_post_header_age_units_key" translatable="false">pref_appearance_post_header_age_units</string>
-	<string name="pref_appearance_post_header_age_units_title">Opened post maximum age units</string>
+	<string name="pref_appearance_post_header_age_units_title">Opened post age precision</string>
 	<string name="pref_appearance_comment_age_units_key" translatable="false">pref_appearance_comment_age_units</string>
-	<string name="pref_appearance_comment_age_units_title">Comment maximum age units</string>
+	<string name="pref_appearance_comment_age_units_title">Comment age precision</string>
+	<string name="pref_appearance_age_units_1">One unit (\"x hours\")</string>
+	<string name="pref_appearance_age_units_2">Two units (\"x hours, x mins\")</string>
+	<string name="pref_appearance_age_units_3">Three units (\"x hours, x mins, x secs\")</string>
 	<string name="pref_appearance_comment_age_mode_key" translatable="false">pref_appearance_comment_age_mode</string>
 	<string name="pref_appearance_comment_age_mode_title">Comment age mode</string>
-	<string name="pref_appearance_comment_age_mode_absolute">Absolute</string>
-	<string name="pref_appearance_comment_age_mode_relative_post">Relative to post</string>
-	<string name="pref_appearance_comment_age_mode_relative_parent">Relative to parent comment</string>
+	<string name="pref_appearance_comment_age_mode_absolute">Time since comment (\"x mins ago\")</string>
+	<string name="pref_appearance_comment_age_mode_relative_post">Relative to post (\"after x mins\")</string>
+	<string name="pref_appearance_comment_age_mode_relative_parent">Relative to parent comment (\"replied x mins later\")</string>
 
 	<!-- 2020-11-13 -->
 	<string name="press_back_again">Press back again</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1305,4 +1305,19 @@
 	<!-- 2020-09-19 -->
 	<string name="action_save_image_success_no_path">Image saved successfully</string>
 
+	<!-- 2020-10-31 -->
+	<string name="time_after">after %s</string>
+	<string name="time_after_reply">replying %s later</string>
+	<string name="pref_appearance_post_age_units_key" translatable="false">pref_appearance_post_age_units</string>
+	<string name="pref_appearance_post_age_units_title">Post maximum age units</string>
+	<string name="pref_appearance_post_header_age_units_key" translatable="false">pref_appearance_post_header_age_units</string>
+	<string name="pref_appearance_post_header_age_units_title">Opened post maximum age units</string>
+	<string name="pref_appearance_comment_age_units_key" translatable="false">pref_appearance_comment_age_units</string>
+	<string name="pref_appearance_comment_age_units_title">Comment maximum age units</string>
+	<string name="pref_appearance_comment_age_mode_key" translatable="false">pref_appearance_comment_age_mode</string>
+	<string name="pref_appearance_comment_age_mode_title">Comment age mode</string>
+	<string name="pref_appearance_comment_age_mode_absolute">Absolute</string>
+	<string name="pref_appearance_comment_age_mode_relative_post">Relative to post</string>
+	<string name="pref_appearance_comment_age_mode_relative_parent">Relative to parent comment</string>
+
 </resources>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -167,4 +167,14 @@
 
     </PreferenceCategory>
 
+	<PreferenceCategory android:title="@string/pref_appearance_inbox_header">
+
+		<ListPreference android:title="@string/pref_appearance_inbox_age_units_title"
+						android:key="@string/pref_appearance_inbox_age_units_key"
+						android:entries="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_return"
+						android:defaultValue="2"/>
+
+	</PreferenceCategory>
+
 </PreferenceScreen>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -87,7 +87,7 @@
 		<ListPreference android:title="@string/pref_appearance_post_age_units_title"
 						android:key="@string/pref_appearance_post_age_units_key"
 						android:entries="@array/pref_appearance_age_units_items"
-						android:entryValues="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_return"
 						android:defaultValue="2"/>
 
 		<CheckBoxPreference android:title="@string/pref_appearance_post_subtitle_items_use_different_settings_title"
@@ -107,7 +107,7 @@
 						android:key="@string/pref_appearance_post_header_age_units_key"
 						android:dependency="@string/pref_appearance_post_subtitle_items_use_different_settings_key"
 						android:entries="@array/pref_appearance_age_units_items"
-						android:entryValues="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_return"
 						android:defaultValue="2"/>
 
 		<CheckBoxPreference
@@ -139,7 +139,7 @@
 		<ListPreference android:title="@string/pref_appearance_comment_age_units_title"
 						android:key="@string/pref_appearance_comment_age_units_key"
 						android:entries="@array/pref_appearance_age_units_items"
-						android:entryValues="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_return"
 						android:defaultValue="2"/>
 
 		<ListPreference android:title="@string/pref_appearance_comment_age_mode_title"

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -74,6 +74,12 @@
 			android:entryValues="@array/pref_appearance_post_subtitle_items_return"
 			android:defaultValue="@array/pref_appearance_post_subtitle_items_default" />
 
+		<ListPreference android:title="@string/pref_appearance_post_age_units_title"
+						android:key="@string/pref_appearance_post_age_units_key"
+						android:entries="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_items"
+						android:defaultValue="2"/>
+
 		<CheckBoxPreference android:title="@string/pref_appearance_post_subtitle_items_use_different_settings_title"
 							android:key="@string/pref_appearance_post_subtitle_items_use_different_settings_key"
 							android:defaultValue="false"/>
@@ -86,6 +92,13 @@
 			android:entries="@array/pref_appearance_post_subtitle_items"
 			android:entryValues="@array/pref_appearance_post_subtitle_items_return"
 			android:defaultValue="@array/pref_appearance_post_subtitle_items_default" />
+
+		<ListPreference android:title="@string/pref_appearance_post_header_age_units_title"
+						android:key="@string/pref_appearance_post_header_age_units_key"
+						android:dependency="@string/pref_appearance_post_subtitle_items_use_different_settings_key"
+						android:entries="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_items"
+						android:defaultValue="2"/>
 
 		<CheckBoxPreference
 				android:title="@string/pref_appearance_post_show_comments_button_title"
@@ -112,6 +125,18 @@
             android:entries="@array/pref_appearance_comment_header_items"
             android:entryValues="@array/pref_appearance_comment_header_items_return"
             android:defaultValue="@array/pref_appearance_comment_header_items_default" />
+
+		<ListPreference android:title="@string/pref_appearance_comment_age_units_title"
+						android:key="@string/pref_appearance_comment_age_units_key"
+						android:entries="@array/pref_appearance_age_units_items"
+						android:entryValues="@array/pref_appearance_age_units_items"
+						android:defaultValue="2"/>
+
+		<ListPreference android:title="@string/pref_appearance_comment_age_mode_title"
+						android:key="@string/pref_appearance_comment_age_mode_key"
+						android:entries="@array/pref_appearance_comment_age_mode_items"
+						android:entryValues="@array/pref_appearance_comment_age_mode_return"
+						android:defaultValue="absolute"/>
 
         <CheckBoxPreference android:title="@string/pref_appearance_linkbuttons_title"
                             android:key="@string/pref_appearance_linkbuttons_key"


### PR DESCRIPTION
Taking inspiration from @QuantumBadger's comment [here](https://old.reddit.com/r/RedReader/comments/jhturs/request_make_the_posts_and_comments_age_shorter/gabd40k/), I decided to take a stab at this. With this, you can now choose the number of time units that will be displayed. You can show only one, show every unit from years to milliseconds, or anywhere in-between.

In addition, I added a preference to allow users to switch between three modes for comment ages:
- Absolute: As it is now: if it says "1 day ago", then the comment was posted one day ago.
- Relative to post: All comments' ages are relative to the post they're on. "1 day ago" means it was posted one day after the original post.
- Relative to parent comment: All comments' ages are relative to the comment they're replying to (top-level comments are still relative to the post).

Some of the code might not be perfect: in particular, I wonder if there is a better way to get access to the ages of parent-comments and posts then this currently uses in RedditCommentView.

Also, I'm not sure what the ideal string would be for comment replies: right now it's "replying %s later", which works okay but is pretty long. It should probably be self-explanatory enough, to prevent confusion.

In any case, I look forward to receiving feedback on this and making any necessary improvements. :-)