### PR TITLE
Block posts from blocked subreddits on the front page

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -785,7 +785,9 @@ public class PostListingFragment extends RRFragment
 											|| mPostListingURL.asSubredditPostListURL().type
 													== SubredditPostListURL.Type.ALL_SUBTRACTION
 											|| mPostListingURL.asSubredditPostListURL().type
-													== SubredditPostListURL.Type.POPULAR);
+													== SubredditPostListURL.Type.POPULAR
+											|| mPostListingURL.asSubredditPostListURL().type
+													== SubredditPostListURL.Type.FRONTPAGE);
 
 							// Grab this so we don't have to pull from the prefs every post
 							final HashSet<SubredditCanonicalId> blockedSubreddits

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -721,8 +721,8 @@
     <string name="block_subreddit">Block Subreddit</string>
     <string name="unblock_subreddit">Unblock Subreddit</string>
     <string name="pref_blocked_subreddits_key" translatable="false">pref_blocked_subreddits</string>
-    <string name="block_done">Subreddit blocked. Future visits to /r/all will exclude this subreddit.</string>
-    <string name="unblock_done">Subreddit unblocked. Future visits to /r/all will include this subreddit.</string>
+    <string name="block_done">Subreddit blocked. Future visits to the front page, /r/popular, and /r/all will exclude this subreddit.</string>
+    <string name="unblock_done">Subreddit unblocked. Future visits to the front page, /r/popular, and /r/all will include this subreddit.</string>
 
     <!-- 2016-03-14-->
     <string name="pref_behaviour_comment_min_key" translatable="false">pref_behaviour_comment_min</string>


### PR DESCRIPTION
Posts from blocked subreddits will now be hidden on the front page, which is nice for using the app while logged out.

I also updated the toasts that appear when (un)blocking a sub to reflect this. I kept close to the original wording, but perhaps the strings are a bit long for toasts?

Closes #653, Closes #891.