### PR TITLE
Add ability to use new controversial date-sorts as defaults, convert old prefs on upgrade.

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/FeatureFlagHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/FeatureFlagHandler.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.activities.BaseActivity;
 import org.quantumbadger.redreader.cache.CacheManager;
@@ -45,7 +46,8 @@ public final class FeatureFlagHandler {
 
 	private enum FeatureFlag {
 
-		COMMENT_HEADER_SUBREDDIT_FEATURE("commentHeaderSubredditFeature");
+		COMMENT_HEADER_SUBREDDIT_FEATURE("commentHeaderSubredditFeature"),
+		CONTROVERSIAL_DATE_SORTS_FEATURE("controversialDateSortsFeature");
 
 		@NonNull private final String id;
 
@@ -57,6 +59,15 @@ public final class FeatureFlagHandler {
 		public final String getId() {
 			return "rr_feature_flag_" + id;
 		}
+	}
+
+	private static String getString(
+			@StringRes final int id,
+			final String defaultString,
+			final Context context,
+			final SharedPreferences sharedPreferences) {
+
+		return sharedPreferences.getString(context.getString(id), defaultString);
 	}
 
 	private static Set<String> getStringSet(
@@ -98,6 +109,64 @@ public final class FeatureFlagHandler {
 										R.string.pref_appearance_comment_header_items_key),
 								existingCommentHeaderItems)
 						.apply();
+			}
+
+			if(getAndSetFeatureFlag(prefs, FeatureFlag.CONTROVERSIAL_DATE_SORTS_FEATURE)
+					== FeatureFlagStatus.UPGRADE_NEEDED) {
+
+				Log.i(TAG, "Upgrading, add date sorting for controversial posts/user comments");
+
+				final String existingDefaultPostsSort = getString(
+						R.string.pref_behaviour_postsort_key,
+						"hot",
+						context,
+						prefs);
+
+				final String existingDefaultMultiPostsSort = getString(
+						R.string.pref_behaviour_multi_postsort_key,
+						"hot",
+						context,
+						prefs);
+
+				final String existingDefaultUserPostsSort = getString(
+						R.string.pref_behaviour_user_postsort_key,
+						"new",
+						context,
+						prefs);
+
+				final String existingDefaultUserCommentsSort = getString(
+						R.string.pref_behaviour_user_commentsort_key,
+						"new",
+						context,
+						prefs);
+
+				if(existingDefaultPostsSort.equals("controversial")) {
+					prefs.edit().putString(
+							context.getString(R.string.pref_behaviour_postsort_key),
+							"controversial_day")
+						.apply();
+				}
+
+				if(existingDefaultMultiPostsSort.equals("controversial")) {
+					prefs.edit().putString(
+							context.getString(R.string.pref_behaviour_multi_postsort_key),
+							"controversial_day")
+							.apply();
+				}
+
+				if(existingDefaultUserPostsSort.equals("controversial")) {
+					prefs.edit().putString(
+							context.getString(R.string.pref_behaviour_user_postsort_key),
+							"controversial_all")
+							.apply();
+				}
+
+				if(existingDefaultUserCommentsSort.equals("controversial")) {
+					prefs.edit().putString(
+							context.getString(R.string.pref_behaviour_user_commentsort_key),
+							"controversial_all")
+							.apply();
+				}
 			}
 		});
 	}

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -132,7 +132,12 @@
 		<item>@string/sort_posts_hot</item>
 		<item>@string/sort_posts_new</item>
 		<item>@string/sort_posts_rising</item>
-		<item>@string/sort_posts_controversial</item>
+		<item>@string/sort_posts_controversial_hour</item>
+		<item>@string/sort_posts_controversial_today</item>
+		<item>@string/sort_posts_controversial_week</item>
+		<item>@string/sort_posts_controversial_month</item>
+		<item>@string/sort_posts_controversial_year</item>
+		<item>@string/sort_posts_controversial_all</item>
 		<item>@string/sort_posts_best</item>
 		<item>@string/sort_posts_top_hour</item>
 		<item>@string/sort_posts_top_today</item>
@@ -147,7 +152,12 @@
 		<item>hot</item>
 		<item>new</item>
 		<item>rising</item>
