### PR TITLE
Add date sorting for search sorts

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -1114,11 +1114,98 @@ public final class OptionsMenuUtility {
 			sortPosts.getItem().setShowAsAction(handleShowAsActionIfRoom(showAsAction));
 		}
 
-		addSort(activity, sortPosts, R.string.sort_posts_relevance, PostSort.RELEVANCE);
-		addSort(activity, sortPosts, R.string.sort_posts_new, PostSort.NEW);
-		addSort(activity, sortPosts, R.string.sort_posts_hot, PostSort.HOT);
-		addSort(activity, sortPosts, R.string.sort_posts_top, PostSort.TOP);
-		addSort(activity, sortPosts, R.string.sort_posts_comments, PostSort.COMMENTS);
+		final SubMenu sortPostsRelevance = sortPosts.addSubMenu(R.string.sort_posts_relevance);
+
+		addSort(
+				activity,
+				sortPostsRelevance,
+				R.string.sort_posts_relevance_hour,
+				PostSort.RELEVANCE_HOUR);
+		addSort(
+				activity,
+				sortPostsRelevance,
+				R.string.sort_posts_relevance_today,
+				PostSort.RELEVANCE_DAY);
+		addSort(
+				activity,
+				sortPostsRelevance,
+				R.string.sort_posts_relevance_week,
+				PostSort.RELEVANCE_WEEK);
+		addSort(
+				activity,
+				sortPostsRelevance,
+				R.string.sort_posts_relevance_month,
+				PostSort.RELEVANCE_MONTH);
+		addSort(
+				activity,
+				sortPostsRelevance,
+				R.string.sort_posts_relevance_year,
+				PostSort.RELEVANCE_YEAR);
+		addSort(
+				activity,
+				sortPostsRelevance,
+				R.string.sort_posts_relevance_all,
+				PostSort.RELEVANCE_ALL);
+
+		final SubMenu sortPostsNew = sortPosts.addSubMenu(R.string.sort_posts_new);
+
+		addSort(activity, sortPostsNew, R.string.sort_posts_new_hour, PostSort.NEW_HOUR);
+		addSort(activity, sortPostsNew, R.string.sort_posts_new_today, PostSort.NEW_DAY);
+		addSort(activity, sortPostsNew, R.string.sort_posts_new_week, PostSort.NEW_WEEK);
+		addSort(activity, sortPostsNew, R.string.sort_posts_new_month, PostSort.NEW_MONTH);
+		addSort(activity, sortPostsNew, R.string.sort_posts_new_year, PostSort.NEW_YEAR);
+		addSort(activity, sortPostsNew, R.string.sort_posts_new_all, PostSort.NEW_ALL);
+
+		final SubMenu sortPostsHot = sortPosts.addSubMenu(R.string.sort_posts_hot);
+
+		addSort(activity, sortPostsHot, R.string.sort_posts_hot_hour, PostSort.HOT_HOUR);
+		addSort(activity, sortPostsHot, R.string.sort_posts_hot_today, PostSort.HOT_DAY);
+		addSort(activity, sortPostsHot, R.string.sort_posts_hot_week, PostSort.HOT_WEEK);
+		addSort(activity, sortPostsHot, R.string.sort_posts_hot_month, PostSort.HOT_MONTH);
+		addSort(activity, sortPostsHot, R.string.sort_posts_hot_year, PostSort.HOT_YEAR);
+		addSort(activity, sortPostsHot, R.string.sort_posts_hot_all, PostSort.HOT_ALL);
+
+		final SubMenu sortPostsTop = sortPosts.addSubMenu(R.string.sort_posts_top);
+
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_hour, PostSort.TOP_HOUR);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_today, PostSort.TOP_DAY);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_week, PostSort.TOP_WEEK);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_month, PostSort.TOP_MONTH);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_year, PostSort.TOP_YEAR);
+		addSort(activity, sortPostsTop, R.string.sort_posts_top_all, PostSort.TOP_ALL);
+
+		final SubMenu sortPostsComments = sortPosts.addSubMenu(R.string.sort_posts_comments);
+
+		addSort(
+				activity,
+				sortPostsComments,
+				R.string.sort_posts_comments_hour,
+				PostSort.COMMENTS_HOUR);
+		addSort(
+				activity,
+				sortPostsComments,
+				R.string.sort_posts_comments_today,
+				PostSort.COMMENTS_DAY);
+		addSort(
+				activity,
+				sortPostsComments,
+				R.string.sort_posts_comments_week,
+				PostSort.COMMENTS_WEEK);
+		addSort(
+				activity,
+				sortPostsComments,
+				R.string.sort_posts_comments_month,
+				PostSort.COMMENTS_MONTH);
+		addSort(
+				activity,
+				sortPostsComments,
+				R.string.sort_posts_comments_year,
+				PostSort.COMMENTS_YEAR);
+		addSort(
+				activity,
+				sortPostsComments,
+				R.string.sort_posts_comments_all,
+				PostSort.COMMENTS_ALL);
 	}
 
 	private static void addSort(

--- a/src/main/java/org/quantumbadger/redreader/reddit/PostSort.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/PostSort.java
@@ -40,9 +40,30 @@ public enum PostSort {
 	CONTROVERSIAL_ALL,
 	BEST,
 	// Sorts related to Search Listings
-	RELEVANCE,
-	COMMENTS,
-	TOP;
+	RELEVANCE_HOUR,
+	RELEVANCE_DAY,
+	RELEVANCE_WEEK,
+	RELEVANCE_MONTH,
+	RELEVANCE_YEAR,
+	RELEVANCE_ALL,
+	NEW_HOUR,
+	NEW_DAY,
+	NEW_WEEK,
+	NEW_MONTH,
+	NEW_YEAR,
+	NEW_ALL,
+	COMMENTS_HOUR,
+	COMMENTS_DAY,
+	COMMENTS_WEEK,
+	COMMENTS_MONTH,
+	COMMENTS_YEAR,
+	COMMENTS_ALL,
+	HOT_HOUR,
+	HOT_DAY,
+	HOT_WEEK,
+	HOT_MONTH,
+	HOT_YEAR,
+	HOT_ALL;
 
 	@Nullable
 	public static PostSort valueOfOrNull(@NonNull final String string) {
@@ -114,6 +135,121 @@ public enum PostSort {
 				return TOP_YEAR;
 			} else {
 				return TOP_ALL;
+			}
+
+		} else {
+			return null;
+		}
+	}
+
+	@Nullable
+	public static PostSort parseSearch(@Nullable String sort, @Nullable String t) {
+
+		if(sort == null) {
+			return null;
+		}
+
+		sort = StringUtils.asciiLowercase(sort);
+		t = t != null ? StringUtils.asciiLowercase(t) : null;
+
+		if(sort.equals("relevance")) {
+
+			if(t == null) {
+				return RELEVANCE_ALL;
+			} else if(t.equals("all")) {
+				return RELEVANCE_ALL;
+			} else if(t.equals("hour")) {
+				return RELEVANCE_HOUR;
+			} else if(t.equals("day")) {
+				return RELEVANCE_DAY;
+			} else if(t.equals("week")) {
+				return RELEVANCE_WEEK;
+			} else if(t.equals("month")) {
+				return RELEVANCE_MONTH;
+			} else if(t.equals("year")) {
+				return RELEVANCE_YEAR;
+			} else {
+				return RELEVANCE_ALL;
+			}
+
+		} else if(sort.equals("new")) {
+
+			if(t == null) {
+				return NEW_ALL;
+			} else if(t.equals("all")) {
+				return NEW_ALL;
+			} else if(t.equals("hour")) {
+				return NEW_HOUR;
+			} else if(t.equals("day")) {
+				return NEW_DAY;
+			} else if(t.equals("week")) {
+				return NEW_WEEK;
+			} else if(t.equals("month")) {
+				return NEW_MONTH;
+			} else if(t.equals("year")) {
+				return NEW_YEAR;
+			} else {
+				return NEW_ALL;
+			}
+
+		} else if(sort.equals("hot")) {
+
+			if(t == null) {
+				return HOT_ALL;
+			} else if(t.equals("all")) {
+				return HOT_ALL;
+			} else if(t.equals("hour")) {
+				return HOT_HOUR;
+			} else if(t.equals("day")) {
+				return HOT_DAY;
+			} else if(t.equals("week")) {
+				return HOT_WEEK;
+			} else if(t.equals("month")) {
+				return HOT_MONTH;
+			} else if(t.equals("year")) {
+				return HOT_YEAR;
+			} else {
+				return HOT_ALL;
+			}
+
+		} else if(sort.equals("top")) {
+
+			if(t == null) {
+				return TOP_ALL;
+			} else if(t.equals("all")) {
+				return TOP_ALL;
+			} else if(t.equals("hour")) {
+				return TOP_HOUR;
+			} else if(t.equals("day")) {
+				return TOP_DAY;
+			} else if(t.equals("week")) {
+				return TOP_WEEK;
+			} else if(t.equals("month")) {
+				return TOP_MONTH;
+			} else if(t.equals("year")) {
+				return TOP_YEAR;
+			} else {
+				return TOP_ALL;
+			}
+
+		} else if(sort.equals("comments")) {
+
+			if(t == null) {
+				return COMMENTS_ALL;
+			} else if(t.equals("all")) {
+				return COMMENTS_ALL;
+			} else if(t.equals("hour")) {
+				return COMMENTS_HOUR;
+			} else if(t.equals("day")) {
+				return COMMENTS_DAY;
+			} else if(t.equals("week")) {
+				return COMMENTS_WEEK;
+			} else if(t.equals("month")) {
+				return COMMENTS_MONTH;
+			} else if(t.equals("year")) {
+				return COMMENTS_YEAR;
+			} else {
+				return COMMENTS_ALL;
 			}
 
 		} else {

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
@@ -59,7 +59,7 @@ public class SearchPostListURL extends PostListingURL {
 			final Integer limit,
 			final String before,
 			final String after) {
-		this(subreddit, query, PostSort.RELEVANCE, limit, before, after);
+		this(subreddit, query, PostSort.RELEVANCE_ALL, limit, before, after);
 	}
 
 	public static SearchPostListURL build(String subreddit, final String query) {
@@ -111,14 +111,39 @@ public class SearchPostListURL extends PostListingURL {
 
 		if(order != null) {
 			switch(order) {
-				case RELEVANCE:
-				case NEW:
-				case HOT:
-				case TOP:
-				case COMMENTS:
-					builder.appendQueryParameter(
-							"sort",
-							StringUtils.asciiLowercase(order.name()));
+				case RELEVANCE_HOUR:
+				case RELEVANCE_DAY:
+				case RELEVANCE_WEEK:
+				case RELEVANCE_MONTH:
+				case RELEVANCE_YEAR:
+				case RELEVANCE_ALL:
+				case NEW_HOUR:
+				case NEW_DAY:
+				case NEW_WEEK:
+				case NEW_MONTH:
+				case NEW_YEAR:
+				case NEW_ALL:
+				case HOT_HOUR:
+				case HOT_DAY:
+				case HOT_WEEK:
+				case HOT_MONTH:
+				case HOT_YEAR:
+				case HOT_ALL:
+				case TOP_HOUR:
+				case TOP_DAY:
+				case TOP_WEEK:
+				case TOP_MONTH:
+				case TOP_YEAR:
+				case TOP_ALL:
+				case COMMENTS_HOUR:
+				case COMMENTS_DAY:
+				case COMMENTS_WEEK:
+				case COMMENTS_MONTH:
+				case COMMENTS_YEAR:
+				case COMMENTS_ALL:
+					final String[] parts = order.name().split("_");
+					builder.appendQueryParameter("sort", StringUtils.asciiLowercase(parts[0]));
+					builder.appendQueryParameter("t", StringUtils.asciiLowercase(parts[1]));
 					break;
 			}
 		}
@@ -154,10 +179,13 @@ public class SearchPostListURL extends PostListingURL {
 
 		boolean restrictSubreddit = false;
 		String query = "";
-		PostSort order = null;
+		final PostSort order;
 		Integer limit = null;
 		String before = null;
 		String after = null;
+
+		String sortParam = null;
+		String timeParam = null;
 
 		for(final String parameterKey : General.getUriQueryParameterNames(uri)) {
 
@@ -174,7 +202,10 @@ public class SearchPostListURL extends PostListingURL {
 				}
 
 			} else if(parameterKey.equalsIgnoreCase("sort")) {
-				order = PostSort.valueOfOrNull(uri.getQueryParameter(parameterKey));
+				sortParam = uri.getQueryParameter(parameterKey);
+
+			} else if(parameterKey.equalsIgnoreCase("t")) {
+				timeParam = uri.getQueryParameter(parameterKey);
 
 			} else if(parameterKey.equalsIgnoreCase("q")) {
 				query = uri.getQueryParameter(parameterKey);
@@ -183,6 +214,8 @@ public class SearchPostListURL extends PostListingURL {
 				restrictSubreddit = "on".equalsIgnoreCase(uri.getQueryParameter(parameterKey));
 			}
 		}
+
+		order = PostSort.parseSearch(sortParam, timeParam);
 
 		final String[] pathSegments;
 		{

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1575,5 +1575,31 @@
 	<string name="sort_posts_controversial_month">Controversial: This Month</string>
 	<string name="sort_posts_controversial_year">Controversial: This Year</string>
 	<string name="sort_posts_controversial_all">Controversial: All Time</string>
+
+	<!-- 2021-07-18 -->
+	<string name="sort_posts_relevance_hour">Relevance: This Hour</string>
+	<string name="sort_posts_relevance_today">Relevance: Today</string>
+	<string name="sort_posts_relevance_week">Relevance: This Week</string>
+	<string name="sort_posts_relevance_month">Relevance: This Month</string>
+	<string name="sort_posts_relevance_year">Relevance: This Year</string>
+	<string name="sort_posts_relevance_all">Relevance: All Time</string>
+	<string name="sort_posts_new_hour">New: This Hour</string>
+	<string name="sort_posts_new_today">New: Today</string>
+	<string name="sort_posts_new_week">New: This Week</string>
+	<string name="sort_posts_new_month">New: This Month</string>
+	<string name="sort_posts_new_year">New: This Year</string>
+	<string name="sort_posts_new_all">New: All Time</string>
+	<string name="sort_posts_hot_hour">Hot: This Hour</string>
+	<string name="sort_posts_hot_today">Hot: Today</string>
+	<string name="sort_posts_hot_week">Hot: This Week</string>
+	<string name="sort_posts_hot_month">Hot: This Month</string>
+	<string name="sort_posts_hot_year">Hot: This Year</string>
+	<string name="sort_posts_hot_all">Hot: All Time</string>
+	<string name="sort_posts_comments_hour">Comments: This Hour</string>
+	<string name="sort_posts_comments_today">Comments: Today</string>
+	<string name="sort_posts_comments_week">Comments: This Week</string>
+	<string name="sort_posts_comments_month">Comments: This Month</string>
+	<string name="sort_posts_comments_year">Comments: This Year</string>
+	<string name="sort_posts_comments_all">Comments: All Time</string>
 	
 </resources>


### PR DESCRIPTION
Similar to my earlier PR, this adds date sorting for searches. There's no need to mess with any preferences here, since there isn't an option to set a default sort for searches (although maybe that's something we should add?)

I did my best to match the original code; since *every* search sort can be sorted by time period, it's a bit verbose. I could potentially do some reworking, but maybe it's best to leave it as is for ease of understanding, despite the length?