### PR TITLE
Reply post action menu item

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -335,6 +335,13 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 						R.string.action_report,
 						Action.REPORT));
 			}
+
+			if(itemPref.contains(Action.REPLY) && !post.isArchived) {
+				menu.add(new RPVMenuItem(
+						activity,
+						R.string.action_reply,
+						Action.REPLY));
+			}
 		}
 
 		if(itemPref.contains(Action.EXTERNAL)) {

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -443,6 +443,7 @@
         <item>@string/action_hide</item>
         <item>@string/action_delete</item>
         <item>@string/action_report</item>
+        <item>@string/action_reply</item>
         <item>@string/action_external</item>
         <item>@string/action_selftext_links</item>
         <item>@string/action_save_image</item>
@@ -469,6 +470,7 @@
         <item>hide</item>
         <item>delete</item>
         <item>report</item>
+        <item>reply</item>
         <item>external</item>
         <item>selftext_links</item>
         <item>save_image</item>
@@ -1098,6 +1100,7 @@
 		<item>hide</item>
 		<item>delete</item>
 		<item>report</item>
+		<item>reply</item>
 		<item>external</item>
 		<item>selftext_links</item>
 		<item>save_image</item>


### PR DESCRIPTION
This adds a Reply option to the post action menu. I think it's a good idea to include this as a default option (which I've done here), for consistency with the comment action menu.

Closes #896.

PS: I accidentally used tabs instead of spaces in part of arrays.xml when I was working on this, and didn't notice until looking over this PR on GitHub, hence the awkward commit history. Maybe it'd be a good idea to switch to all tabs or all spaces in xml files, at least for the most commonly changed ones in `res/values` and `res/xml`?