### PR TITLE
Always show scrollbar when scrolling

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/views/ScrollbarRecyclerViewManager.java
+++ b/src/main/java/org/quantumbadger/redreader/views/ScrollbarRecyclerViewManager.java
@@ -103,9 +103,8 @@ public class ScrollbarRecyclerViewManager {
 						hideScrollbar();
 						break;
 					case RecyclerView.SCROLL_STATE_DRAGGING:
-						showScrollbar();
-						break;
 					case RecyclerView.SCROLL_STATE_SETTLING:
+						showScrollbar();
 						break;
 				}
 


### PR DESCRIPTION
It turns out that scrolling with non-touchscreen methods will never result in `SCROLL_STATE_DRAGGING` and go straight to `SCROLL_STATE_SETTLING` (for the methods I tested, at least). I suppose that makes sense - when using, for instance, a D-Pad, the RecyclerView is never "currently being dragged by outside input", since you scroll immediately upon pressing the button.

The simple solution is to also show the scrollbar when in the SETTLING state. This does not seem to affect the animation when scrolling with the touchscreen.

Closes #746.