-		<item>controversial</item>
+		<item>controversial_hour</item>
+		<item>controversial_day</item>
+		<item>controversial_week</item>
+		<item>controversial_month</item>
+		<item>controversial_year</item>
+		<item>controversial_all</item>
 		<item>best</item>
 		<item>top_hour</item>
 		<item>top_day</item>
@@ -974,7 +984,12 @@
 	<string-array name="pref_behaviour_user_postsort_array">
 		<item>@string/sort_posts_hot</item>
 		<item>@string/sort_posts_new</item>
-		<item>@string/sort_posts_controversial</item>
+		<item>@string/sort_posts_controversial_hour</item>
+		<item>@string/sort_posts_controversial_today</item>
+		<item>@string/sort_posts_controversial_week</item>
+		<item>@string/sort_posts_controversial_month</item>
+		<item>@string/sort_posts_controversial_year</item>
+		<item>@string/sort_posts_controversial_all</item>
 		<item>@string/sort_posts_top_hour</item>
 		<item>@string/sort_posts_top_today</item>
 		<item>@string/sort_posts_top_week</item>
@@ -987,7 +1002,12 @@
 	<string-array name="pref_behaviour_user_postsort_array_return">
 		<item>hot</item>
 		<item>new</item>
-		<item>controversial</item>
+		<item>controversial_hour</item>
+		<item>controversial_day</item>
+		<item>controversial_week</item>
+		<item>controversial_month</item>
+		<item>controversial_year</item>
+		<item>controversial_all</item>
 		<item>top_hour</item>
 		<item>top_day</item>
 		<item>top_week</item>
@@ -1000,7 +1020,12 @@
 		<item>@string/sort_posts_hot</item>
 		<item>@string/sort_posts_new</item>
 		<item>@string/sort_posts_rising</item>
-		<item>@string/sort_posts_controversial</item>
+		<item>@string/sort_posts_controversial_hour</item>
+		<item>@string/sort_posts_controversial_today</item>
+		<item>@string/sort_posts_controversial_week</item>
+		<item>@string/sort_posts_controversial_month</item>
+		<item>@string/sort_posts_controversial_year</item>
+		<item>@string/sort_posts_controversial_all</item>
 		<item>@string/sort_posts_top_hour</item>
 		<item>@string/sort_posts_top_today</item>
 		<item>@string/sort_posts_top_week</item>
@@ -1014,7 +1039,12 @@
 		<item>hot</item>
 		<item>new</item>
 		<item>rising</item>
-		<item>controversial</item>
+		<item>controversial_hour</item>
+		<item>controversial_day</item>
+		<item>controversial_week</item>
+		<item>controversial_month</item>
+		<item>controversial_year</item>
+		<item>controversial_all</item>
 		<item>top_hour</item>
 		<item>top_day</item>
 		<item>top_week</item>
@@ -1026,7 +1056,12 @@
 	<string-array name="pref_behaviour_user_commentsort_array">
 		<item>@string/sort_comments_hot</item>
 		<item>@string/sort_comments_new</item>
-		<item>@string/sort_comments_controversial</item>
+		<item>@string/sort_posts_controversial_hour</item>
+		<item>@string/sort_posts_controversial_today</item>
+		<item>@string/sort_posts_controversial_week</item>
+		<item>@string/sort_posts_controversial_month</item>
+		<item>@string/sort_posts_controversial_year</item>
+		<item>@string/sort_posts_controversial_all</item>
 		<item>@string/sort_comments_top_hour</item>
 		<item>@string/sort_comments_top_today</item>
 		<item>@string/sort_comments_top_week</item>
@@ -1039,7 +1074,12 @@
 	<string-array name="pref_behaviour_user_commentsort_array_return">
 		<item>hot</item>
 		<item>new</item>
-		<item>controversial</item>
+		<item>controversial_hour</item>
+		<item>controversial_day</item>
+		<item>controversial_week</item>
+		<item>controversial_month</item>
+		<item>controversial_year</item>
+		<item>controversial_all</item>
 		<item>top_hour</item>
 		<item>top_day</item>
 		<item>top_week</item>


### PR DESCRIPTION
I realized that in #878, I forgot to add an option to use the new controversial sorts as defaults in the settings, and to make sure they upgrade gracefully if originally set to **Controversial** (without a time period).