### PR TITLE
Add ability to view sent messages

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -425,9 +425,16 @@ public class MainActivity extends RefreshableActivity
 				startActivity(new Intent(this, InboxListingActivity.class));
 				break;
 
+			case MainMenuFragment.MENU_MENU_ACTION_SENT_MESSAGES: {
+				final Intent intent = new Intent(this, InboxListingActivity.class);
+				intent.putExtra("inboxType", "sent");
+				startActivity(intent);
+				break;
+			}
+
 			case MainMenuFragment.MENU_MENU_ACTION_MODMAIL: {
 				final Intent intent = new Intent(this, InboxListingActivity.class);
-				intent.putExtra("modmail", true);
+				intent.putExtra("inboxType", "modmail");
 				startActivity(intent);
 				break;
 			}

--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -138,6 +138,7 @@ public class MainMenuListingManager {
 
 		final Drawable rrIconPerson;
 		final Drawable rrIconEnvOpen;
+		final Drawable rrIconSentMessages;
 		final Drawable rrIconSend;
 		final Drawable rrIconStarFilled;
 		final Drawable rrIconCross;
@@ -148,6 +149,7 @@ public class MainMenuListingManager {
 			final TypedArray attr = activity.obtainStyledAttributes(new int[] {
 					R.attr.rrIconPerson,
 					R.attr.rrIconEnvOpen,
+					R.attr.rrIconSentMessages,
 					R.attr.rrIconSend,
 					R.attr.rrIconStarFilled,
 					R.attr.rrIconCross,
@@ -157,15 +159,16 @@ public class MainMenuListingManager {
 
 			rrIconPerson = ContextCompat.getDrawable(activity, attr.getResourceId(0, 0));
 			rrIconEnvOpen = ContextCompat.getDrawable(activity, attr.getResourceId(1, 0));
-			rrIconSend = ContextCompat.getDrawable(activity, attr.getResourceId(2, 0));
+			rrIconSentMessages = ContextCompat.getDrawable(activity, attr.getResourceId(2,0));
+			rrIconSend = ContextCompat.getDrawable(activity, attr.getResourceId(3, 0));
 			rrIconStarFilled = ContextCompat.getDrawable(
 					activity,
-					attr.getResourceId(3, 0));
-			rrIconCross = ContextCompat.getDrawable(activity, attr.getResourceId(4, 0));
-			rrIconUpvote = ContextCompat.getDrawable(activity, attr.getResourceId(5, 0));
+					attr.getResourceId(4, 0));
+			rrIconCross = ContextCompat.getDrawable(activity, attr.getResourceId(5, 0));
+			rrIconUpvote = ContextCompat.getDrawable(activity, attr.getResourceId(6, 0));
 			rrIconDownvote = ContextCompat.getDrawable(
 					activity,
-					attr.getResourceId(6, 0));
+					attr.getResourceId(7, 0));
 
 			attr.recycle();
 		}
@@ -288,6 +291,16 @@ public class MainMenuListingManager {
 									R.string.mainmenu_inbox,
 									MainMenuFragment.MENU_MENU_ACTION_INBOX,
 									rrIconEnvOpen,
+									isFirst.getAndSet(false)));
+				}
+
+				if(mainMenuUserItems.contains(MainMenuFragment.MainMenuUserItems.SENT_MESSAGES)) {
+					mAdapter.appendToGroup(
+							GROUP_USER_ITEMS,
+							makeItem(
+									R.string.mainmenu_sent_messages,
+									MainMenuFragment.MENU_MENU_ACTION_SENT_MESSAGES,
+									rrIconSentMessages,
 									isFirst.getAndSet(false)));
 				}
 

--- a/src/main/java/org/quantumbadger/redreader/fragments/MainMenuFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/MainMenuFragment.java
@@ -68,6 +68,7 @@ public class MainMenuFragment extends RRFragment implements
 	public static final int MENU_MENU_ACTION_POPULAR = 11;
 	public static final int MENU_MENU_ACTION_RANDOM = 12;
 	public static final int MENU_MENU_ACTION_RANDOM_NSFW = 13;
+	public static final int MENU_MENU_ACTION_SENT_MESSAGES = 14;
 
 	@IntDef({
 			MENU_MENU_ACTION_FRONTPAGE,
@@ -83,7 +84,8 @@ public class MainMenuFragment extends RRFragment implements
 			MENU_MENU_ACTION_ALL,
 			MENU_MENU_ACTION_POPULAR,
 			MENU_MENU_ACTION_RANDOM,
-			MENU_MENU_ACTION_RANDOM_NSFW})
+			MENU_MENU_ACTION_RANDOM_NSFW,
+			MENU_MENU_ACTION_SENT_MESSAGES})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface MainMenuAction {
 	}
