### PR TITLE
Add date sorting for Controversial posts & user comments

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -1042,11 +1042,40 @@ public final class OptionsMenuUtility {
 		if(includeRising) {
 			addSort(activity, sortPosts, R.string.sort_posts_rising, PostSort.RISING);
 		}
+
+		final SubMenu sortsPostsControversial =
+				sortPosts.addSubMenu(R.string.sort_posts_controversial);
+
 		addSort(
 				activity,
-				sortPosts,
-				R.string.sort_posts_controversial,
-				PostSort.CONTROVERSIAL);
+				sortsPostsControversial,
+				R.string.sort_posts_controversial_hour,
+				PostSort.CONTROVERSIAL_HOUR);
+		addSort(
+				activity,
+				sortsPostsControversial,
+				R.string.sort_posts_controversial_today,
+				PostSort.CONTROVERSIAL_DAY);
+		addSort(
+				activity,
+				sortsPostsControversial,
+				R.string.sort_posts_controversial_week,
+				PostSort.CONTROVERSIAL_WEEK);
+		addSort(
+				activity,
+				sortsPostsControversial,
+				R.string.sort_posts_controversial_month,
+				PostSort.CONTROVERSIAL_MONTH);
+		addSort(
+				activity,
+				sortsPostsControversial,
+				R.string.sort_posts_controversial_year,
+				PostSort.CONTROVERSIAL_YEAR);
+		addSort(
+				activity, sortsPostsControversial,
+				R.string.sort_posts_controversial_all,
+				PostSort.CONTROVERSIAL_ALL);
+
 		if(includeBest) {
 			addSort(activity, sortPosts, R.string.sort_posts_best, PostSort.BEST);
 		}
@@ -1207,11 +1236,40 @@ public final class OptionsMenuUtility {
 				sortComments,
 				R.string.sort_comments_new,
 				UserCommentListingURL.Sort.NEW);
+
+		final SubMenu sortCommentsControversial
+				= sortComments.addSubMenu(R.string.sort_comments_controversial);
+
 		addSort(
 				activity,
-				sortComments,
-				R.string.sort_comments_controversial,
-				UserCommentListingURL.Sort.CONTROVERSIAL);
+				sortCommentsControversial,
+				R.string.sort_posts_controversial_hour,
+				UserCommentListingURL.Sort.CONTROVERSIAL_HOUR);
+		addSort(
+				activity,
+				sortCommentsControversial,
+				R.string.sort_posts_controversial_today,
+				UserCommentListingURL.Sort.CONTROVERSIAL_DAY);
+		addSort(
+				activity,
+				sortCommentsControversial,
+				R.string.sort_posts_controversial_week,
+				UserCommentListingURL.Sort.CONTROVERSIAL_WEEK);
+		addSort(
+				activity,
+				sortCommentsControversial,
+				R.string.sort_posts_controversial_month,
+				UserCommentListingURL.Sort.CONTROVERSIAL_MONTH);
+		addSort(
+				activity,
+				sortCommentsControversial,
+				R.string.sort_posts_controversial_year,
+				UserCommentListingURL.Sort.CONTROVERSIAL_YEAR);
+		addSort(
+				activity,
+				sortCommentsControversial,
+				R.string.sort_posts_controversial_all,
+				UserCommentListingURL.Sort.CONTROVERSIAL_ALL);
 
 		final SubMenu sortCommentsTop
 				= sortComments.addSubMenu(R.string.sort_comments_top);

