### PR TITLE
Add more post/comment fling actions

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -1143,7 +1143,25 @@ public final class PrefsUtility {
 	// pref_behaviour_fling_post
 
 	public enum PostFlingAction {
-		UPVOTE, DOWNVOTE, SAVE, HIDE, COMMENTS, LINK, ACTION_MENU, BROWSER, BACK, DISABLED
+		UPVOTE,
+		DOWNVOTE,
+		SAVE,
+		HIDE,
+		COMMENTS,
+		LINK,
+		ACTION_MENU,
+		BROWSER,
+		BACK,
+		REPORT,
+		SAVE_IMAGE,
+		GOTO_SUBREDDIT,
+		SHARE,
+		SHARE_COMMENTS,
+		SHARE_IMAGE,
+		COPY,
+		USER_PROFILE,
+		PROPERTIES,
+		DISABLED
 	}
 
 	public static PostFlingAction pref_behaviour_fling_post_left(
@@ -1186,7 +1204,14 @@ public final class PrefsUtility {
 		UPVOTE,
 		DOWNVOTE,
 		SAVE,
+		REPORT,
 		REPLY,
+		CONTEXT,
+		GO_TO_COMMENT,
+		COMMENT_LINKS,
+		SHARE,
+		COPY_TEXT,
+		COPY_URL,
 		USER_PROFILE,
 		COLLAPSE,
 		ACTION_MENU,

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -128,10 +128,52 @@ public class RedditCommentView extends FlingableItemView
 							R.string.action_save);
 				}
 
+			case REPORT:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.REPORT,
+						R.string.action_report
+				);
+
 			case REPLY:
 				return new ActionDescriptionPair(
 						RedditAPICommentAction.RedditCommentAction.REPLY,
 						R.string.action_reply);
+
+			case CONTEXT:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.CONTEXT,
+						R.string.action_comment_context
+				);
+
+			case GO_TO_COMMENT:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.GO_TO_COMMENT,
+						R.string.action_comment_go_to
+				);
+
+			case COMMENT_LINKS:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.COMMENT_LINKS,
+						R.string.action_comment_links
+				);
+
+			case SHARE:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.SHARE,
+						R.string.action_share
+				);
+
+			case COPY_TEXT:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.COPY_TEXT,
+						R.string.action_copy_text
+				);
+
+			case COPY_URL:
+				return new ActionDescriptionPair(
+						RedditAPICommentAction.RedditCommentAction.COPY_URL,
+						R.string.action_copy_link
+				);
 
 			case USER_PROFILE:
 				return new ActionDescriptionPair(

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -246,6 +246,60 @@ public final class RedditPostView extends FlingableItemView
 						RedditPreparedPost.Action.EXTERNAL,
 						R.string.action_external_short);
 
+			case REPORT:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.REPORT,
+						R.string.action_report
+				);
+
+			case SAVE_IMAGE:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.SAVE_IMAGE,
+						R.string.action_save_image
+				);
+
+			case GOTO_SUBREDDIT:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.GOTO_SUBREDDIT,
+						R.string.action_gotosubreddit
+				);
+
+			case SHARE:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.SHARE,
+						R.string.action_share
+				);
+
+			case SHARE_COMMENTS:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.SHARE_COMMENTS,
+						R.string.action_share_comments
+				);
+
+			case SHARE_IMAGE:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.SHARE_IMAGE,
+						R.string.action_share_image
+				);
+
+			case COPY:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.COPY,
+						R.string.action_copy_link
+				);
+
+			case USER_PROFILE:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.USER_PROFILE,
+						R.string.action_user_profile_short
+				);
+
+			case PROPERTIES:
+				return new ActionDescriptionPair(
+						RedditPreparedPost.Action.PROPERTIES,
+						R.string.action_properties
+				);
+
 			case ACTION_MENU:
 				return new ActionDescriptionPair(
 						RedditPreparedPost.Action.ACTION_MENU,

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -39,6 +39,15 @@
         <item>@string/action_comments</item>
         <item>@string/action_link</item>
         <item>@string/action_external</item>
+        <item>@string/action_report</item>
+        <item>@string/action_save_image</item>
+        <item>@string/action_gotosubreddit</item>
+        <item>@string/action_share</item>
+        <item>@string/action_share_comments</item>
+        <item>@string/action_share_image</item>
+        <item>@string/action_copy_link</item>
+        <item>@string/action_user_profile</item>
+        <item>@string/action_properties</item>
         <item>@string/action_actionmenu</item>
 		<item>@string/action_back</item>
         <item>@string/action_fling_disabled</item>
@@ -53,6 +62,15 @@
         <item>comments</item>
         <item>link</item>
         <item>browser</item>
+        <item>report</item>
+        <item>save_image</item>
+        <item>goto_subreddit</item>
+        <item>share</item>
+        <item>share_comments</item>
+        <item>share_image</item>
+        <item>copy</item>
+        <item>user_profile</item>
+        <item>properties</item>
         <item>action_menu</item>
 		<item>back</item>
         <item>disabled</item>
@@ -73,7 +91,14 @@
 		<item>@string/action_upvote</item>
 		<item>@string/action_downvote</item>
 		<item>@string/action_save</item>
+		<item>@string/action_report</item>
 		<item>@string/action_reply</item>
+		<item>@string/action_comment_context</item>
+		<item>@string/action_comment_go_to</item>
+		<item>@string/action_comment_links</item>
+		<item>@string/action_share</item>
+		<item>@string/action_copy_text</item>
+		<item>@string/action_copy_link</item>
 		<item>@string/action_user_profile</item>
 		<item>@string/action_collapse</item>
 		<item>@string/action_properties</item>
@@ -87,7 +112,14 @@
 		<item>upvote</item>
 		<item>downvote</item>
 		<item>save</item>
+		<item>report</item>
 		<item>reply</item>
+		<item>context</item>
+		<item>go_to_comment</item>
+		<item>comment_links</item>
+		<item>share</item>
+		<item>copy_text</item>
+		<item>copy_url</item>
 		<item>user_profile</item>
 		<item>collapse</item>
 		<item>properties</item>


### PR DESCRIPTION
I noticed that several actions for posts and comments available through the action menu aren't available as quickly-accessible fling actions. This adds many of those actions as options for that.

I included every action I felt could plausibly be used widely and regularly; actions that are for subreddit management (subscribing, pinning, or blocking subs), only applicable to user posts/comments (editing, deleting), or only applicable to self-text (since you can't see the self-text without opening it) were not added.