### PR TITLE
Better highlighting of posts/comments

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
@@ -255,6 +255,10 @@ public class RedditParsedPost implements RedditThingWithIdAndType {
 		return mSrc.author;
 	}
 
+	public String getDistinguished() {
+		return mSrc.distinguished;
+	}
+
 	public String getRawSelfTextMarkdown() {
 		return mSrc.selftext;
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -34,6 +34,7 @@ import android.widget.ImageButton;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import org.apache.commons.text.StringEscapeUtils;
 import org.quantumbadger.redreader.R;
@@ -1272,10 +1273,19 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		}
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.AUTHOR)) {
+			@StringRes final int authorString;
+
+			if("moderator".equals(src.getDistinguished())) {
+				authorString = R.string.accessibility_subtitle_author_moderator_withperiod;
+			} else if("admin".equals(src.getDistinguished())) {
+				authorString = R.string.accessibility_subtitle_author_admin_withperiod;
+			} else {
+				authorString = R.string.accessibility_subtitle_author_withperiod;
+			}
 
 			accessibilitySubtitle
 					.append(context.getString(
-							R.string.accessibility_subtitle_author_withperiod,
+							authorString,
 							ScreenreaderPronunciation.getPronunciation(
 									context,
 									src.getAuthor())))

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1116,12 +1116,39 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.AUTHOR)) {
 			postListDescSb.append(context.getString(R.string.subtitle_by) + " ", 0);
-			postListDescSb.append(
-					src.getAuthor(),
-					BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR,
-					boldCol,
-					0,
-					1f);
+
+			final boolean setBackgroundColour;
+			final int backgroundColour; // TODO color from theme
+
+			if("moderator".equals(src.getDistinguished())) {
+				setBackgroundColour = true;
+				backgroundColour = Color.rgb(0, 170, 0);
+			} else if("admin".equals(src.getDistinguished())) {
+				setBackgroundColour = true;
+				backgroundColour = Color.rgb(170, 0, 0);
+			} else {
+				setBackgroundColour = false;
+				backgroundColour = 0;
+			}
+
+			if(setBackgroundColour) {
+				postListDescSb.append(
+						BetterSSB.NBSP + src.getAuthor() + BetterSSB.NBSP,
+						BetterSSB.BOLD
+								| BetterSSB.FOREGROUND_COLOR
+								| BetterSSB.BACKGROUND_COLOR,
+						Color.WHITE,
+						backgroundColour,
+						1f);
+			} else {
+				postListDescSb.append(
+						src.getAuthor(),
+						BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR,
+						boldCol,
+						0,
+						1f);
+			}
+
 			postListDescSb.append(" ", 0);
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -22,6 +22,7 @@ import android.graphics.Color;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.activities.BaseActivity;
@@ -300,9 +301,32 @@ public class RedditRenderableComment
 		}
 
 		if(theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.AUTHOR)) {
+			@StringRes final int authorString;
+
+			if(rawComment.author.equalsIgnoreCase(mParentPostAuthor)
+					&& !rawComment.author.equals("[deleted]")) {
+				if("moderator".equals(rawComment.distinguished)) {
+					authorString
+							= R.string.accessibility_subtitle_author_submitter_moderator_withperiod;
+				} else if("admin".equals(rawComment.distinguished)) {
+					authorString
+							= R.string.accessibility_subtitle_author_submitter_admin_withperiod;
+				} else {
+					authorString = R.string.accessibility_subtitle_author_submitter_withperiod;
+				}
+			} else {
+				if("moderator".equals(rawComment.distinguished)) {
+					authorString = R.string.accessibility_subtitle_author_moderator_withperiod;
+				} else if("admin".equals(rawComment.distinguished)) {
+					authorString = R.string.accessibility_subtitle_author_admin_withperiod;
+				} else {
+					authorString = R.string.accessibility_subtitle_author_withperiod;
+				}
+			}
+
 			accessibilityHeader
 					.append(context.getString(
-							R.string.accessibility_subtitle_author_withperiod,
+							authorString,
 							ScreenreaderPronunciation.getPronunciation(
 									context,
 									rawComment.author)))

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -48,6 +48,8 @@ public final class RedditPost implements Parcelable, RedditThingWithIdAndType {
 	@Nullable public JsonObject preview;
 	@Nullable public Boolean is_video;
 
+	@Nullable public String distinguished;
+
 	public RedditPost() {
 	}
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1554,5 +1554,12 @@
 
 	<string name="error_http_429_title">Too many requests</string>
 	<string name="error_http_429_message">The server has rejected the request due to a rate limit. Please try again in a moment.</string>
+
+	<!-- 2021-06-27 -->
+	<string name="accessibility_subtitle_author_submitter_withperiod">Author: %s, submitter.</string>
+	<string name="accessibility_subtitle_author_moderator_withperiod">Author: %s, moderator.</string>
+	<string name="accessibility_subtitle_author_admin_withperiod">Author: %s, admin.</string>
+	<string name="accessibility_subtitle_author_submitter_moderator_withperiod">Author: %s, submitter and moderator.</string>
+	<string name="accessibility_subtitle_author_submitter_admin_withperiod">Author: %s, submitter and admin.</string>
 	
 </resources>


### PR DESCRIPTION
This highlights posts by admins and moderators, and highlights posts/comments by special authors when reading out-loud for screen readers. Feel free to comment on my proposed strings for this; in particular, I think "OP" might be a better term than "submitter", but also might be easy to mistake for extra syllables of the author's name?

One thing to note: comments, made by an admin/moderator that submitted the original post, are currently only highlighted as being from the OP. Maybe we should add a visual indicator that they are also an admin/mod? Old Reddit [shows both](https://old.reddit.com/r/announcements/comments/dpqd0z/the_extra_life_charity_award_raise_awareness_for/f5xpwav/).

Closes #62.