### PR TITLE
Show correct icon for account manager depending on theme

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -610,7 +610,11 @@ public final class OptionsMenuUtility {
 
 				accounts.setShowAsAction(showAsAction);
 				if(longText) {
-					accounts.setIcon(R.drawable.ic_settings_light);
+					if(PrefsUtility.isNightMode(activity)) {
+						accounts.setIcon(R.drawable.ic_settings_dark);
+					} else {
+						accounts.setIcon(R.drawable.ic_settings_light);
+					}
 				} else {
 					accounts.setIcon(R.drawable.ic_accounts_dark);
 				}


### PR DESCRIPTION
I forgot to make sure that the icon for the **Manage...** submenu in the quick account switcher added in #798 always matches the current theme. This fixes that.

Thanks for catching this quickly @QuantumBadger.