### PR TITLE
Add content descriptions for media buttons

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/ImageViewActivity.java
@@ -40,8 +40,11 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.annotation.UiThread;
 import com.github.lzyzsd.circleprogress.DonutProgress;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
@@ -471,6 +474,7 @@ public class ImageViewActivity extends BaseActivity
 
 				AndroidCommon.UI_THREAD_HANDLER.post(() -> addFloatingToolbarButton(
 						R.drawable.ic_action_info_dark,
+						R.string.props_image_title,
 						view -> ImageInfoDialog.newInstance(mImageInfo).show(
 								getSupportFragmentManager(),
 								null)));
@@ -1105,7 +1109,8 @@ public class ImageViewActivity extends BaseActivity
 
 	@Nullable
 	private ImageButton addFloatingToolbarButton(
-			final int drawable,
+			@DrawableRes final int drawable,
+			@StringRes final int description,
 			@NonNull final View.OnClickListener listener) {
 
 		if(mFloatingToolbar == null) {
@@ -1122,6 +1127,7 @@ public class ImageViewActivity extends BaseActivity
 		final int buttonPadding = General.dpToPixels(this, 10);
 		ib.setPadding(buttonPadding, buttonPadding, buttonPadding, buttonPadding);
 		ib.setImageResource(drawable);
+		ib.setContentDescription(getResources().getString(description));
 
 		ib.setOnClickListener(listener);
 
@@ -1229,15 +1235,20 @@ public class ImageViewActivity extends BaseActivity
 						= new AtomicReference<>();
 				muteButton.set(addFloatingToolbarButton(
 						muteByDefault ? iconMuted : iconUnmuted,
+						muteByDefault ? R.string.video_unmute : R.string.video_mute,
 						view -> {
 							final ImageButton button = muteButton.get();
 
 							if(mVideoPlayerWrapper.isMuted()) {
 								mVideoPlayerWrapper.setMuted(false);
 								button.setImageResource(iconUnmuted);
+								button.setContentDescription(
+										getResources().getString(R.string.video_mute));
 							} else {
 								mVideoPlayerWrapper.setMuted(true);
 								button.setImageResource(iconMuted);
+								button.setContentDescription(
+										getResources().getString(R.string.video_unmute));
 							}
 						}));
 			}

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -31,6 +31,8 @@ import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.Player;
@@ -134,6 +136,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 					context,
 					mControlView,
 					R.drawable.exo_controls_previous,
+					R.string.video_restart,
 					view -> {
 						mVideoPlayer.seekTo(0);
 						updateProgress();
@@ -143,6 +146,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 					context,
 					mControlView,
 					R.drawable.exo_controls_rewind,
+					R.string.video_rewind,
 					view -> {
 						mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - 3000);
 						updateProgress();
@@ -155,15 +159,20 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						context,
 						mControlView,
 						R.drawable.exo_controls_pause,
+						R.string.video_pause,
 						view -> {
 							mVideoPlayer.setPlayWhenReady(!mVideoPlayer.getPlayWhenReady());
 
 							if(mVideoPlayer.getPlayWhenReady()) {
 								playButton.get()
 										.setImageResource(R.drawable.exo_controls_pause);
+								playButton.get().setContentDescription(
+										context.getString(R.string.video_pause));
 							} else {
 								playButton.get()
 										.setImageResource(R.drawable.exo_controls_play);
+								playButton.get().setContentDescription(
+										context.getString(R.string.video_play));
 							}
 
 							updateProgress();
@@ -176,6 +185,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 					context,
 					mControlView,
 					R.drawable.exo_controls_fastforward,
+					R.string.video_fast_forward,
 					view -> {
 						mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + 3000);
 						updateProgress();
@@ -188,21 +198,28 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						context,
 						mControlView,
 						R.drawable.ic_zoom_in_dark,
+						R.string.video_zoom_in,
 						v -> {
 							if (videoPlayerView.getResizeMode()
 									== AspectRatioFrameLayout.RESIZE_MODE_FIT) {
 								videoPlayerView.setResizeMode(
 										AspectRatioFrameLayout.RESIZE_MODE_ZOOM);
 								zoomButton.get().setImageResource(R.drawable.ic_zoom_out_dark);
+								zoomButton.get().setContentDescription(
+										context.getString(R.string.video_zoom_out));
 							} else {
 								videoPlayerView.setResizeMode(
 										AspectRatioFrameLayout.RESIZE_MODE_FIT);
 								zoomButton.get().setImageResource(R.drawable.ic_zoom_in_dark);
+								zoomButton.get().setContentDescription(
+										context.getString(R.string.video_zoom_in));
 							}
 						}));
 
 				if(videoPlayerView.getResizeMode() == AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
 					zoomButton.get().setImageResource(R.drawable.ic_zoom_out_dark);
+					zoomButton.get().setContentDescription(
+							context.getString(R.string.video_zoom_out));
 				}
 
 				addButton(zoomButton.get(), buttons);
@@ -337,6 +354,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			@NonNull final Context context,
 			@NonNull final ViewGroup root,
 			@DrawableRes final int image,
+			@StringRes final int description,
 			@NonNull final OnClickListener clickListener) {
 
 		final ImageButton ib = (ImageButton)LayoutInflater.from(context).inflate(
@@ -348,6 +366,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 		ib.setPadding(buttonPadding, buttonPadding, buttonPadding, buttonPadding);
 
 		ib.setImageResource(image);
+		ib.setContentDescription(context.getString(description));
 
 		ib.setOnClickListener(clickListener);
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1454,4 +1454,15 @@
 	<string name="pref_menus_comment_context_items_key" translatable="false">pref_menus_comment_context_items</string>
 	<string name="pref_menus_comment_context_items_title">Action menu items</string>
 
+	<!-- 2021-03-19 -->
+	<string name="video_mute">Mute</string>
+	<string name="video_unmute">Unmute</string>
+	<string name="video_restart">Restart video</string>
+	<string name="video_rewind">Rewind</string>
+	<string name="video_play">Play</string>
+	<string name="video_pause">Pause</string>
+	<string name="video_fast_forward">Fast forward</string>
+	<string name="video_zoom_in">Zoom in</string>
+	<string name="video_zoom_out">Zoom out</string>
+
 </resources>


### PR DESCRIPTION
I noticed that buttons in both the floating image buttons and the media playback controls were unlabeled for screen readers, and added descriptions for them.