--- a/src/main/java/org/quantumbadger/redreader/reddit/PostSort.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/PostSort.java
@@ -32,7 +32,12 @@ public enum PostSort {
 	TOP_MONTH,
 	TOP_YEAR,
 	TOP_ALL,
-	CONTROVERSIAL,
+	CONTROVERSIAL_HOUR,
+	CONTROVERSIAL_DAY,
+	CONTROVERSIAL_WEEK,
+	CONTROVERSIAL_MONTH,
+	CONTROVERSIAL_YEAR,
+	CONTROVERSIAL_ALL,
 	BEST,
 	// Sorts related to Search Listings
 	RELEVANCE,
@@ -69,7 +74,24 @@ public enum PostSort {
 			return BEST;
 
 		} else if(sort.equals("controversial")) {
-			return CONTROVERSIAL;
+
+			if(t == null) {
+				return CONTROVERSIAL_ALL;
+			} else if(t.equals("all")) {
+				return CONTROVERSIAL_ALL;
+			} else if(t.equals("hour")) {
+				return CONTROVERSIAL_HOUR;
+			} else if(t.equals("day")) {
+				return CONTROVERSIAL_DAY;
+			} else if(t.equals("week")) {
+				return CONTROVERSIAL_WEEK;
+			} else if(t.equals("month")) {
+				return CONTROVERSIAL_MONTH;
+			} else if(t.equals("year")) {
+				return CONTROVERSIAL_YEAR;
+			} else {
+				return CONTROVERSIAL_ALL;
+			}
 
 		} else if(sort.equals("rising")) {
 			return RISING;
@@ -104,10 +126,15 @@ public enum PostSort {
 		switch(this) {
 			case HOT:
 			case NEW:
-			case CONTROVERSIAL:
 				builder.appendQueryParameter("sort", StringUtils.asciiLowercase(name()));
 				break;
 
+			case CONTROVERSIAL_HOUR:
+			case CONTROVERSIAL_DAY:
+			case CONTROVERSIAL_WEEK:
+			case CONTROVERSIAL_MONTH:
+			case CONTROVERSIAL_YEAR:
+			case CONTROVERSIAL_ALL:
 			case TOP_HOUR:
 			case TOP_DAY:
 			case TOP_WEEK:
@@ -127,21 +154,25 @@ public enum PostSort {
 			case HOT:
 			case NEW:
 			case RISING:
-			case CONTROVERSIAL:
 			case BEST:
 				builder.appendEncodedPath(StringUtils.asciiLowercase(name()));
 				break;
 
+			case CONTROVERSIAL_HOUR:
+			case CONTROVERSIAL_DAY:
+			case CONTROVERSIAL_WEEK:
+			case CONTROVERSIAL_MONTH:
+			case CONTROVERSIAL_YEAR:
+			case CONTROVERSIAL_ALL:
 			case TOP_HOUR:
 			case TOP_DAY:
 			case TOP_WEEK:
 			case TOP_MONTH:
 			case TOP_YEAR:
 			case TOP_ALL:
-				builder.appendEncodedPath("top");
-				builder.appendQueryParameter(
-						"t",
-						StringUtils.asciiLowercase(name().split("_")[1]));
+				final String[] parts = name().split("_");
+				builder.appendEncodedPath(StringUtils.asciiLowercase(name().split("_")[0]));
+				builder.appendQueryParameter("t", StringUtils.asciiLowercase(parts[1]));
 				break;
 		}
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/MultiredditPostListURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/MultiredditPostListURL.java
@@ -248,6 +248,12 @@ public class MultiredditPostListURL extends PostListingURL {
 		}
 
 		switch(order) {
+			case CONTROVERSIAL_HOUR:
+			case CONTROVERSIAL_DAY:
+			case CONTROVERSIAL_WEEK:
+			case CONTROVERSIAL_MONTH:
+			case CONTROVERSIAL_YEAR:
+			case CONTROVERSIAL_ALL:
 			case TOP_HOUR:
 			case TOP_DAY:
 			case TOP_WEEK:

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/SubredditPostListURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/SubredditPostListURL.java
@@ -392,6 +392,12 @@ public class SubredditPostListURL extends PostListingURL {
 		}
 
 		switch(order) {
+			case CONTROVERSIAL_HOUR:
+			case CONTROVERSIAL_DAY:
+			case CONTROVERSIAL_WEEK:
+			case CONTROVERSIAL_MONTH:
+			case CONTROVERSIAL_YEAR:
+			case CONTROVERSIAL_ALL:
 			case TOP_HOUR:
 			case TOP_DAY:
 			case TOP_WEEK:

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/UserCommentListingURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/UserCommentListingURL.java
@@ -177,8 +177,12 @@ public class UserCommentListingURL extends CommentListingURL {
 	public enum Sort {
 		NEW,
 		HOT,
-		CONTROVERSIAL,
-		TOP,
+		CONTROVERSIAL_HOUR,
+		CONTROVERSIAL_DAY,
+		CONTROVERSIAL_WEEK,
+		CONTROVERSIAL_MONTH,
+		CONTROVERSIAL_YEAR,
+		CONTROVERSIAL_ALL,
 		TOP_HOUR,
 		TOP_DAY,
 		TOP_WEEK,
@@ -203,7 +207,23 @@ public class UserCommentListingURL extends CommentListingURL {
 				return NEW;
 
 			} else if(sort.equals("controversial")) {
-				return CONTROVERSIAL;
+				if(t == null) {
+					return CONTROVERSIAL_ALL;
+				} else if(t.equals("all")) {
+					return CONTROVERSIAL_ALL;
+				} else if(t.equals("hour")) {
+					return CONTROVERSIAL_HOUR;
+				} else if(t.equals("day")) {
+					return CONTROVERSIAL_DAY;
+				} else if(t.equals("week")) {
+					return CONTROVERSIAL_WEEK;
+				} else if(t.equals("month")) {
+					return CONTROVERSIAL_MONTH;
+				} else if(t.equals("year")) {
+					return CONTROVERSIAL_YEAR;
+				} else {
+					return CONTROVERSIAL_ALL;
+				}
 
 			} else if(sort.equals("top")) {
 
@@ -235,10 +255,15 @@ public class UserCommentListingURL extends CommentListingURL {
 			switch(this) {
 				case HOT:
 				case NEW:
-				case CONTROVERSIAL:
 					builder.appendQueryParameter("sort", StringUtils.asciiLowercase(name()));
 					break;
 
+				case CONTROVERSIAL_HOUR:
+				case CONTROVERSIAL_DAY:
+				case CONTROVERSIAL_WEEK:
+				case CONTROVERSIAL_MONTH:
+				case CONTROVERSIAL_YEAR:
+				case CONTROVERSIAL_ALL:
 				case TOP_HOUR:
 				case TOP_DAY:
 				case TOP_WEEK:

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/UserPostListingURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/UserPostListingURL.java
@@ -217,13 +217,21 @@ public class UserPostListingURL extends PostListingURL {
 		}
 
 		switch(order) {
+			case CONTROVERSIAL_HOUR:
+			case CONTROVERSIAL_DAY:
+			case CONTROVERSIAL_WEEK:
+			case CONTROVERSIAL_MONTH:
+			case CONTROVERSIAL_YEAR:
+			case CONTROVERSIAL_ALL:
 			case TOP_HOUR:
 			case TOP_DAY:
 			case TOP_WEEK:
 			case TOP_MONTH:
 			case TOP_YEAR:
 			case TOP_ALL:
-				return path + "?t=" + StringUtils.asciiLowercase(order.name().split("_")[1]);
+				final String[] parts = order.name().split("_");
+				return path + "?sort=" + StringUtils.asciiLowercase(parts[0])
+						+ "&t=" + StringUtils.asciiLowercase(parts[1]);
 
 			default:
 				return path + "?sort=" + StringUtils.asciiLowercase(order.name());

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1560,5 +1560,13 @@
 
 	<!-- 2021-07-01 -->
 	<string name="prefs_category_menus_appbar_screen_key" translatable="false">prefs_category_menus_appbar_screen</string>
+
+	<!-- 2021-07-05 -->
+	<string name="sort_posts_controversial_hour">Controversial: This Hour</string>
+	<string name="sort_posts_controversial_today">Controversial: Today</string>
+	<string name="sort_posts_controversial_week">Controversial: This Week</string>
+	<string name="sort_posts_controversial_month">Controversial: This Month</string>
+	<string name="sort_posts_controversial_year">Controversial: This Year</string>
+	<string name="sort_posts_controversial_all">Controversial: All Time</string>
 	
 </resources>


### PR DESCRIPTION
With this, you can now sort Controversial by hour/day/week/month/year/all on posts and user comments. I also noticed and fixed a small error in the human path creator in `UserPostListingURL`.

Closes #666. (The poster of this issue wants to be able to sort *all* sort types; Reddit does not provide all sorts with date sorting, so this is not possible, unless we add our own manual sorting logic — quite a task. I think we can close that issue?)