### PR TITLE
Inline images

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -752,6 +752,16 @@ public final class PrefsUtility {
 				sharedPreferences);
 	}
 
+	public static boolean appearance_post_show_inline_image(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		return getBoolean(
+				R.string.pref_appearance_post_show_inline_image_key,
+				false,
+				context,
+				sharedPreferences);
+	}
+
 	public enum AppearanceCommentHeaderItem {
 		AUTHOR, FLAIR, SCORE, AGE, GOLD
 	}

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -1009,6 +1009,7 @@ public class PostListingFragment extends RRFragment
 										TAG,
 										"Successfully precached "
 												+ url.toString());
+								preparedPost.notifyCached();
 							}
 						}));
 	}

--- a/src/main/java/org/quantumbadger/redreader/image/ImageRenderer.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ImageRenderer.java
@@ -1,0 +1,106 @@
+package org.quantumbadger.redreader.image;
+
+import android.graphics.Bitmap;
+import android.graphics.Rect;
+import android.graphics.drawable.BitmapDrawable;
+import android.net.Uri;
+import android.os.Process;
+import android.provider.MediaStore;
+import android.util.Log;
+import android.widget.ImageView;
+
+import org.quantumbadger.redreader.activities.BaseActivity;
+import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
+
+import java.io.IOException;
+
+public class ImageRenderer {
+
+	private static final float MAX_WIDTH = 800.0f;
+	private static final float MAX_HEIGHT = 800.0f;
+
+	private Thread thread;
+	private boolean stopped;
+	private long mImageStartRender;
+	public ImageRenderer(
+			Uri fileUri,
+			ImageView inlineImageView,
+			RedditPreparedPost post,
+			BaseActivity mActivity) {
+
+		mImageStartRender = System.currentTimeMillis();
+		float dpScale = mActivity.getResources().getDisplayMetrics().density;
+
+		if (fileUri == null){
+			return;
+		}
+
+		thread = new Thread("Image rendering thread"){
+			@Override
+			public void run() {
+
+				Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
+
+				if (stopped){
+					return;
+				}
+
+				Rect windowSize = new Rect ();
+				mActivity.getWindow().getDecorView().getWindowVisibleDisplayFrame(windowSize);
+
+				final int availableHeight = Math.min((int)(MAX_HEIGHT * dpScale), (int)windowSize.height());
+				final int availableWidth = Math.min((int)(MAX_WIDTH * dpScale), (int)windowSize.width());
+
+
+				final Bitmap rawBitmap;
+				try {
+					rawBitmap = MediaStore.Images.Media.getBitmap(mActivity.getContentResolver(), fileUri);
+				} catch (IOException e) {
+					e.printStackTrace();
+					return;
+				}
+
+				if (rawBitmap == null){
+					return;
+				}
+
+				final Bitmap scaledBitmap =
+						ThumbnailScaler.scaleToFit(
+								rawBitmap,
+								availableWidth,
+								availableHeight);
+
+				final BitmapDrawable result = new BitmapDrawable(mActivity.getResources(), scaledBitmap);
+				if (stopped){
+					return;
+				}
+				mActivity.runOnUiThread(()->{
+					if (stopped){
+						return;
+					}
+					if (inlineImageView != null) {
+						inlineImageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+						inlineImageView.setImageDrawable(result);
+
+						int height = result.getIntrinsicHeight();
+						inlineImageView.setMinimumHeight(height);
+
+						if (post != null) {
+							post.lastImageHeight = height;
+						}
+
+						long totalMilis = System.currentTimeMillis() - mImageStartRender;
+						Log.d("ImageRenderer", "Took " + totalMilis + "ms to render");
+
+					}
+				});
+			}
+		};
+
+		thread.start();
+	}
+
+	public void stop() {
+		stopped = true;
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/image/ThumbnailScaler.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ThumbnailScaler.java
@@ -79,6 +79,27 @@ public final class ThumbnailScaler {
 		}
 	}
 
+
+	public static Bitmap scaleToFit(final Bitmap image, final int width, final int height) {
+
+		float xScale = ((float)width) / (float)image.getWidth();
+		float yScale = ((float)height) / (float)image.getHeight();
+		float smallerScale = (xScale <= yScale) ? xScale : yScale;
+
+
+		Bitmap scaled = Bitmap.createScaledBitmap(
+				image,
+				Math.round(smallerScale * image.getWidth()),
+				Math.round(smallerScale * image.getHeight()),
+				true);
+
+		if(image != scaled) {
+			image.recycle();
+		}
+
+		return scaled;
+	}
+
 	public static Bitmap scaleNoCrop(final Bitmap image, final int desiredSquareSizePx) {
 
 		final int currentSquareSizePx = Math.max(image.getWidth(), image.getHeight());

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -104,11 +104,15 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 	public long lastChange;
 
+	public int lastImageHeight;
+
 	private final boolean showSubreddit;
 
 	private RedditPostView mBoundView = null;
 
-	public enum Action {
+	private final boolean mInlineImagesPref;
+
+    public enum Action {
 		UPVOTE(R.string.action_upvote),
 		UNVOTE(R.string.action_vote_remove),
 		DOWNVOTE(R.string.action_downvote),
@@ -167,6 +171,11 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		final RedditAccount user =
 				RedditAccountManager.getInstance(context).getDefaultAccount();
 		mChangeDataManager = RedditChangeDataManager.getInstance(user);
+
+		mInlineImagesPref =
+				PrefsUtility.appearance_post_show_inline_image(context,
+						General.getSharedPrefs(context));
+		lastImageHeight = 0;
 
 		isArchived = post.isArchived();
 
@@ -1280,6 +1289,15 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			if(context != null) {
 				postListDescription = rebuildSubtitle(mBoundView.getContext());
 				mBoundView.updateAppearance();
+			}
+		}
+	}
+
+	public void notifyCached() {
+		if (mBoundView != null && mInlineImagesPref) {
+			final Context context = mBoundView.getContext();
+			if (context != null) {
+				mBoundView.updateAppearanceOnUI();
 			}
 		}
 	}

--- a/src/main/res/layout/reddit_post.xml
+++ b/src/main/res/layout/reddit_post.xml
@@ -30,108 +30,144 @@
 			android:layout_height="1px"
 			android:background="?rrListDividerCol"/>
 
-	<!-- The elements in the layout below get reversed in left-hand mode -->
 	<LinearLayout
-			android:id="@+id/reddit_post_layout"
+			android:id="@+id/reddit_post_wrapper"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:gravity="center_vertical"
-			android:background="?rrListItemBackgroundCol"
-			android:orientation="horizontal"
-			android:minHeight="64dp"
-			android:elevation="10dp"
-			android:nextFocusRight="@id/reddit_post_comments_button"
-			android:baselineAligned="false"
-			tools:ignore="UnusedAttribute">
+			android:orientation="vertical"
+			android:baselineAligned="false">
+		<TextView
+				android:id="@+id/reddit_post_title_alternate"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:textColor="?rrPostTitleCol"
+				android:paddingLeft="20dp"
+				android:paddingRight="20dp"
+				android:paddingTop="12dp"
+				android:paddingBottom="12dp"
+				android:textSize="18sp"
+				android:visibility="gone"
+				tools:visibility="visible"
+				tools:text="This is an example headline"/>
 
-		<FrameLayout
-				android:layout_width="wrap_content"
-				android:layout_height="match_parent"
+		<ImageView
+				android:id="@+id/reddit_inline_image_view"
+				android:gravity="top"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:scaleType="center"
+				android:visibility="gone"
+				android:background="?rrPostThumbnailBackground"
+				android:elevation="5dp"
+				android:minHeight="100dp"
+				tools:ignore="ContentDescription"
+				tools:visibility="visible"
+				tools:layout_height="200dp"
+				tools:src="@mipmap/icon_inv"/>
+		<!-- The elements in the layout below get reversed in left-hand mode -->
+		<LinearLayout
+				android:id="@+id/reddit_post_layout"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:gravity="center_vertical"
+				android:background="?rrListItemBackgroundCol"
+				android:orientation="horizontal"
+				android:minHeight="64dp"
+				android:elevation="10dp"
+				android:nextFocusRight="@id/reddit_post_comments_button"
 				android:baselineAligned="false"
-				android:background="?rrPostThumbnailBackground">
+				tools:ignore="UnusedAttribute">
 
-			<ImageView
-					android:id="@+id/reddit_post_thumbnail_view"
+			<FrameLayout
 					android:layout_width="wrap_content"
 					android:layout_height="match_parent"
-					android:scaleType="center"
-					tools:ignore="ContentDescription"/>
+					android:baselineAligned="false"
+					android:background="?rrPostThumbnailBackground">
 
-			<ImageView
-					android:id="@+id/reddit_post_overlay_icon"
-					android:layout_width="64dp"
-					android:layout_height="match_parent"
-					android:scaleType="center"
-					android:visibility="gone"
-					android:background="#99000000"
-					tools:ignore="ContentDescription"/>
+				<ImageView
+						android:id="@+id/reddit_post_thumbnail_view"
+						android:layout_width="wrap_content"
+						android:layout_height="match_parent"
+						android:scaleType="center"
+						tools:ignore="ContentDescription"/>
 
-		</FrameLayout>
+				<ImageView
+						android:id="@+id/reddit_post_overlay_icon"
+						android:layout_width="64dp"
+						android:layout_height="match_parent"
+						android:scaleType="center"
+						android:visibility="gone"
+						android:background="#99000000"
+						tools:ignore="ContentDescription"/>
 
-		<LinearLayout
-				android:id="@+id/reddit_post_textLayout"
-				android:layout_height="wrap_content"
-				android:layout_width="0px"
-				android:orientation="vertical"
-				android:paddingLeft="2dp"
-				android:paddingRight="2dp"
-				android:gravity="center_vertical"
-				android:layout_weight="1">
+			</FrameLayout>
 
-			<TextView
-					android:id="@+id/reddit_post_title"
-					android:layout_width="match_parent"
+			<LinearLayout
+					android:id="@+id/reddit_post_textLayout"
 					android:layout_height="wrap_content"
-					android:textColor="?rrPostTitleCol"
-					android:paddingLeft="10dp"
-					android:paddingRight="10dp"
-					android:paddingTop="5dp"
-					android:paddingBottom="0dp"
-					android:textSize="14sp"/>
-
-			<TextView
-					android:id="@+id/reddit_post_subtitle"
-					android:layout_width="match_parent"
-					android:layout_height="wrap_content"
+					android:layout_width="0px"
+					android:orientation="vertical"
+					android:paddingLeft="2dp"
+					android:paddingRight="2dp"
 					android:gravity="center_vertical"
-					android:textColor="#909090"
-					android:paddingLeft="10dp"
-					android:paddingRight="10dp"
-					android:paddingTop="1dp"
-					android:paddingBottom="5dp"
-					android:textSize="11sp"
-					tools:ignore="SmallSp"/>
+					android:layout_weight="1">
 
-		</LinearLayout>
+				<TextView
+						android:id="@+id/reddit_post_title"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:textColor="?rrPostTitleCol"
+						android:paddingLeft="10dp"
+						android:paddingRight="10dp"
+						android:paddingTop="5dp"
+						android:paddingBottom="0dp"
+						android:textSize="14sp"/>
 
-		<LinearLayout
-				android:id="@+id/reddit_post_comments_button"
-				android:layout_width="50dp"
-				android:layout_height="match_parent"
-				android:gravity="center"
-				android:background="?rrPostCommentsButtonBackCol"
-				android:orientation="vertical"
-				android:nextFocusLeft="@id/reddit_post_layout">
+				<TextView
+						android:id="@+id/reddit_post_subtitle"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:gravity="center_vertical"
+						android:textColor="#909090"
+						android:paddingLeft="10dp"
+						android:paddingRight="10dp"
+						android:paddingTop="1dp"
+						android:paddingBottom="5dp"
+						android:textSize="11sp"
+						tools:ignore="SmallSp"/>
 
-			<ImageView
-					android:layout_height="wrap_content"
-					android:layout_width="match_parent"
-					android:src="?rrIconComments"
-					android:scaleType="fitCenter"
-					android:layout_marginLeft="8dp"
-					android:layout_marginRight="8dp"
-					android:layout_marginTop="4dp"
-					android:layout_marginBottom="2dp"
-					android:contentDescription="@string/action_comments"/>
+			</LinearLayout>
 
-			<TextView
-					android:id="@+id/reddit_post_comments_text"
-					android:layout_height="wrap_content"
-					android:layout_width="fill_parent"
+			<LinearLayout
+					android:id="@+id/reddit_post_comments_button"
+					android:layout_width="50dp"
+					android:layout_height="match_parent"
 					android:gravity="center"
-					android:textSize="11sp"
-					android:textColor="?rrPostCommentsButtonTextCol"
-					tools:ignore="SmallSp"/>
+					android:background="?rrPostCommentsButtonBackCol"
+					android:orientation="vertical"
+					android:nextFocusLeft="@id/reddit_post_layout">
+
+				<ImageView
+						android:layout_height="wrap_content"
+						android:layout_width="match_parent"
+						android:src="?rrIconComments"
+						android:scaleType="fitCenter"
+						android:layout_marginLeft="8dp"
+						android:layout_marginRight="8dp"
+						android:layout_marginTop="4dp"
+						android:layout_marginBottom="2dp"
+						android:contentDescription="@string/action_comments"/>
+
+				<TextView
+						android:id="@+id/reddit_post_comments_text"
+						android:layout_height="wrap_content"
+						android:layout_width="fill_parent"
+						android:gravity="center"
+						android:textSize="11sp"
+						android:textColor="?rrPostCommentsButtonTextCol"
+						tools:ignore="SmallSp"/>
+
+			</LinearLayout>
 
 		</LinearLayout>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1371,4 +1371,8 @@
 
 	<string name="three_dots_menu">More options</string>
 
+	<!-- 2020-11-19 -->
+	<string name="pref_appearance_post_show_inline_image_title" translatable="false">Show inline images</string>
+    <string name="pref_appearance_post_show_inline_image_key" translatable="false">pref_appearance_post_show_inline_image</string>
+
 </resources>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -114,6 +114,11 @@
 				android:defaultValue="true"/>
 
 		<CheckBoxPreference
+				android:title="@string/pref_appearance_post_show_inline_image_title"
+				android:key="@string/pref_appearance_post_show_inline_image_key"
+				android:defaultValue="false"/>
+
+		<CheckBoxPreference
 				android:title="@string/pref_appearance_hide_headertoolbar_postlist_title"
 				android:key="@string/pref_appearance_hide_headertoolbar_postlist_key"
 				android:defaultValue="false"/>


### PR DESCRIPTION
Adds the option to see images inline on a post listing if they are cached. Default is off.

The images are loaded from disk and resized on a separate thread so scrolling performance isn't affected during the resize.