### PR TITLE
Inform user there are no posts to show when necessary

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/adapters/RedditListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/RedditListingManager.java
@@ -18,12 +18,8 @@
 package org.quantumbadger.redreader.adapters;
 
 import android.content.Context;
-import androidx.annotation.StringRes;
 import androidx.recyclerview.widget.LinearLayoutManager;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.TextView;
-import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.views.LoadingSpinnerView;
 import org.quantumbadger.redreader.views.RedditPostHeaderView;
@@ -33,7 +29,7 @@ import java.util.Collection;
 
 public abstract class RedditListingManager {
 
-	private final GroupedRecyclerViewAdapter mAdapter = new GroupedRecyclerViewAdapter(8);
+	private final GroupedRecyclerViewAdapter mAdapter = new GroupedRecyclerViewAdapter(7);
 	private LinearLayoutManager mLayoutManager;
 
 	private static final int
@@ -43,12 +39,9 @@ public abstract class RedditListingManager {
 			GROUP_ITEMS = 3,
 			GROUP_LOAD_MORE_BUTTON = 4,
 			GROUP_LOADING = 5,
-			GROUP_FOOTER_ERRORS = 6,
-			GROUP_EMPTY = 7;
+			GROUP_FOOTER_ERRORS = 6;
 
 	private final GroupedRecyclerViewItemFrameLayout mLoadingItem;
-	private final GroupedRecyclerViewItemFrameLayout mEmptyItem;
-	private final View mEmptyView;
 	private boolean mWorkaroundDone = false;
 
 	public RedditListingManager(final Context context) {
@@ -59,14 +52,6 @@ public abstract class RedditListingManager {
 
 		mLoadingItem = new GroupedRecyclerViewItemFrameLayout(loadingSpinnerView);
 		mAdapter.appendToGroup(GROUP_LOADING, mLoadingItem);
-
-		mEmptyView = LayoutInflater.from(context).inflate(
-						R.layout.no_items_yet,
-						null,
-						false);
-		mEmptyItem = new GroupedRecyclerViewItemFrameLayout(mEmptyView);
-		mAdapter.appendToGroup(GROUP_EMPTY, mEmptyItem);
-		mEmptyItem.setHidden(true);
 	}
 
 	public void setLayoutManager(final LinearLayoutManager layoutManager) {
@@ -150,17 +135,6 @@ public abstract class RedditListingManager {
 		General.checkThisIsUIThread();
 		mLoadingItem.setHidden(!visible);
 		mAdapter.updateHiddenStatus();
-	}
-
-	public void setEmptyVisible(final boolean visible) {
-		General.checkThisIsUIThread();
-		mEmptyItem.setHidden(!visible);
-		mAdapter.updateHiddenStatus();
-	}
-
-	public void setEmptyText(@StringRes final int text) {
-		General.checkThisIsUIThread();
-		((TextView)mEmptyView.findViewById(R.id.empty_view_text)).setText(text);
 	}
 
 	public GroupedRecyclerViewAdapter getAdapter() {

--- a/src/main/java/org/quantumbadger/redreader/adapters/RedditListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/RedditListingManager.java
@@ -18,8 +18,12 @@
 package org.quantumbadger.redreader.adapters;
 
 import android.content.Context;
+import androidx.annotation.StringRes;
 import androidx.recyclerview.widget.LinearLayoutManager;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
+import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.views.LoadingSpinnerView;
 import org.quantumbadger.redreader.views.RedditPostHeaderView;
@@ -29,7 +33,7 @@ import java.util.Collection;
 
 public abstract class RedditListingManager {
 
-	private final GroupedRecyclerViewAdapter mAdapter = new GroupedRecyclerViewAdapter(7);
+	private final GroupedRecyclerViewAdapter mAdapter = new GroupedRecyclerViewAdapter(8);
 	private LinearLayoutManager mLayoutManager;
 
 	private static final int
@@ -39,9 +43,12 @@ public abstract class RedditListingManager {
 			GROUP_ITEMS = 3,
 			GROUP_LOAD_MORE_BUTTON = 4,
 			GROUP_LOADING = 5,
-			GROUP_FOOTER_ERRORS = 6;
+			GROUP_FOOTER_ERRORS = 6,
+			GROUP_EMPTY = 7;
 
 	private final GroupedRecyclerViewItemFrameLayout mLoadingItem;
+	private final GroupedRecyclerViewItemFrameLayout mEmptyItem;
+	private final View mEmptyView;
 	private boolean mWorkaroundDone = false;
 
 	public RedditListingManager(final Context context) {
@@ -52,6 +59,14 @@ public abstract class RedditListingManager {
 
 		mLoadingItem = new GroupedRecyclerViewItemFrameLayout(loadingSpinnerView);
 		mAdapter.appendToGroup(GROUP_LOADING, mLoadingItem);
+
+		mEmptyView = LayoutInflater.from(context).inflate(
+						R.layout.no_items_yet,
+						null,
+						false);
+		mEmptyItem = new GroupedRecyclerViewItemFrameLayout(mEmptyView);
+		mAdapter.appendToGroup(GROUP_EMPTY, mEmptyItem);
+		mEmptyItem.setHidden(true);
 	}
 
 	public void setLayoutManager(final LinearLayoutManager layoutManager) {
@@ -135,6 +150,17 @@ public abstract class RedditListingManager {
 		General.checkThisIsUIThread();
 		mLoadingItem.setHidden(!visible);
 		mAdapter.updateHiddenStatus();
+	}
+
+	public void setEmptyVisible(final boolean visible) {
+		General.checkThisIsUIThread();
+		mEmptyItem.setHidden(!visible);
+		mAdapter.updateHiddenStatus();
+	}
+
+	public void setEmptyText(@StringRes final int text) {
+		General.checkThisIsUIThread();
+		((TextView)mEmptyView.findViewById(R.id.empty_view_text)).setText(text);
 	}
 
 	public GroupedRecyclerViewAdapter getAdapter() {

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -634,13 +634,16 @@ public class CommentListingFragment extends RRFragment
 			if(mCommentListingManager.getCommentCount() == 0) {
 
 				final View emptyView = LayoutInflater.from(getContext()).inflate(
-						R.layout.no_comments_yet,
+						R.layout.no_items_yet,
 						mRecyclerView,
 						false);
 
 				if(mCommentListingManager.isSearchListing()) {
 					((TextView)emptyView.findViewById(R.id.empty_view_text))
 							.setText(R.string.no_search_results);
+				} else {
+					((TextView)emptyView.findViewById(R.id.empty_view_text))
+							.setText(R.string.no_comments_yet);
 				}
 
 				mCommentListingManager.addViewToItems(emptyView);

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -947,7 +947,8 @@ public class PostListingFragment extends RRFragment
 								mPostListingManager.addPosts(downloadedPosts);
 								mPostListingManager.setLoadingVisible(false);
 
-								if(mPostCount == 0) {
+								if(mPostCount == 0
+										&& (mAfter == null || mAfter.equals(mLastAfter))) {
 									@StringRes final int emptyViewText;
 
 									if(mPostsNotShown) {
@@ -966,10 +967,16 @@ public class PostListingFragment extends RRFragment
 										}
 									}
 
-									mPostListingManager.setEmptyVisible(true);
-									mPostListingManager.setEmptyText(emptyViewText);
-								} else {
-									mPostListingManager.setEmptyVisible(false);
+									final View emptyView =
+											LayoutInflater.from(getContext()).inflate(
+													R.layout.no_items_yet,
+													mRecyclerView,
+													false);
+
+									((TextView)emptyView.findViewById(R.id.empty_view_text))
+											.setText(emptyViewText);
+
+									mPostListingManager.addViewToItems(emptyView);
 								}
 
 								onPostsAdded();

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -128,6 +129,7 @@ public class PostListingFragment extends RRFragment
 	private long mTimestamp;
 
 	private int mPostCount = 0;
+	private boolean mPostsNotShown = false;
 	private final AtomicInteger mPostRefreshCount = new AtomicInteger(0);
 
 	private final HashSet<String> mPostIds = new HashSet<>(200);
@@ -879,6 +881,7 @@ public class PostListingFragment extends RRFragment
 									// has been clicked on AND user preference
 									// "hideReadPosts" is true
 									if(hideReadPosts && preparedPost.isRead()) {
+										mPostsNotShown = true;
 										continue;
 									}
 
@@ -934,6 +937,8 @@ public class PostListingFragment extends RRFragment
 
 									mPostCount++;
 									mPostRefreshCount.decrementAndGet();
+								} else {
+									mPostsNotShown = true;
 								}
 							}
 
@@ -941,6 +946,32 @@ public class PostListingFragment extends RRFragment
 
 								mPostListingManager.addPosts(downloadedPosts);
 								mPostListingManager.setLoadingVisible(false);
+
+								if(mPostCount == 0) {
+									@StringRes final int emptyViewText;
+
+									if(mPostsNotShown) {
+										if(mPostListingURL.pathType()
+												== RedditURLParser.SEARCH_POST_LISTING_URL) {
+											emptyViewText = R.string.no_search_results_hidden;
+										} else {
+											emptyViewText = R.string.no_posts_yet_hidden;
+										}
+									} else {
+										if(mPostListingURL.pathType()
+												== RedditURLParser.SEARCH_POST_LISTING_URL) {
+											emptyViewText = R.string.no_search_results;
+										} else {
+											emptyViewText = R.string.no_posts_yet;
+										}
+									}
+
+									mPostListingManager.setEmptyVisible(true);
+									mPostListingManager.setEmptyText(emptyViewText);
+								} else {
+									mPostListingManager.setEmptyVisible(false);
+								}
+
 								onPostsAdded();
 
 								mRequest = null;

--- a/src/main/res/layout/no_items_yet.xml
+++ b/src/main/res/layout/no_items_yet.xml
@@ -31,8 +31,7 @@
 			android:layout_gravity="center"
 			android:textAlignment="center"
 			android:textSize="18sp"
-			android:textColor="?rrSubTextCol"
-			android:text="@string/no_comments_yet"/>
+			android:textColor="?rrSubTextCol"/>
 
 </FrameLayout>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1560,5 +1560,10 @@
 
 	<!-- 2021-07-01 -->
 	<string name="prefs_category_menus_appbar_screen_key" translatable="false">prefs_category_menus_appbar_screen</string>
+
+	<!-- 2021-07-06 -->
+	<string name="no_posts_yet">No posts yet.</string>
+	<string name="no_posts_yet_hidden">No posts shown due to settings.</string>
+	<string name="no_search_results_hidden">No search results shown due to settings.</string>
 	
 </resources>


### PR DESCRIPTION
This shows a bit of text when there are no posts to display. Currently, if no posts are to be shown when getting a list of posts, the user simply sees a blank screen. Adding this will give a more polished appearance, and assure users that there is truly nothing to see (rather than leaving them wondering if the app/connection had a glitch).

One thing to note: this does show a message while still downloading posts, if there are no posts to show *yet* due to settings. The message will disappear if posts to display are found. I think this is nice, because it can give the user an impression of why a search is taking awhile (due to the app filtering out many of the posts retrieved).