### PR TITLE
Do not close loading images when tapped

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -361,6 +361,10 @@ public class ImageViewActivity extends BaseActivity
 			}
 
 			backButton.setOnClickListener(v -> finish());
+
+			//Consume & ignore touch events, so loading images aren't closed by tapping.
+			//noinspection ClickableViewAccessibility
+			backButton.setOnTouchListener((v, event) -> true);
 		}
 
 		final FrameLayout outerFrame = new FrameLayout(this);


### PR DESCRIPTION
This prevents loading images from being closed by touching the screen. I've tested this with TalkBack and it doesn't seem to affect the behavior there, although it might be a good idea to double-check.

Closes #819.