### PR TITLE
Add preference for minimum comment height

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -122,7 +122,9 @@ public final class PrefsUtility {
 						R.string.pref_images_inline_image_previews_nsfw_key))
 				|| key.equals(context.getString(R.string.pref_images_high_res_thumbnails_key))
 				|| key.equals(context.getString(
-						R.string.pref_accessibility_separate_body_text_lines_key));
+						R.string.pref_accessibility_separate_body_text_lines_key))
+				|| key.equals(context.getString(
+						R.string.pref_accessibility_min_comment_height_key));
 	}
 
 	public static boolean isRestartRequired(final Context context, final String key) {
@@ -2049,5 +2051,19 @@ public final class PrefsUtility {
 				false,
 				context,
 				sharedPreferences);
+	}
+
+	public static int pref_accessibility_min_comment_height(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		try {
+			return Integer.parseInt(getString(
+					R.string.pref_accessibility_min_comment_height_key,
+					"0",
+					context,
+					sharedPreferences));
+		} catch(final Throwable e) {
+			return 0;
+		}
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -143,7 +143,8 @@ public final class SettingsFragment extends PreferenceFragment {
 				R.string.pref_appearance_inbox_age_units_key,
 				R.string.pref_images_thumbnail_size_key,
 				R.string.pref_images_inline_image_previews_key,
-				R.string.pref_images_high_res_thumbnails_key
+				R.string.pref_images_high_res_thumbnails_key,
+				R.string.pref_accessibility_min_comment_height_key
 		};
 
 		final int[] editTextPrefsToUpdate = {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -287,6 +287,12 @@ public class RedditCommentView extends FlingableItemView
 		mBodyHolder = rootView.findViewById(R.id.view_reddit_comment_bodyholder);
 		mIndentedContent = rootView.findViewById(R.id.view_reddit_comment_indented_content);
 
+		final int minimumCommentHeight = PrefsUtility.pref_accessibility_min_comment_height(
+				context,
+				General.getSharedPrefs(context));
+
+		mIndentedContent.setMinimumHeight(General.dpToPixels(context, minimumCommentHeight));
+
 		mBodyFontScale = PrefsUtility.appearance_fontscale_bodytext(
 				context,
 				General.getSharedPrefs(context));

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1111,4 +1111,27 @@
 		<item>256</item>
 	</string-array>
 
+	<!-- 2021-01-25 -->
+
+	<string-array name="pref_accessibility_min_comment_height_items">
+		<item>@string/pref_accessibility_min_comment_height_none</item>
+		<item>30 dp</item>
+		<item>35 dp</item>
+		<item>40 dp</item>
+		<item>45 dp</item>
+		<item>50 dp</item>
+		<item>55 dp</item>
+	</string-array>
+
+	<!-- Constants. Do not change. -->
+	<string-array name="pref_accessibility_min_comment_height_return">
+		<item>0</item>
+		<item>30</item>
+		<item>35</item>
+		<item>40</item>
+		<item>45</item>
+		<item>50</item>
+		<item>55</item>
+	</string-array>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1444,4 +1444,9 @@
 	<!-- 2020-01-03 -->
 	<string name="action_not_handled_by_installed_app_toast">No app found to handle this action</string>
 
+	<!-- 2021-01-25 -->
+	<string name="pref_accessibility_min_comment_height_key" translatable="false">pref_accessibility_min_comment_height</string>
+	<string name="pref_accessibility_min_comment_height_title">Minimum comment height</string>
+	<string name="pref_accessibility_min_comment_height_none">None</string>
+
 </resources>

--- a/src/main/res/xml/prefs_accessibility.xml
+++ b/src/main/res/xml/prefs_accessibility.xml
@@ -24,4 +24,10 @@
 						android:key="@string/pref_accessibility_separate_body_text_lines_key"
 						android:defaultValue="false"/>
 
+	<ListPreference android:title="@string/pref_accessibility_min_comment_height_title"
+					android:key="@string/pref_accessibility_min_comment_height_key"
+					android:entries="@array/pref_accessibility_min_comment_height_items"
+					android:entryValues="@array/pref_accessibility_min_comment_height_return"
+					android:defaultValue="0"/>
+
 </PreferenceScreen>


### PR DESCRIPTION
I often tap the wrong collapsed comment when holding my phone certain ways (in my defence, I have my system UI set to small). As a result, I was inspired to add an accessibility preference to set a minimum comment height, so people who experience motor-control issues, or who are simply prone to fat-fingering, will have an easier time.

While this is mainly targeted at making collapsed comments easier to hit, this is a minimum for the whole comment; at higher levels, this will also start to affect non-collapsed comments (if they're short enough).