### PR TITLE
Disable certain logging in release builds

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/AlbumListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/AlbumListingActivity.java
@@ -65,7 +65,9 @@ public class AlbumListingActivity extends BaseActivity {
 			return;
 		}
 
-		Log.i("AlbumListingActivity", "Loading URL " + mUrl);
+		if(General.isSensitiveDebugLoggingEnabled()) {
+			Log.i("AlbumListingActivity", "Loading URL " + mUrl);
+		}
 
 		final ProgressBar progressBar = new ProgressBar(
 				this,
@@ -203,9 +205,11 @@ public class AlbumListingActivity extends BaseActivity {
 
 					@Override
 					public void onSuccess(@NonNull final AlbumInfo info) {
-						Log.i(
-								"AlbumListingActivity",
-								"Got album, " + info.images.size() + " image(s)");
+						if(General.isSensitiveDebugLoggingEnabled()) {
+							Log.i(
+									"AlbumListingActivity",
+									"Got album, " + info.images.size() + " image(s)");
+						}
 
 						AndroidCommon.UI_THREAD_HANDLER.post(() -> {
 

--- a/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
@@ -163,10 +163,12 @@ public class AlbumAdapter extends RecyclerView.Adapter<VH3TextIcon> {
 								@Nullable final Integer httpStatus,
 								@Nullable final String readableMessage) {
 
-							Log.e(
-									"AlbumAdapter",
-									"Failed to fetch thumbnail " + imageInfo.urlBigSquare,
-									t);
+							if(General.isSensitiveDebugLoggingEnabled()) {
+								Log.e(
+										"AlbumAdapter",
+										"Failed to fetch thumbnail " + imageInfo.urlBigSquare,
+										t);
+							}
 						}
 
 						@Override

--- a/src/main/java/org/quantumbadger/redreader/common/General.java
+++ b/src/main/java/org/quantumbadger/redreader/common/General.java
@@ -39,6 +39,8 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
+import org.quantumbadger.redreader.BuildConfig;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.BugReportActivity;
 import org.quantumbadger.redreader.cache.CacheRequest;
@@ -161,6 +163,10 @@ public final class General {
 				TypedValue.COMPLEX_UNIT_SP,
 				sp,
 				context.getResources().getDisplayMetrics()));
+	}
+
+	public static boolean isSensitiveDebugLoggingEnabled() {
+		return BuildConfig.DEBUG;
 	}
 
 	public static void quickToast(final Context context, final int textRes) {

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -690,7 +690,9 @@ public class LinkHandler {
 			final boolean returnUrlOnFailure,
 			final GetImageInfoListener listener) {
 
-		Log.i("getImgurImageInfo", "Image " + imgId + ": trying API v3 with auth");
+		if(General.isSensitiveDebugLoggingEnabled()) {
+			Log.i("getImgurImageInfo", "Image " + imgId + ": trying API v3 with auth");
+		}
 
 		ImgurAPIV3.getImageInfo(
 				context,
@@ -705,9 +707,11 @@ public class LinkHandler {
 							final Integer status,
 							final String readableMessage) {
 
-						Log.i(
-								"getImgurImageInfo",
-								"Image " + imgId + ": trying API v3 without auth");
+						if(General.isSensitiveDebugLoggingEnabled()) {
+							Log.i(
+									"getImgurImageInfo",
+									"Image " + imgId + ": trying API v3 without auth");
+						}
 
 						ImgurAPIV3.getImageInfo(
 								context,
@@ -722,9 +726,11 @@ public class LinkHandler {
 											final Integer status,
 											final String readableMessage) {
 
-										Log.i(
-												"getImgurImageInfo",
-												"Image " + imgId + ": trying API v2");
+										if(General.isSensitiveDebugLoggingEnabled()) {
+											Log.i(
+													"getImgurImageInfo",
+													"Image " + imgId + ": trying API v2");
+										}
 
 										ImgurAPI.getImageInfo(
 												context,
@@ -805,7 +811,9 @@ public class LinkHandler {
 			@NonNull final Priority priority,
 			final GetAlbumInfoListener listener) {
 
-		Log.i("getImgurAlbumInfo", "Album " + albumId + ": trying API v3 with auth");
+		if(General.isSensitiveDebugLoggingEnabled()) {
+			Log.i("getImgurAlbumInfo", "Album " + albumId + ": trying API v3 with auth");
+		}
 
 		ImgurAPIV3.getAlbumInfo(
 				context,
@@ -821,9 +829,11 @@ public class LinkHandler {
 							final Integer status,
 							final String readableMessage) {
 
-						Log.i(
-								"getImgurAlbumInfo",
-								"Album " + albumId + ": trying API v3 without auth");
+						if(General.isSensitiveDebugLoggingEnabled()) {
+							Log.i(
+									"getImgurAlbumInfo",
+									"Album " + albumId + ": trying API v3 without auth");
+						}
 
 						ImgurAPIV3.getAlbumInfo(
 								context,
@@ -839,9 +849,11 @@ public class LinkHandler {
 											final Integer status,
 											final String readableMessage) {
 
-										Log.i(
-												"getImgurAlbumInfo",
-												"Album " + albumId + ": trying API v2");
+										if(General.isSensitiveDebugLoggingEnabled()) {
+											Log.i(
+													"getImgurAlbumInfo",
+													"Album " + albumId + ": trying API v2");
+										}
 
 										ImgurAPI.getAlbumInfo(
 												context,

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -978,7 +978,9 @@ public class PostListingFragment extends RRFragment
 		final URI url = General.uriFromString(controller.getUri().toString());
 
 		if(url == null) {
-			Log.i(TAG, String.format("Not precaching '%s': failed to parse URL", url));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(TAG, String.format("Not precaching '%s': failed to parse URL", url));
+			}
 			return;
 		}
 
@@ -1004,13 +1006,15 @@ public class PostListingFragment extends RRFragment
 									@Nullable final Integer httpStatus,
 									@Nullable final String readableMessage) {
 
-								Log.e(
-										TAG,
-										"Failed to precache "
-												+ url.toString()
-												+ "(RequestFailureType code: "
-												+ type
-												+ ")");
+								if(General.isSensitiveDebugLoggingEnabled()) {
+									Log.e(
+											TAG,
+											"Failed to precache "
+													+ url.toString()
+													+ "(RequestFailureType code: "
+													+ type
+													+ ")");
+								}
 							}
 
 							@Override
@@ -1037,10 +1041,12 @@ public class PostListingFragment extends RRFragment
 		// Don't precache huge images
 		if(info.size != null
 				&& info.size > 15 * 1024 * 1024) {
-			Log.i(TAG, String.format(
-					"Not precaching '%s': too big (%d kB)",
-					info.urlOriginal,
-					info.size / 1024));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(TAG, String.format(
+						"Not precaching '%s': too big (%d kB)",
+						info.urlOriginal,
+						info.size / 1024));
+			}
 			return;
 		}
 
@@ -1048,9 +1054,11 @@ public class PostListingFragment extends RRFragment
 		if(ImageInfo.MediaType.GIF.equals(info.mediaType)
 				&& !gifViewMode.downloadInApp) {
 
-			Log.i(TAG, String.format(
-					"Not precaching '%s': GIFs opened externally",
-					info.urlOriginal));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(TAG, String.format(
+						"Not precaching '%s': GIFs opened externally",
+						info.urlOriginal));
+			}
 			return;
 		}
 
@@ -1058,9 +1066,11 @@ public class PostListingFragment extends RRFragment
 		if(ImageInfo.MediaType.IMAGE.equals(info.mediaType)
 				&& !imageViewMode.downloadInApp) {
 
-			Log.i(TAG, String.format(
-					"Not precaching '%s': images opened externally",
-					info.urlOriginal));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(TAG, String.format(
+						"Not precaching '%s': images opened externally",
+						info.urlOriginal));
+			}
 			return;
 		}
 
@@ -1069,9 +1079,11 @@ public class PostListingFragment extends RRFragment
 		if(ImageInfo.MediaType.VIDEO.equals(info.mediaType)
 				&& !videoViewMode.downloadInApp) {
 
-			Log.i(TAG, String.format(
-					"Not precaching '%s': videos opened externally",
-					info.urlOriginal));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(TAG, String.format(
+						"Not precaching '%s': videos opened externally",
+						info.urlOriginal));
+			}
 			return;
 		}
 
@@ -1095,7 +1107,9 @@ public class PostListingFragment extends RRFragment
 
 		final URI uri = General.uriFromString(url);
 		if(uri == null) {
-			Log.i(TAG, String.format("Not precaching '%s': failed to parse URL", url));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(TAG, String.format("Not precaching '%s': failed to parse URL", url));
+			}
 			return;
 		}
 
@@ -1118,14 +1132,16 @@ public class PostListingFragment extends RRFragment
 							@Nullable final Integer httpStatus,
 							@Nullable final String readableMessage) {
 
-						Log.e(TAG, String.format(
-								Locale.US,
-								"Failed to precache %s (RequestFailureType %d,"
-										+ " status %s, readable '%s')",
-								url,
-								type,
-								httpStatus == null ? "NULL" : httpStatus.toString(),
-								readableMessage == null ? "NULL" : readableMessage));
+						if(General.isSensitiveDebugLoggingEnabled()) {
+							Log.e(TAG, String.format(
+									Locale.US,
+									"Failed to precache %s (RequestFailureType %d,"
+											+ " status %s, readable '%s')",
+									url,
+									type,
+									httpStatus == null ? "NULL" : httpStatus.toString(),
+									readableMessage == null ? "NULL" : readableMessage));
+						}
 					}
 
 					@Override

--- a/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
@@ -32,6 +32,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.common.Constants;
+import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.TorCommon;
 import org.quantumbadger.redreader.http.HTTPBackend;
 
@@ -167,7 +168,9 @@ public class OKHTTPBackend extends HTTPBackend {
 					response = call.execute();
 				} catch(final Exception e) {
 					listener.onError(CacheRequest.REQUEST_FAILURE_CONNECTION, e, null);
-					Log.i(TAG, "request didn't even connect: " + e.getMessage());
+					if(General.isSensitiveDebugLoggingEnabled()) {
+						Log.i(TAG, "request didn't even connect: " + e.getMessage());
+					}
 					return;
 				}
 
@@ -197,11 +200,13 @@ public class OKHTTPBackend extends HTTPBackend {
 
 				} else {
 
-					Log.e(TAG, String.format(
-							Locale.US,
-							"Got HTTP error %d for %s",
-							status,
-							details.toString()));
+					if(General.isSensitiveDebugLoggingEnabled()) {
+						Log.e(TAG, String.format(
+								Locale.US,
+								"Got HTTP error %d for %s",
+								status,
+								details.toString()));
+					}
 
 					listener.onError(CacheRequest.REQUEST_FAILURE_REQUEST, null, status);
 				}

--- a/src/main/java/org/quantumbadger/redreader/receivers/NewMessageChecker.java
+++ b/src/main/java/org/quantumbadger/redreader/receivers/NewMessageChecker.java
@@ -127,7 +127,9 @@ public class NewMessageChecker extends BroadcastReceiver {
 
 							final int messageCount = children.size();
 
-							Log.e(TAG, "Got response. Message count = " + messageCount);
+							if(General.isSensitiveDebugLoggingEnabled()) {
+								Log.i(TAG, "Got response. Message count = " + messageCount);
+							}
 
 							if(messageCount < 1) {
 								return;

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
@@ -108,13 +108,15 @@ public final class RedditChangeDataManager {
 				entry.getValue().writeTo(dos);
 			}
 
-			Log.i(
-					TAG,
-					String.format(
-							Locale.US,
-							"Wrote %d entries for user '%s'",
-							entrySet.size(),
-							username));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(
+						TAG,
+						String.format(
+								Locale.US,
+								"Wrote %d entries for user '%s'",
+								entrySet.size(),
+								username));
+			}
 		}
 
 		Log.i(TAG, "All entries written to stream.");
@@ -135,13 +137,15 @@ public final class RedditChangeDataManager {
 			final String username = dis.readUTF();
 			final int entryCount = dis.readInt();
 
-			Log.i(
-					TAG,
-					String.format(
-							Locale.US,
-							"Reading %d entries for user '%s'",
-							entryCount,
-							username));
+			if(General.isSensitiveDebugLoggingEnabled()) {
+				Log.i(
+						TAG,
+						String.format(
+								Locale.US,
+								"Reading %d entries for user '%s'",
+								entryCount,
+								username));
+			}
 
 			final HashMap<String, Entry> entries = new HashMap<>(entryCount);
 
@@ -157,21 +161,25 @@ public final class RedditChangeDataManager {
 					RedditAccountManager.getInstance(context).getAccount(username);
 
 			if(account == null) {
-				Log.i(
-						TAG,
-						String.format(
-								Locale.US,
-								"Skipping user '%s' as the account no longer exists",
-								username));
+				if(General.isSensitiveDebugLoggingEnabled()) {
+					Log.i(
+							TAG,
+							String.format(
+									Locale.US,
+									"Skipping user '%s' as the account no longer exists",
+									username));
+				}
 
 			} else {
 				getInstance(account).insertAll(entries);
-				Log.i(
-						TAG,
-						String.format(
-								Locale.US,
-								"Finished inserting entries for user '%s'",
-								username));
+				if(General.isSensitiveDebugLoggingEnabled()) {
+					Log.i(
+							TAG,
+							String.format(
+									Locale.US,
+									"Finished inserting entries for user '%s'",
+									username));
+				}
 			}
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1355,13 +1355,15 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 							@Nullable final Integer httpStatus,
 							@Nullable final String readableMessage) {
 
-						Log.e(
-								TAG,
-								"Failed to download thumbnail "
-										+ uriStr
-										+ " with status "
-										+ httpStatus,
-								t);
+						if(General.isSensitiveDebugLoggingEnabled()) {
+							Log.e(
+									TAG,
+									"Failed to download thumbnail "
+											+ uriStr
+											+ " with status "
+											+ httpStatus,
+									t);
+						}
 					}
 				}));
 	}


### PR DESCRIPTION
This disables all logs mentioned [here](https://github.com/QuantumBadger/RedReader/issues/851#issuecomment-792227147) in release builds. I also corrected a log in `NewMessageChecker` that was set to ERROR instead of INFO.

Closes #851.