### PR TITLE
Add dialog for clearing the cache

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/cache/CacheDbManager.java
+++ b/src/main/java/org/quantumbadger/redreader/cache/CacheDbManager.java
@@ -307,4 +307,31 @@ final class CacheDbManager extends SQLiteOpenHelper {
 		final SQLiteDatabase db = this.getWritableDatabase();
 		db.execSQL(String.format(Locale.US, "DELETE FROM %s", TABLE));
 	}
+
+	public synchronized HashMap<Long, Integer> getFilesToSize() {
+		final SQLiteDatabase db = this.getWritableDatabase();
+
+		final Cursor cursor = db.query(
+				TABLE,
+				new String[] {FIELD_ID, FIELD_TYPE},
+				null,
+				null,
+				null,
+				null,
+				null,
+				null);
+
+		final HashMap<Long, Integer> filesToCheck = new HashMap<>(32);
+
+		while(cursor.moveToNext()) {
+			final long id = cursor.getLong(0);
+			final int type = cursor.getInt(1);
+
+			filesToCheck.put(id, type);
+		}
+
+		cursor.close();
+
+		return filesToCheck;
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/cache/CacheManager.java
+++ b/src/main/java/org/quantumbadger/redreader/cache/CacheManager.java
@@ -179,7 +179,7 @@ public final class CacheManager {
 	public synchronized void pruneCache() {
 		pruneCache(PrefsUtility.pref_cache_maxage(
 				context,
-				PreferenceManager.getDefaultSharedPreferences(context)));
+				General.getSharedPrefs(context)));
 	}
 
 	public synchronized void pruneCache(

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -1288,11 +1288,33 @@ public final class PrefsUtility {
 
 	// pref_cache_maxage
 
+	public static HashMap<Integer, Long> createFileTypeToLongMap() {
+		return createFileTypeToLongMap(0, 0, 0);
+	}
+
+	public static HashMap<Integer, Long> createFileTypeToLongMap(
+			final long listings,
+			final long thumbnails,
+			final long images) {
+		final HashMap<Integer, Long> maxAgeMap = new HashMap<>(10);
+
+		maxAgeMap.put(Constants.FileType.POST_LIST, listings);
+		maxAgeMap.put(Constants.FileType.COMMENT_LIST, listings);
+		maxAgeMap.put(Constants.FileType.SUBREDDIT_LIST, listings);
+		maxAgeMap.put(Constants.FileType.SUBREDDIT_ABOUT, listings);
+		maxAgeMap.put(Constants.FileType.USER_ABOUT, listings);
+		maxAgeMap.put(Constants.FileType.INBOX_LIST, listings);
+		maxAgeMap.put(Constants.FileType.THUMBNAIL, thumbnails);
+		maxAgeMap.put(Constants.FileType.IMAGE, images);
+		maxAgeMap.put(Constants.FileType.IMAGE_INFO, images);
+		maxAgeMap.put(Constants.FileType.CAPTCHA, images);
+
+		return maxAgeMap;
+	}
+
 	public static HashMap<Integer, Long> pref_cache_maxage(
 			final Context context,
 			final SharedPreferences sharedPreferences) {
-
-		final HashMap<Integer, Long> result = new HashMap<>();
 
 		final long maxAgeListing = 1000L
 				* 60L
@@ -1319,18 +1341,7 @@ public final class PrefsUtility {
 				context,
 				sharedPreferences));
 
-		result.put(Constants.FileType.POST_LIST, maxAgeListing);
-		result.put(Constants.FileType.COMMENT_LIST, maxAgeListing);
-		result.put(Constants.FileType.SUBREDDIT_LIST, maxAgeListing);
-		result.put(Constants.FileType.SUBREDDIT_ABOUT, maxAgeListing);
-		result.put(Constants.FileType.USER_ABOUT, maxAgeListing);
-		result.put(Constants.FileType.INBOX_LIST, maxAgeListing);
-		result.put(Constants.FileType.THUMBNAIL, maxAgeThumb);
-		result.put(Constants.FileType.IMAGE, maxAgeImage);
-		result.put(Constants.FileType.IMAGE_INFO, maxAgeImage);
-		result.put(Constants.FileType.CAPTCHA, maxAgeImage);
-
-		return result;
+		return createFileTypeToLongMap(maxAgeListing, maxAgeThumb, maxAgeImage);
 	}
 
 	public static Long pref_cache_maxage_entry(

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
@@ -184,7 +184,7 @@ public final class RedditChangeDataManager {
 
 	public static void pruneAllUsers(final Context context) {
 		pruneAllUsers(PrefsUtility.pref_cache_maxage_entry(
-				context, PreferenceManager.getDefaultSharedPreferences(context)));
+				context, General.getSharedPrefs(context)));
 	}
 
 	public static void pruneAllUsers(final long maxAge) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
@@ -178,7 +178,16 @@ public final class RedditChangeDataManager {
 		Log.i(TAG, "All entries read from stream.");
 	}
 
+	public static void pruneAllUsers() {
+		pruneAllUsers(0);
+	}
+
 	public static void pruneAllUsers(final Context context) {
+		pruneAllUsers(PrefsUtility.pref_cache_maxage_entry(
+				context, PreferenceManager.getDefaultSharedPreferences(context)));
+	}
+
+	public static void pruneAllUsers(final long maxAge) {
 
 		Log.i(TAG, "Pruning for all users...");
 
@@ -191,7 +200,7 @@ public final class RedditChangeDataManager {
 		for(final RedditAccount user : users) {
 
 			final RedditChangeDataManager managerForUser = getInstance(user);
-			managerForUser.prune(context);
+			managerForUser.prune(maxAge);
 		}
 
 		Log.i(TAG, "Pruning complete.");
@@ -589,11 +598,10 @@ public final class RedditChangeDataManager {
 		}
 	}
 
-	private void prune(final Context context) {
+	private void prune(final long maxAge) {
 
 		final long now = System.currentTimeMillis();
-		final long timestampBoundary = now - PrefsUtility.pref_cache_maxage_entry(
-				context, PreferenceManager.getDefaultSharedPreferences(context));
+		final long timestampBoundary = now - maxAge;
 
 		synchronized(mLock) {
 			final Iterator<Map.Entry<String, Entry>> iterator =

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1314,9 +1314,14 @@
 	<string name="pref_cache_clear_key" translatable="false">pref_cache_clear</string>
 	<string name="pref_cache_clear_title">Clear cache</string>
 	<string name="dialog_clear">Clear</string>
-	<string name="cache_clear_dialog_listings">Listings (%s)</string>
-	<string name="cache_clear_dialog_thumbnails">Thumbnails (%s)</string>
-	<string name="cache_clear_dialog_images">Images (%s)</string>
+	<string name="cache_clear_dialog_loading">Loading data usages</string>
+	<string name="cache_clear_dialog_loaded">Loaded data usages</string>
+	<string name="cache_clear_dialog_listings">Listings</string>
+	<string name="cache_clear_dialog_listings_data">Listings (%s)</string>
+	<string name="cache_clear_dialog_thumbnails">Thumbnails</string>
+	<string name="cache_clear_dialog_thumbnails_data">Thumbnails (%s)</string>
+	<string name="cache_clear_dialog_images">Images</string>
+	<string name="cache_clear_dialog_images_data">Images (%s)</string>
 	<string name="cache_clear_dialog_flags">Flags</string>
 
 	<!-- 2020-11-13 -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1305,4 +1305,13 @@
 	<!-- 2020-09-19 -->
 	<string name="action_save_image_success_no_path">Image saved successfully</string>
 
+	<!-- 2020-11-08 -->
+	<string name="pref_cache_clear_key" translatable="false">pref_cache_clear</string>
+	<string name="pref_cache_clear_title">Clear cache</string>
+	<string name="dialog_clear">Clear</string>
+	<string name="cache_clear_dialog_listings">Listings (%s)</string>
+	<string name="cache_clear_dialog_thumbnails">Thumbnails (%s)</string>
+	<string name="cache_clear_dialog_images">Images (%s)</string>
+	<string name="cache_clear_dialog_flags">Flags</string>
+
 </resources>

--- a/src/main/res/xml/prefs_cache.xml
+++ b/src/main/res/xml/prefs_cache.xml
@@ -54,6 +54,10 @@
 
     <PreferenceCategory android:title="@string/pref_cache_pruning">
 
+	<Preference
+		android:title="@string/pref_cache_clear_title"
+		android:key="@string/pref_cache_clear_key"/>
+
     <ListPreference android:title="@string/pref_cache_maxage_listing_title"
                     android:key="@string/pref_cache_maxage_listing_key"
                     android:entries="@array/pref_cache_maxage"


### PR DESCRIPTION
This adds a dialog in the **Cache** preferences that allows you to manually clear the cache at any time, by groupings (Listings, Thumbnails, Images, Flags). The dialog also shows you how much space each one of those is currently using (except Flags).

Closes #235, closes #366.