### PR TITLE
Handle non-HTTP URLs using native apps in WebView

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -362,7 +362,7 @@ public class WebViewFragment extends Fragment
 				final Intent nativeAppIntent;
 				try {
 					nativeAppIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
-				} catch (URISyntaxException e) {
+				} catch (final URISyntaxException e) {
 					return false;
 				}
 
@@ -389,7 +389,7 @@ public class WebViewFragment extends Fragment
 				try {
 					startActivity(nativeAppIntent);
 					return true;
-				} catch (ActivityNotFoundException err) {
+				} catch (final ActivityNotFoundException e) {
 					return false;
 				}
 			}

--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -304,6 +304,16 @@ public class WebViewFragment extends Fragment
 					if(RedditURLParser.parse(Uri.parse(url)) != null) {
 						LinkHandler.onLinkClicked(mActivity, url, false);
 					} else {
+						if (!url.startsWith("http:") && !url.startsWith("https:")) {
+							Intent nativeAppIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+							try {
+								startActivity(nativeAppIntent);
+								return true;
+							} catch (ActivityNotFoundException err) {
+								// fall through and open the URL as though it's a regular HTTP URL
+							}
+						}
+
 						if(!PrefsUtility.pref_behaviour_useinternalbrowser()) {
 							LinkHandler.openWebBrowser(
 									mActivity,

--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -305,7 +305,7 @@ public class WebViewFragment extends Fragment
 						LinkHandler.onLinkClicked(mActivity, url, false);
 					} else {
 						if (!url.startsWith("http:") && !url.startsWith("https:")) {
-							Intent nativeAppIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+							final Intent nativeAppIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
 							try {
 								startActivity(nativeAppIntent);
 								return true;

--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -56,6 +56,7 @@ import org.quantumbadger.redreader.views.bezelmenu.SideToolbarOverlay;
 import org.quantumbadger.redreader.views.webview.VideoEnabledWebChromeClient;
 import org.quantumbadger.redreader.views.webview.WebViewFixed;
 
+import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -304,13 +305,31 @@ public class WebViewFragment extends Fragment
 					if(RedditURLParser.parse(Uri.parse(url)) != null) {
 						LinkHandler.onLinkClicked(mActivity, url, false);
 					} else {
-						if (!url.startsWith("http:") && !url.startsWith("https:")) {
-							final Intent nativeAppIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-							try {
-								startActivity(nativeAppIntent);
+						// When websites recognize the user agent is on Android, they sometimes
+						// redirect or offer deep links into native apps. These come in two flavors:
+						//
+						// 1. `intent://` URLs for arbitrary native apps. Launching these may be a
+						//    security vulnerability, because it's not clear what app is being
+						//    loaded with RedReader's permissions. Luckily, these URLs often have
+						//    fallback HTTP URLs, which can be loaded instead.
+						//
+						// 2. Custom scheme URLs, like `twitter://` or `market://` URLs. While these
+						//    can also launch arbitrary apps, the assumption is custom schemes are
+						//    only used for widely known apps (though even those can be replaced by
+						//    alternative apps). Often, these URLs don't have fallbacks, so take the
+						//    risk of loading these in their native apps.
+						//
+						// All this logic is in the `else` block because processing these URLs can
+						// fail, in which case the logic falls through and treats these URLs as
+						// HTTP URLs.
+
+						if (url.startsWith("intent:")) {
+							if (onEncounteredIntentUrl(url)) {
 								return true;
-							} catch (ActivityNotFoundException err) {
-								// fall through and open the URL as though it's a regular HTTP URL
+							}
+						} else if (!url.startsWith("http:") && !url.startsWith("https:")) {
+							if (onEncounteredCustomSchemeUrl(url)) {
+								return true;
 							}
 						}
 
@@ -334,6 +353,45 @@ public class WebViewFragment extends Fragment
 				}
 
 				return true;
+			}
+
+			/**
+			 * Assumes the {@code url} starts with `intent://`
+			 */
+			private boolean onEncounteredIntentUrl(final String url) {
+				final Intent nativeAppIntent;
+				try {
+					nativeAppIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+				} catch (URISyntaxException e) {
+					return false;
+				}
+
+				if (nativeAppIntent == null) {
+					return false;
+				}
+
+				final String fallbackUrl = nativeAppIntent.getStringExtra("browser_fallback_url");
+				if (fallbackUrl == null) {
+					return false;
+				}
+
+				webView.loadUrl(fallbackUrl);
+				currentUrl = fallbackUrl;
+				return true;
+			}
+
+			/**
+			 * Assumes the {@code url} starts with something other than `intent://`, `http://` or
+			 * `https://`
+			 */
+			private boolean onEncounteredCustomSchemeUrl(final String url) {
+				final Intent nativeAppIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+				try {
+					startActivity(nativeAppIntent);
+					return true;
+				} catch (ActivityNotFoundException err) {
+					return false;
+				}
 			}
 
 			@Override


### PR DESCRIPTION
Typically, these are deep links to native apps, which can be opened
using intents. This change attempts to open the native app, falling back
to letting the WebViewClient's URL-handling logic take over if no app is
installed that accepts that intent URL. This not only works for
`intent://` URLs, but also specific ones like `twitter://`.

To verify this change, find a link to a Tweet (found some on r/nfl),
open it using the WebView, then click the "Switch to the app" button
Twitter provides. Before this change, you'd get
`net::ERR_UNKNOWN_URL_SCHEME` erorr in the WebView. After the change, if
you don't have a Twitter client installed, you'll still get the same
error, but if you do have a client installed, it'll be opened.

Closes #787