### PR TITLE
Wrap preference strings, and don't reserve space for icons

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -36,6 +36,8 @@ import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
 import org.quantumbadger.redreader.BuildConfig;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.BaseActivity;
@@ -555,6 +557,29 @@ public final class SettingsFragment extends PreferenceFragmentCompat {
 				});
 			}
 
+		}
+	}
+
+	//Based on https://stackoverflow.com/a/55724743
+	@Override
+	public void setPreferenceScreen(final PreferenceScreen preferenceScreen) {
+		if(preferenceScreen != null) {
+			configureAllPrefsAppearance(preferenceScreen);
+		}
+
+		super.setPreferenceScreen(preferenceScreen);
+	}
+
+	private void configureAllPrefsAppearance(final PreferenceGroup prefGroup) {
+		for(int i = 0; i < prefGroup.getPreferenceCount(); i++) {
+			final Preference pref = prefGroup.getPreference(i);
+
+			pref.setSingleLineTitle(false);
+			pref.setIconSpaceReserved(false);
+
+			if(pref instanceof PreferenceGroup) {
+				configureAllPrefsAppearance((PreferenceGroup)pref);
+			}
 		}
 	}
 


### PR DESCRIPTION
This wraps preference strings that are too long to show on one line. It also looked like a good idea to not reserve space for icons, since we aren't using any.

Thank you for migrating to the new AndroidX preferences, which made this possible.

Closes #750.