### PR TITLE
Show tooltips on the toolbars and side-toolbar

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -37,6 +37,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.TooltipCompat;
 import org.apache.commons.text.StringEscapeUtils;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
@@ -1865,14 +1866,10 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 					accessibilityAction = Action.UNHIDE;
 				}
 
-				final int textRes = accessibilityAction.descriptionResId;
+				final String text = activity.getString(accessibilityAction.descriptionResId);
 
-				ib.setContentDescription(activity.getString(textRes));
-
-				ib.setOnLongClickListener(view -> {
-					General.quickToast(activity, textRes);
-					return true;
-				});
+				ib.setContentDescription(text);
+				TooltipCompat.setTooltipText(ib, text);
 
 				toolbar.addItem(ib);
 			}

--- a/src/main/java/org/quantumbadger/redreader/views/PostListingHeader.java
+++ b/src/main/java/org/quantumbadger/redreader/views/PostListingHeader.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -28,6 +29,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.TooltipCompat;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
@@ -121,10 +123,9 @@ public final class PostListingHeader extends LinearLayout
 				activity,
 				sharedPreferences)) {
 
-			final LinearLayout buttons = (LinearLayout)inflate(
-					activity,
-					R.layout.subreddit_header_toolbar,
-					this);
+			final LinearLayout buttons =
+					inflate(activity, R.layout.subreddit_header_toolbar, this)
+							.findViewById(R.id.subreddit_toolbar_layout);
 
 			final ImageButton buttonSubscribe =
 					buttons.findViewById(R.id.subreddit_toolbar_button_subscribe);
@@ -144,6 +145,11 @@ public final class PostListingHeader extends LinearLayout
 					buttons.findViewById(R.id.subreddit_toolbar_button_share);
 			final ImageButton buttonInfo =
 					buttons.findViewById(R.id.subreddit_toolbar_button_info);
+
+			for(int i = 0; i < buttons.getChildCount(); i++) {
+				final View button = buttons.getChildAt(i);
+				TooltipCompat.setTooltipText(button, button.getContentDescription());
+			}
 
 			buttonSubscribeLoading.addView(new ButtonLoadingSpinnerView(activity));
 

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
@@ -23,6 +23,7 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.TooltipCompat;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
@@ -124,7 +125,8 @@ public class RedditPostHeaderView extends LinearLayout {
 			// A user is logged in
 
 			final LinearLayout buttons =
-					(LinearLayout)inflate(activity, R.layout.post_header_toolbar, this);
+					inflate(activity, R.layout.post_header_toolbar, this)
+							.findViewById(R.id.post_toolbar_layout);
 
 			final ImageButton buttonAddUpvote =
 					buttons.findViewById(R.id.post_toolbar_botton_add_upvote);
@@ -140,6 +142,11 @@ public class RedditPostHeaderView extends LinearLayout {
 					buttons.findViewById(R.id.post_toolbar_botton_share);
 			final ImageButton buttonMore =
 					buttons.findViewById(R.id.post_toolbar_botton_more);
+
+			for(int i = 0; i < buttons.getChildCount(); i++) {
+				final ImageButton button = (ImageButton)buttons.getChildAt(i);
+				TooltipCompat.setTooltipText(button, button.getContentDescription());
+			}
 
 			buttonAddUpvote.setOnClickListener(v -> post.performAction(
 					activity,

--- a/src/main/res/layout/post_header_toolbar.xml
+++ b/src/main/res/layout/post_header_toolbar.xml
@@ -20,6 +20,7 @@
 <LinearLayout
 		xmlns:android="http://schemas.android.com/apk/res/android"
 		xmlns:tools="http://schemas.android.com/tools"
+		android:id="@+id/post_toolbar_layout"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:background="?rrPostToolbarCol"

--- a/src/main/res/layout/subreddit_header_toolbar.xml
+++ b/src/main/res/layout/subreddit_header_toolbar.xml
@@ -20,6 +20,7 @@
 <LinearLayout
 		xmlns:android="http://schemas.android.com/apk/res/android"
 		xmlns:tools="http://schemas.android.com/tools"
+		android:id="@+id/subreddit_toolbar_layout"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:background="?rrPostToolbarCol"


### PR DESCRIPTION
This adds tooltips to the toolbars added in v1.10. It also replaces the toasts on the side-toolbar with tooltips, for consistency.

Closes #751.