### PR TITLE
Prevent replying to archived posts and comments

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -329,6 +329,11 @@ public class RedditAPICommentAction {
 				break;
 
 			case REPLY: {
+				if(renderableComment.getParsedComment().getRawComment().isArchived()) {
+					General.quickToast(activity, R.string.error_archived_reply, Toast.LENGTH_SHORT);
+					break;
+				}
+
 				final Intent intent = new Intent(activity, CommentReplyActivity.class);
 				intent.putExtra(
 						CommentReplyActivity.PARENT_ID_AND_TYPE_KEY,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -790,6 +790,11 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 				break;
 
 			case REPLY:
+				if(post.isArchived) {
+					General.quickToast(activity, R.string.error_archived_reply, Toast.LENGTH_SHORT);
+					break;
+				}
+
 				final Intent intent = new Intent(activity, CommentReplyActivity.class);
 				intent.putExtra(
 						CommentReplyActivity.PARENT_ID_AND_TYPE_KEY,

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1605,5 +1605,8 @@
 	<string name="sort_posts_comments_month">Comments: This Month</string>
 	<string name="sort_posts_comments_year">Comments: This Year</string>
 	<string name="sort_posts_comments_all">Comments: All Time</string>
+
+	<!-- 2021-09-07 -->
+	<string name="error_archived_reply">This has been archived and can no longer be replied to.</string>
 	
 </resources>


### PR DESCRIPTION
While working on #901, I noticed that RedReader doesn't stop you from trying to reply to an archived post or comment. This fixes that, in a way similar to how attempted votes are handled.