@@ -203,7 +205,7 @@ public class MainMenuFragment extends RRFragment implements
 	}
 
 	public enum MainMenuUserItems {
-		PROFILE, INBOX, SUBMITTED, SAVED, HIDDEN, UPVOTED, DOWNVOTED, MODMAIL
+		PROFILE, INBOX, SUBMITTED, SAVED, HIDDEN, UPVOTED, DOWNVOTED, MODMAIL, SENT_MESSAGES
 	}
 
 	public enum MainMenuShortcutItems {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedMessage.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedMessage.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import org.apache.commons.text.StringEscapeUtils;
 import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.activities.BaseActivity;
 import org.quantumbadger.redreader.activities.CommentReplyActivity;
 import org.quantumbadger.redreader.common.BetterSSB;
@@ -37,6 +38,7 @@ import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRThemeAttributes;
 import org.quantumbadger.redreader.common.RRTime;
 import org.quantumbadger.redreader.common.ScreenreaderPronunciation;
+import org.quantumbadger.redreader.common.StringUtils;
 import org.quantumbadger.redreader.reddit.prepared.bodytext.BodyElement;
 import org.quantumbadger.redreader.reddit.prepared.html.HtmlReader;
 import org.quantumbadger.redreader.reddit.things.RedditMessage;
@@ -132,12 +134,17 @@ public final class RedditPreparedMessage implements RedditRenderableInboxItem {
 
 	@Override
 	public void handleInboxClick(final BaseActivity activity) {
-		openReplyActivity(activity);
+		final String currentCanonicalUserName = RedditAccountManager.getInstance(activity)
+				.getDefaultAccount().getCanonicalUsername();
+
+		if(!StringUtils.asciiLowercase(src.author.trim()).equals(currentCanonicalUserName)) {
+			openReplyActivity(activity);
+		}
 	}
 
 	@Override
 	public void handleInboxLongClick(final BaseActivity activity) {
-		openReplyActivity(activity);
+		handleInboxClick(activity);
 	}
 
 	@Override

--- a/src/main/res/drawable/ic_action_sent_messages_dark.xml
+++ b/src/main/res/drawable/ic_action_sent_messages_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+		android:width="24dp"
+		android:height="24dp"
+		android:viewportWidth="24"
+		android:viewportHeight="24">
+	<path
+		android:fillColor="#FFFFFFFF"
+		android:pathData="M13 17H17V14L22 18.5L17 23V20H13V17M20 4H4A2 2 0 0 0 2 6V18A2 2 0 0 0 4 20H11.35A5.8 5.8 0 0 1 11 18A6 6 0 0 1 22 14.69V6A2 2 0 0 0 20 4M20 8L12 13L4 8V6L12 11L20 6Z" />
+</vector>

--- a/src/main/res/drawable/ic_action_sent_messages_light.xml
+++ b/src/main/res/drawable/ic_action_sent_messages_light.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+		android:width="24dp"
+		android:height="24dp"
+		android:viewportWidth="24"
+		android:viewportHeight="24">
+	<path
+		android:fillColor="#89000000"
+		android:pathData="M13 17H17V14L22 18.5L17 23V20H13V17M20 4H4A2 2 0 0 0 2 6V18A2 2 0 0 0 4 20H11.35A5.8 5.8 0 0 1 11 18A6 6 0 0 1 22 14.69V6A2 2 0 0 0 20 4M20 8L12 13L4 8V6L12 11L20 6Z" />
+</vector>

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -615,7 +615,7 @@
     <string-array name="pref_menus_mainmenu_useritems_items">
         <item>@string/mainmenu_profile</item>
         <item>@string/mainmenu_inbox</item>
-		<item>@string/mainmenu_sent_messages</item>
+        <item>@string/mainmenu_sent_messages</item>
         <item>@string/mainmenu_submitted</item>
         <item>@string/mainmenu_saved</item>
         <item>@string/mainmenu_hidden</item>
@@ -628,7 +628,7 @@
     <string-array name="pref_menus_mainmenu_useritems_items_return">
         <item>profile</item>
         <item>inbox</item>
-		<item>sent_messages</item>
+        <item>sent_messages</item>
         <item>submitted</item>
         <item>saved</item>
         <item>hidden</item>

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -615,6 +615,7 @@
     <string-array name="pref_menus_mainmenu_useritems_items">
         <item>@string/mainmenu_profile</item>
         <item>@string/mainmenu_inbox</item>
+		<item>@string/mainmenu_sent_messages</item>
         <item>@string/mainmenu_submitted</item>
         <item>@string/mainmenu_saved</item>
         <item>@string/mainmenu_hidden</item>
@@ -627,6 +628,7 @@
     <string-array name="pref_menus_mainmenu_useritems_items_return">
         <item>profile</item>
         <item>inbox</item>
+		<item>sent_messages</item>
         <item>submitted</item>
         <item>saved</item>
         <item>hidden</item>

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -77,6 +77,7 @@
     <attr name="rrIconAdd" format="reference" />
     <attr name="rrIconCross" format="reference" />
     <attr name="rrIconEnvOpen" format="reference" />
+	<attr name="rrIconSentMessages" format="reference" />
     <attr name="rrIconInfo" format="reference" />
     <attr name="rrIconRefresh" format="reference" />
     <attr name="rrIconReply" format="reference" />

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -77,7 +77,7 @@
     <attr name="rrIconAdd" format="reference" />
     <attr name="rrIconCross" format="reference" />
     <attr name="rrIconEnvOpen" format="reference" />
-	<attr name="rrIconSentMessages" format="reference" />
+    <attr name="rrIconSentMessages" format="reference" />
     <attr name="rrIconInfo" format="reference" />
     <attr name="rrIconRefresh" format="reference" />
     <attr name="rrIconReply" format="reference" />

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1454,4 +1454,7 @@
 	<string name="pref_menus_comment_context_items_key" translatable="false">pref_menus_comment_context_items</string>
 	<string name="pref_menus_comment_context_items_title">Action menu items</string>
 
+	<!-- 2021-03-16 -->
+	<string name="mainmenu_sent_messages">Sent Messages</string>
+
 </resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -94,6 +94,7 @@
         <item name="rrIconAdd">@drawable/ic_action_add_dark</item>
         <item name="rrIconCross">@drawable/ic_action_cross_dark</item>
         <item name="rrIconEnvOpen">@drawable/ic_action_env_open_dark</item>
+		<item name="rrIconSentMessages">@drawable/ic_action_sent_messages_dark</item>
         <item name="rrIconInfo">@drawable/ic_action_info_dark</item>
         <item name="rrIconRefresh">@drawable/ic_refresh_dark</item>
         <item name="rrIconReply">@drawable/ic_action_reply_dark</item>
@@ -345,6 +346,7 @@
         <item name="rrIconAdd">@drawable/ic_action_add_light</item>
         <item name="rrIconCross">@drawable/ic_action_cross_light</item>
         <item name="rrIconEnvOpen">@drawable/ic_action_env_open_light</item>
+		<item name="rrIconSentMessages">@drawable/ic_action_sent_messages_light</item>
         <item name="rrIconInfo">@drawable/ic_action_info_light</item>
         <item name="rrIconRefresh">@drawable/ic_refresh_light</item>
         <item name="rrIconReply">@drawable/ic_action_reply_light</item>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -94,7 +94,7 @@
         <item name="rrIconAdd">@drawable/ic_action_add_dark</item>
         <item name="rrIconCross">@drawable/ic_action_cross_dark</item>
         <item name="rrIconEnvOpen">@drawable/ic_action_env_open_dark</item>
-		<item name="rrIconSentMessages">@drawable/ic_action_sent_messages_dark</item>
+        <item name="rrIconSentMessages">@drawable/ic_action_sent_messages_dark</item>
         <item name="rrIconInfo">@drawable/ic_action_info_dark</item>
         <item name="rrIconRefresh">@drawable/ic_refresh_dark</item>
         <item name="rrIconReply">@drawable/ic_action_reply_dark</item>
@@ -346,7 +346,7 @@
         <item name="rrIconAdd">@drawable/ic_action_add_light</item>
         <item name="rrIconCross">@drawable/ic_action_cross_light</item>
         <item name="rrIconEnvOpen">@drawable/ic_action_env_open_light</item>
-		<item name="rrIconSentMessages">@drawable/ic_action_sent_messages_light</item>
+        <item name="rrIconSentMessages">@drawable/ic_action_sent_messages_light</item>
         <item name="rrIconInfo">@drawable/ic_action_info_light</item>
         <item name="rrIconRefresh">@drawable/ic_refresh_light</item>
         <item name="rrIconReply">@drawable/ic_action_reply_light</item>


### PR DESCRIPTION
Decided to implement this. I was unable to fully test if Modmail still works correctly since I'm not a moderator of any subreddit, so be sure to check that. I have *not* set this to appear in the **User items** by default, but I think it probably should be there for easy discovery, and I can make it so if desired.

I used email-send by Michael Richins from [Material Design Icons](https://materialdesignicons.com/) for the menu icon.

Closes #346.