### PR TITLE
Implement toggles for thumbnails and previews on spoiler posts

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -121,6 +121,8 @@ public final class PrefsUtility {
 				|| key.equals(context.getString(R.string.pref_images_inline_image_previews_key))
 				|| key.equals(context.getString(
 						R.string.pref_images_inline_image_previews_nsfw_key))
+				|| key.equals(context.getString(
+						R.string.pref_images_inline_image_previews_spoiler_key))
 				|| key.equals(context.getString(R.string.pref_images_high_res_thumbnails_key))
 				|| key.equals(context.getString(
 						R.string.pref_accessibility_separate_body_text_lines_key))
@@ -359,6 +361,16 @@ public final class PrefsUtility {
 			final SharedPreferences sharedPreferences) {
 		return getBoolean(
 				R.string.pref_appearance_thumbnails_nsfw_show_key,
+				false,
+				context,
+				sharedPreferences);
+	}
+
+	public static boolean appearance_thumbnails_spoiler_show(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		return getBoolean(
+				R.string.pref_appearance_thumbnails_spoiler_show_key,
 				false,
 				context,
 				sharedPreferences);
@@ -877,6 +889,16 @@ public final class PrefsUtility {
 			final SharedPreferences sharedPreferences) {
 		return getBoolean(
 				R.string.pref_images_inline_image_previews_nsfw_key,
+				false,
+				context,
+				sharedPreferences);
+	}
+
+	public static boolean images_inline_image_previews_spoiler(
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+		return getBoolean(
+				R.string.pref_images_inline_image_previews_spoiler_key,
 				false,
 				context,
 				sharedPreferences);

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -723,6 +723,11 @@ public class PostListingFragment extends RRFragment
 											activity,
 											mSharedPreferences);
 
+							final boolean showSpoilerPreviews
+									= PrefsUtility.images_inline_image_previews_spoiler(
+											activity,
+											mSharedPreferences);
+
 							final boolean downloadThumbnails
 									= PrefsUtility.appearance_thumbnails_show(
 											activity,
@@ -735,6 +740,11 @@ public class PostListingFragment extends RRFragment
 
 							final boolean showNsfwThumbnails
 									= PrefsUtility.appearance_thumbnails_nsfw_show(
+											activity,
+											mSharedPreferences);
+
+							final boolean showSpoilerThumbnails
+									= PrefsUtility.appearance_thumbnails_spoiler_show(
 											activity,
 											mSharedPreferences);
 
@@ -826,10 +836,14 @@ public class PostListingFragment extends RRFragment
 										&& mPostIds.add(post.getIdAlone())) {
 
 									final boolean downloadThisThumbnail = downloadThumbnails
-											&& (!post.over_18 || showNsfwThumbnails);
+											&& (!post.over_18 || showNsfwThumbnails)
+											&& (!post.spoiler || showSpoilerThumbnails);
 
 									final boolean downloadThisPreview = inlinePreviews
-											&& (!post.over_18 || showNsfwPreviews);
+											&& (!post.over_18 || showNsfwPreviews)
+											&& (!post.spoiler || showSpoilerPreviews);
+											// remove this if merged: couldn't find out if
+											// post.spoiler was correct
 
 									final int positionInList = mPostCount;
 

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -842,8 +842,6 @@ public class PostListingFragment extends RRFragment
 									final boolean downloadThisPreview = inlinePreviews
 											&& (!post.over_18 || showNsfwPreviews)
 											&& (!post.spoiler || showSpoilerPreviews);
-											// remove this if merged: couldn't find out if
-											// post.spoiler was correct
 
 									final int positionInList = mPostCount;
 

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -286,12 +286,15 @@ public final class SettingsFragment extends PreferenceFragment {
 					getString(R.string.pref_appearance_thumbnails_show_list_key));
 			final Preference thumbnailNsfwPref =
 					findPreference(getString(R.string.pref_appearance_thumbnails_nsfw_show_key));
+			final Preference thumbnailSpoilerPref =
+					findPreference(getString(R.string.pref_appearance_thumbnails_spoiler_show_key));
 
 			if(thumbnailPref != null) {
 				thumbnailPref.setOnPreferenceChangeListener((preference, newValue) -> {
 					final int index = thumbnailPref.findIndexOfValue((String)newValue);
 					thumbnailPref.setSummary(thumbnailPref.getEntries()[index]);
 					thumbnailNsfwPref.setEnabled(!newValue.equals("never"));
+					thumbnailSpoilerPref.setEnabled(!newValue.equals("never"));
 					return true;
 				});
 			}
@@ -302,12 +305,15 @@ public final class SettingsFragment extends PreferenceFragment {
 				getString(R.string.pref_images_inline_image_previews_key));
 		final Preference inlineImagesNsfwPref =
 				findPreference(getString(R.string.pref_images_inline_image_previews_nsfw_key));
+		final Preference inlineImagesSpoilerPref =
+				findPreference(getString(R.string.pref_images_inline_image_previews_spoiler_key));
 
 		if(inlineImagesPref != null) {
 			inlineImagesPref.setOnPreferenceChangeListener((preference, newValue) -> {
 				final int index = inlineImagesPref.findIndexOfValue((String)newValue);
 				inlineImagesPref.setSummary(inlineImagesPref.getEntries()[index]);
 				inlineImagesNsfwPref.setEnabled(!newValue.equals("never"));
+				inlineImagesSpoilerPref.setEnabled(!newValue.equals("never"));
 				return true;
 			});
 		}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1407,7 +1407,7 @@
 	<string name="pref_images_inline_image_previews_nsfw_title">Show NSFW previews</string>
 	<string name="pref_images_inline_image_previews_nsfw_key" translatable="false">pref_images_inline_image_previews_nsfw_key</string>
 
-	<string name="pref_images_inline_image_previews_spoiler_title">Show NSFW previews</string>
+	<string name="pref_images_inline_image_previews_spoiler_title">Show spoiler previews</string>
 	<string name="pref_images_inline_image_previews_spoiler_key" translatable="false">pref_images_inline_image_previews_spoiler_key</string>
 
 	<string name="pref_header_image_viewer">Image viewer</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -55,6 +55,9 @@
     <string name="pref_appearance_thumbnails_nsfw_show_key" translatable="false">pref_appearance_thumbnails_nsfw_show</string>
     <string name="pref_appearance_thumbnails_nsfw_show_title">Show NSFW thumbnails</string>
 
+    <string name="pref_appearance_thumbnails_spoiler_show_key" translatable="false">pref_appearance_thumbnails_spoiler_show</string>
+    <string name="pref_appearance_thumbnails_spoiler_show_title">Show spoiler thumbnails</string>
+
     <string name="pref_appearance_thumbnails_wifionly_key" translatable="false">pref_appearance_thumbnails_wifionly</string>
     <string name="pref_appearance_thumbnails_wifionly_title">Thumbnails on Wi-Fi only</string>
 
@@ -772,7 +775,7 @@
 
 	<!-- 2016-06-24 -->
 	<string name="save_image_permission_denied">Permission denied: could not save image.</string>
-	
+
 	<!-- 2016-06-25 -->
 	<string name="pref_behaviour_imageview_mode_title">Image viewer</string>
 	<string name="pref_behaviour_imageview_mode_key" translatable="false">pref_behaviour_imageview_mode</string>
@@ -788,7 +791,7 @@
 
 	<!-- 2016-06-30 -->
 	<string name="inbox_unread_only">Unread Messages Only</string>
-	
+
 	<!-- 2016-07-02 -->
 	<string name="pref_behaviour_actions_comment_longclick_key" translatable="false">pref_behaviour_actions_comment_longclick</string>
 	<string name="pref_behaviour_actions_comment_longclick_title">Long press</string>
@@ -811,7 +814,7 @@
 	<string name="submit_post_actionbar">Submit Post</string>
 	<string name="submit_comment_actionbar">Submit Comment</string>
 	<string name="edit_comment_actionbar">Edit Comment</string>
-	
+
 	<!-- 2016-07-16 -->
 	<string name="pref_behaviour_fling_comment_left_key" translatable="false">pref_behaviour_fling_comment_left</string>
 	<string name="pref_behaviour_fling_comment_left_title">Fling left</string>
@@ -1025,7 +1028,7 @@
 	<!-- 2018-02-10 -->
 	<string name="search_listing_header_query">Search Query</string>
 	<string name="search_listing_header_sub">Limit to Subreddit</string>
-  
+
 	<!-- 2018-02-11 -->
 	<string name="pref_behaviour_sharing_header">Sharing</string>
 	<string name="pref_behaviour_sharing_include_desc_key" translatable="false">pref_behaviour_sharing_include_desc</string>
@@ -1092,7 +1095,7 @@
 	<string name="prefs_category_images_video">Images/Video</string>
 
 	<string name="notification_channel_name_reddit_messages">Incoming Reddit Messages</string>
-	
+
 	<!-- 2019-10-05 -->
 	<string name="post_text_copied_to_clipboard">Post self-text copied to clipboard</string>
 	<string name="action_copy_selftext">Copy Self-Text</string>
@@ -1403,6 +1406,9 @@
 
 	<string name="pref_images_inline_image_previews_nsfw_title">Show NSFW previews</string>
 	<string name="pref_images_inline_image_previews_nsfw_key" translatable="false">pref_images_inline_image_previews_nsfw_key</string>
+
+	<string name="pref_images_inline_image_previews_spoiler_title">Show NSFW previews</string>
+	<string name="pref_images_inline_image_previews_spoiler_key" translatable="false">pref_images_inline_image_previews_spoiler_key</string>
 
 	<string name="pref_header_image_viewer">Image viewer</string>
 

--- a/src/main/res/xml/prefs_images_video.xml
+++ b/src/main/res/xml/prefs_images_video.xml
@@ -31,6 +31,10 @@
 							android:key="@string/pref_images_inline_image_previews_nsfw_key"
 							android:defaultValue="false"/>
 
+		<CheckBoxPreference android:title="@string/pref_images_inline_image_previews_spoiler_title"
+							android:key="@string/pref_images_inline_image_previews_spoiler_key"
+							android:defaultValue="false"/>
+
 	</PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/pref_header_image_viewer">
@@ -108,6 +112,10 @@
 		<CheckBoxPreference android:title="@string/pref_appearance_thumbnails_nsfw_show_title"
 							android:key="@string/pref_appearance_thumbnails_nsfw_show_key"
 							android:defaultValue="false"/>
+
+		<CheckBoxPreference android:title="@string/pref_appearance_thumbnails_spoiler_show_title"
+					  android:key="@string/pref_appearance_thumbnails_spoiler_show_key"
+					  android:defaultValue="false"/>
 
 		<ListPreference android:title="@string/pref_images_high_res_thumbnails_title"
 						android:key="@string/pref_images_high_res_thumbnails_key"


### PR DESCRIPTION
Closes #864

I don't have any experience writing Java, and haven't tested this. I couldn't tell whether `post.spoiler` was the correct way to tell if a post is a spoiler, so could someone verify that? The comment on line 845 of PostListingFragment.java should be removed once that is done.