### PR TITLE
Refactor sorts in OptionsMenuUtility, move sorts to their own files

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -34,10 +34,11 @@ import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
 import org.quantumbadger.redreader.fragments.SessionListDialog;
 import org.quantumbadger.redreader.listingcontrollers.CommentListingController;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
-import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.views.RedditPostView;
 
 import java.util.UUID;
@@ -91,7 +92,7 @@ public class CommentListingActivity extends RefreshableActivity
 				}
 
 				if(savedInstanceState.containsKey(SAVEDSTATE_SORT)) {
-					controller.setSort(PostCommentListingURL.Sort.valueOf(
+					controller.setSort(PostCommentSort.valueOf(
 							savedInstanceState.getString(SAVEDSTATE_SORT)));
 				}
 
@@ -117,7 +118,7 @@ public class CommentListingActivity extends RefreshableActivity
 			outState.putString(SAVEDSTATE_SESSION, session.toString());
 		}
 
-		final PostCommentListingURL.Sort sort = controller.getSort();
+		final PostCommentSort sort = controller.getSort();
 		if(sort != null) {
 			outState.putString(SAVEDSTATE_SORT, sort.name());
 		}
@@ -188,13 +189,13 @@ public class CommentListingActivity extends RefreshableActivity
 	}
 
 	@Override
-	public void onSortSelected(final PostCommentListingURL.Sort order) {
+	public void onSortSelected(final PostCommentSort order) {
 		controller.setSort(order);
 		requestRefresh(RefreshableFragment.COMMENTS, false);
 	}
 
 	@Override
-	public void onSortSelected(final UserCommentListingURL.Sort order) {
+	public void onSortSelected(final UserCommentSort order) {
 		controller.setSort(order);
 		requestRefresh(RefreshableFragment.COMMENTS, false);
 	}

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -58,8 +58,10 @@ import org.quantumbadger.redreader.fragments.PostListingFragment;
 import org.quantumbadger.redreader.fragments.SessionListDialog;
 import org.quantumbadger.redreader.listingcontrollers.CommentListingController;
 import org.quantumbadger.redreader.listingcontrollers.PostListingController;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
 import org.quantumbadger.redreader.reddit.PostSort;
 import org.quantumbadger.redreader.reddit.RedditSubredditHistory;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 import org.quantumbadger.redreader.reddit.api.RedditSubredditSubscriptionManager;
 import org.quantumbadger.redreader.reddit.api.SubredditSubscriptionState;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
@@ -71,7 +73,6 @@ import org.quantumbadger.redreader.reddit.url.PostListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
 import org.quantumbadger.redreader.reddit.url.SearchPostListURL;
 import org.quantumbadger.redreader.reddit.url.SubredditPostListURL;
-import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.UserPostListingURL;
 import org.quantumbadger.redreader.reddit.url.UserProfileURL;
 import org.quantumbadger.redreader.views.RedditPostView;
@@ -821,13 +822,13 @@ public class MainActivity extends RefreshableActivity
 	}
 
 	@Override
-	public void onSortSelected(final PostCommentListingURL.Sort order) {
+	public void onSortSelected(final PostCommentSort order) {
 		commentListingController.setSort(order);
 		requestRefresh(RefreshableFragment.COMMENTS, false);
 	}
 
 	@Override
-	public void onSortSelected(final UserCommentListingURL.Sort order) {
+	public void onSortSelected(final UserCommentSort order) {
 		commentListingController.setSort(order);
 		requestRefresh(RefreshableFragment.COMMENTS, false);
 	}

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -31,10 +31,11 @@ import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
-import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.views.RedditPostView;
 
 import java.util.ArrayList;
@@ -160,11 +161,11 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 	}
 
 	@Override
-	public void onSortSelected(final PostCommentListingURL.Sort order) {
+	public void onSortSelected(final PostCommentSort order) {
 	}
 
 	@Override
-	public void onSortSelected(final UserCommentListingURL.Sort order) {
+	public void onSortSelected(final UserCommentSort order) {
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -26,6 +26,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.WindowManager;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
@@ -36,10 +37,10 @@ import org.quantumbadger.redreader.common.SharedPrefsWrapper;
 import org.quantumbadger.redreader.common.StringUtils;
 import org.quantumbadger.redreader.common.UnexpectedInternalStateException;
 import org.quantumbadger.redreader.fragments.AccountListDialog;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
 import org.quantumbadger.redreader.reddit.PostSort;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 import org.quantumbadger.redreader.reddit.api.SubredditSubscriptionState;
-import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
-import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 import org.quantumbadger.redreader.settings.SettingsActivity;
 
 import java.util.ArrayList;
@@ -1013,6 +1014,82 @@ public final class OptionsMenuUtility {
 		}
 	}
 
+	public interface Sort {
+		@StringRes int getMenuTitle();
+
+		void onSortSelected(final AppCompatActivity activity);
+	}
+
+	private static class SortGroup {
+		final Sort[] sorts;
+		@StringRes final int subMenuTitle;
+
+		SortGroup(final Sort[] sorts, final int subMenuTitle) {
+			this.sorts = sorts;
+			this.subMenuTitle = subMenuTitle;
+		}
+	}
+
+	final static SortGroup CONTROVERSIAL_SORTS = new SortGroup(
+			new PostSort[] {
+					PostSort.CONTROVERSIAL_HOUR,
+					PostSort.CONTROVERSIAL_DAY,
+					PostSort.CONTROVERSIAL_WEEK,
+					PostSort.CONTROVERSIAL_MONTH,
+					PostSort.CONTROVERSIAL_YEAR,
+					PostSort.CONTROVERSIAL_ALL},
+			R.string.sort_posts_controversial);
+
+	final static SortGroup TOP_SORTS = new SortGroup(
+			new PostSort[] {
+					PostSort.TOP_HOUR,
+					PostSort.TOP_DAY,
+					PostSort.TOP_WEEK,
+					PostSort.TOP_MONTH,
+					PostSort.TOP_YEAR,
+					PostSort.TOP_ALL},
+			R.string.sort_posts_top);
+
+	final static SortGroup RELEVANCE_SORTS = new SortGroup(
+			new PostSort[] {
+					PostSort.RELEVANCE_HOUR,
+					PostSort.RELEVANCE_DAY,
+					PostSort.RELEVANCE_WEEK,
+					PostSort.RELEVANCE_MONTH,
+					PostSort.RELEVANCE_YEAR,
+					PostSort.RELEVANCE_ALL},
+			R.string.sort_posts_relevance);
+
+	final static SortGroup NEW_SORTS = new SortGroup(
+			new PostSort[] {
+					PostSort.NEW_HOUR,
+					PostSort.NEW_DAY,
+					PostSort.NEW_WEEK,
+					PostSort.NEW_MONTH,
+					PostSort.NEW_YEAR,
+					PostSort.NEW_ALL},
+			R.string.sort_posts_new);
+
+	final static SortGroup HOT_SORTS = new SortGroup(
+			new PostSort[] {
+					PostSort.HOT_HOUR,
+					PostSort.HOT_DAY,
+					PostSort.HOT_WEEK,
+					PostSort.HOT_MONTH,
+					PostSort.HOT_YEAR,
+					PostSort.HOT_ALL},
+			R.string.sort_posts_hot);
+
+	final static SortGroup COMMENTS_SORTS = new SortGroup(
+			new PostSort[] {
+					PostSort.COMMENTS_HOUR,
+					PostSort.COMMENTS_DAY,
+					PostSort.COMMENTS_WEEK,
+					PostSort.COMMENTS_MONTH,
+					PostSort.COMMENTS_YEAR,
+					PostSort.COMMENTS_ALL},
+			R.string.sort_posts_comments);
+
 	private static void addAllPostSorts(
 			final AppCompatActivity activity,
 			final Menu menu,
@@ -1024,72 +1101,22 @@ public final class OptionsMenuUtility {
 			return;
 		}
 
-		final SubMenu sortPosts = menu.addSubMenu(
-				Menu.NONE,
-				AppbarItemsPref.SORT.ordinal(),
-				Menu.NONE,
-				R.string.options_sort_posts);
+		final SubMenu sortPosts = addSortSubMenu(menu, R.string.options_sort_posts, showAsAction);
 
-		if(showAsAction != MenuItem.SHOW_AS_ACTION_NEVER) {
-			sortPosts.getItem().setIcon(R.drawable.ic_sort_dark);
-			sortPosts.getItem().setShowAsAction(handleShowAsActionIfRoom(showAsAction));
-		}
+		addSort(activity, sortPosts, PostSort.HOT);
+		addSort(activity, sortPosts, PostSort.NEW);
 
-		addSort(activity, sortPosts, R.string.sort_posts_hot, PostSort.HOT);
-		addSort(activity, sortPosts, R.string.sort_posts_new, PostSort.NEW);
 		if(includeRising) {
-			addSort(activity, sortPosts, R.string.sort_posts_rising, PostSort.RISING);
+			addSort(activity, sortPosts, PostSort.RISING);
 		}
 
-		final SubMenu sortsPostsControversial =
-				sortPosts.addSubMenu(R.string.sort_posts_controversial);
-
-		addSort(
-				activity,
-				sortsPostsControversial,
-				R.string.sort_posts_controversial_hour,
-				PostSort.CONTROVERSIAL_HOUR);
-		addSort(
-				activity,
-				sortsPostsControversial,
-				R.string.sort_posts_controversial_today,
-				PostSort.CONTROVERSIAL_DAY);
-		addSort(
-				activity,
-				sortsPostsControversial,
-				R.string.sort_posts_controversial_week,
-				PostSort.CONTROVERSIAL_WEEK);
-		addSort(
-				activity,
-				sortsPostsControversial,
-				R.string.sort_posts_controversial_month,
-				PostSort.CONTROVERSIAL_MONTH);
-		addSort(
-				activity,
-				sortsPostsControversial,
-				R.string.sort_posts_controversial_year,
-				PostSort.CONTROVERSIAL_YEAR);
-		addSort(
-				activity, sortsPostsControversial,
-				R.string.sort_posts_controversial_all,
-				PostSort.CONTROVERSIAL_ALL);
+		addSortsToNewSubmenu(activity, sortPosts, CONTROVERSIAL_SORTS);
 
 		if(includeBest) {
-			addSort(activity, sortPosts, R.string.sort_posts_best, PostSort.BEST);
+			addSort(activity, sortPosts, PostSort.BEST);
 		}
 
-		final SubMenu sortPostsTop = sortPosts.addSubMenu(R.string.sort_posts_top);
-
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_hour, PostSort.TOP_HOUR);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_today, PostSort.TOP_DAY);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_week, PostSort.TOP_WEEK);
-		addSort(
-				activity,
-				sortPostsTop,
-				R.string.sort_posts_top_month,
-				PostSort.TOP_MONTH);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_year, PostSort.TOP_YEAR);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_all, PostSort.TOP_ALL);
+		addSortsToNewSubmenu(activity, sortPosts, TOP_SORTS);
 	}
 
 	private static void addAllSearchSorts(
@@ -1101,122 +1128,13 @@ public final class OptionsMenuUtility {
 			return;
 		}
 
-		final SubMenu sortPosts = menu.addSubMenu(
-				Menu.NONE,
-				AppbarItemsPref.SORT.ordinal(),
-				Menu.NONE,
-				R.string.options_sort_posts);
+		final SubMenu sortPosts = addSortSubMenu(menu, R.string.options_sort_posts, showAsAction);
 
-		if(showAsAction != MenuItem.SHOW_AS_ACTION_NEVER) {
-			sortPosts.getItem().setIcon(R.drawable.ic_sort_dark);
-			sortPosts.getItem().setShowAsAction(handleShowAsActionIfRoom(showAsAction));
-		}
-
-		final SubMenu sortPostsRelevance = sortPosts.addSubMenu(R.string.sort_posts_relevance);
-
-		addSort(
-				activity,
-				sortPostsRelevance,
-				R.string.sort_posts_relevance_hour,
-				PostSort.RELEVANCE_HOUR);
-		addSort(
-				activity,
-				sortPostsRelevance,
-				R.string.sort_posts_relevance_today,
-				PostSort.RELEVANCE_DAY);
-		addSort(
-				activity,
-				sortPostsRelevance,
-				R.string.sort_posts_relevance_week,
-				PostSort.RELEVANCE_WEEK);
-		addSort(
-				activity,
-				sortPostsRelevance,
-				R.string.sort_posts_relevance_month,
-				PostSort.RELEVANCE_MONTH);
-		addSort(
-				activity,
-				sortPostsRelevance,
-				R.string.sort_posts_relevance_year,
-				PostSort.RELEVANCE_YEAR);
-		addSort(
-				activity,
-				sortPostsRelevance,
-				R.string.sort_posts_relevance_all,
-				PostSort.RELEVANCE_ALL);
-
-		final SubMenu sortPostsNew = sortPosts.addSubMenu(R.string.sort_posts_new);
-
-		addSort(activity, sortPostsNew, R.string.sort_posts_new_hour, PostSort.NEW_HOUR);
-		addSort(activity, sortPostsNew, R.string.sort_posts_new_today, PostSort.NEW_DAY);
-		addSort(activity, sortPostsNew, R.string.sort_posts_new_week, PostSort.NEW_WEEK);
-		addSort(activity, sortPostsNew, R.string.sort_posts_new_month, PostSort.NEW_MONTH);
-		addSort(activity, sortPostsNew, R.string.sort_posts_new_year, PostSort.NEW_YEAR);
-		addSort(activity, sortPostsNew, R.string.sort_posts_new_all, PostSort.NEW_ALL);
-
-		final SubMenu sortPostsHot = sortPosts.addSubMenu(R.string.sort_posts_hot);
-
-		addSort(activity, sortPostsHot, R.string.sort_posts_hot_hour, PostSort.HOT_HOUR);
-		addSort(activity, sortPostsHot, R.string.sort_posts_hot_today, PostSort.HOT_DAY);
-		addSort(activity, sortPostsHot, R.string.sort_posts_hot_week, PostSort.HOT_WEEK);
-		addSort(activity, sortPostsHot, R.string.sort_posts_hot_month, PostSort.HOT_MONTH);
-		addSort(activity, sortPostsHot, R.string.sort_posts_hot_year, PostSort.HOT_YEAR);
-		addSort(activity, sortPostsHot, R.string.sort_posts_hot_all, PostSort.HOT_ALL);
-
-		final SubMenu sortPostsTop = sortPosts.addSubMenu(R.string.sort_posts_top);
-
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_hour, PostSort.TOP_HOUR);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_today, PostSort.TOP_DAY);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_week, PostSort.TOP_WEEK);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_month, PostSort.TOP_MONTH);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_year, PostSort.TOP_YEAR);
-		addSort(activity, sortPostsTop, R.string.sort_posts_top_all, PostSort.TOP_ALL);
-
-		final SubMenu sortPostsComments = sortPosts.addSubMenu(R.string.sort_posts_comments);
-
-		addSort(
-				activity,
-				sortPostsComments,
-				R.string.sort_posts_comments_hour,
-				PostSort.COMMENTS_HOUR);
-		addSort(
-				activity,
-				sortPostsComments,
-				R.string.sort_posts_comments_today,
-				PostSort.COMMENTS_DAY);
-		addSort(
-				activity,
-				sortPostsComments,
-				R.string.sort_posts_comments_week,
-				PostSort.COMMENTS_WEEK);
-		addSort(
-				activity,
-				sortPostsComments,
-				R.string.sort_posts_comments_month,
-				PostSort.COMMENTS_MONTH);
-		addSort(
-				activity,
-				sortPostsComments,
-				R.string.sort_posts_comments_year,
-				PostSort.COMMENTS_YEAR);
-		addSort(
-				activity,
-				sortPostsComments,
-				R.string.sort_posts_comments_all,
-				PostSort.COMMENTS_ALL);
-	}
-
-	private static void addSort(
-			final AppCompatActivity activity,
-			final Menu menu,
-			final int name,
-			final PostSort order) {
-
-		menu.add(activity.getString(name))
-				.setOnMenuItemClickListener(item -> {
-					((OptionsMenuPostsListener)activity).onSortSelected(order);
-					return true;
-				});
+		addSortsToNewSubmenu(activity, sortPosts, RELEVANCE_SORTS);
+		addSortsToNewSubmenu(activity, sortPosts, NEW_SORTS);
+		addSortsToNewSubmenu(activity, sortPosts, HOT_SORTS);
+		addSortsToNewSubmenu(activity, sortPosts, TOP_SORTS);
+		addSortsToNewSubmenu(activity, sortPosts, COMMENTS_SORTS);
 	}
 
 	private static void addAllCommentSorts(
@@ -1228,67 +1146,45 @@ public final class OptionsMenuUtility {
 			return;
 		}
 
-		final SubMenu sortComments = menu.addSubMenu(
-				Menu.NONE,
-				AppbarItemsPref.SORT.ordinal(),
-				Menu.NONE,
-				R.string.options_sort_comments);
+		final SubMenu sortComments = addSortSubMenu(
+				menu,
+				R.string.options_sort_comments,
+				showAsAction);
 
-		if(showAsAction != MenuItem.SHOW_AS_ACTION_NEVER) {
-			sortComments.getItem().setIcon(R.drawable.ic_sort_dark);
-			sortComments.getItem()
-					.setShowAsAction(handleShowAsActionIfRoom(showAsAction));
+		final PostCommentSort[] postCommentSorts = {
+				PostCommentSort.BEST,
+				PostCommentSort.HOT,
+				PostCommentSort.NEW,
+				PostCommentSort.OLD,
+				PostCommentSort.CONTROVERSIAL,
+				PostCommentSort.TOP,
+				PostCommentSort.QA
+		};
+
+		for(final PostCommentSort sort : postCommentSorts) {
+			addSort(activity, sortComments, sort);
 		}
-
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_best,
-				PostCommentListingURL.Sort.BEST);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_hot,
-				PostCommentListingURL.Sort.HOT);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_new,
-				PostCommentListingURL.Sort.NEW);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_old,
-				PostCommentListingURL.Sort.OLD);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_controversial,
-				PostCommentListingURL.Sort.CONTROVERSIAL);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_top,
-				PostCommentListingURL.Sort.TOP);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_qa,
-				PostCommentListingURL.Sort.QA);
 	}
 
-	private static void addSort(
-			final AppCompatActivity activity,
-			final Menu menu,
-			final int name,
-			final PostCommentListingURL.Sort order) {
+	final static SortGroup CONTROVERSIAL_COMMENT_SORTS = new SortGroup(
+			new UserCommentSort[] {
+					UserCommentSort.CONTROVERSIAL_HOUR,
+					UserCommentSort.CONTROVERSIAL_DAY,
+					UserCommentSort.CONTROVERSIAL_WEEK,
+					UserCommentSort.CONTROVERSIAL_MONTH,
+					UserCommentSort.CONTROVERSIAL_YEAR,
+					UserCommentSort.CONTROVERSIAL_ALL},
+			R.string.sort_comments_controversial);
 
-		menu.add(activity.getString(name))
-				.setOnMenuItemClickListener(item -> {
-					((OptionsMenuCommentsListener)activity).onSortSelected(order);
-					return true;
-				});
-	}
+	final static SortGroup TOP_COMMENT_SORTS = new SortGroup(
+			new UserCommentSort[] {
+					UserCommentSort.TOP_HOUR,
+					UserCommentSort.TOP_DAY,
+					UserCommentSort.TOP_WEEK,
+					UserCommentSort.TOP_MONTH,
+					UserCommentSort.TOP_YEAR,
+					UserCommentSort.TOP_ALL},
+			R.string.sort_comments_top);
 
 	private static void addAllUserCommentSorts(
 			final AppCompatActivity activity,
@@ -1299,109 +1195,59 @@ public final class OptionsMenuUtility {
 			return;
 		}
 
-		final SubMenu sortComments = menu.addSubMenu(
-				Menu.NONE,
-				AppbarItemsPref.SORT.ordinal(),
-				Menu.NONE,
-				R.string.options_sort_comments);
+		final SubMenu sortComments = addSortSubMenu(
+				menu,
+				R.string.options_sort_comments,
+				showAsAction);
 
-		if(showAsAction != MenuItem.SHOW_AS_ACTION_NEVER) {
-			sortComments.getItem().setIcon(R.drawable.ic_sort_dark);
-			sortComments.getItem()
-					.setShowAsAction(handleShowAsActionIfRoom(showAsAction));
-		}
+		addSort(activity, sortComments, UserCommentSort.HOT);
+		addSort(activity, sortComments, UserCommentSort.NEW);
 
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_hot,
-				UserCommentListingURL.Sort.HOT);
-		addSort(
-				activity,
-				sortComments,
-				R.string.sort_comments_new,
-				UserCommentListingURL.Sort.NEW);
-
-		final SubMenu sortCommentsControversial
-				= sortComments.addSubMenu(R.string.sort_comments_controversial);
-
-		addSort(
-				activity,
-				sortCommentsControversial,
-				R.string.sort_posts_controversial_hour,
-				UserCommentListingURL.Sort.CONTROVERSIAL_HOUR);
-		addSort(
-				activity,
-				sortCommentsControversial,
-				R.string.sort_posts_controversial_today,
-				UserCommentListingURL.Sort.CONTROVERSIAL_DAY);
-		addSort(
-				activity,
-				sortCommentsControversial,
-				R.string.sort_posts_controversial_week,
-				UserCommentListingURL.Sort.CONTROVERSIAL_WEEK);
-		addSort(
-				activity,
-				sortCommentsControversial,
-				R.string.sort_posts_controversial_month,
-				UserCommentListingURL.Sort.CONTROVERSIAL_MONTH);
-		addSort(
-				activity,
-				sortCommentsControversial,
-				R.string.sort_posts_controversial_year,
-				UserCommentListingURL.Sort.CONTROVERSIAL_YEAR);
-		addSort(
-				activity,
-				sortCommentsControversial,
-				R.string.sort_posts_controversial_all,
-				UserCommentListingURL.Sort.CONTROVERSIAL_ALL);
-
-		final SubMenu sortCommentsTop
-				= sortComments.addSubMenu(R.string.sort_comments_top);
-
-		addSort(
-				activity,
-				sortCommentsTop,
-				R.string.sort_posts_top_hour,
-				UserCommentListingURL.Sort.TOP_HOUR);
-		addSort(
-				activity,
-				sortCommentsTop,
-				R.string.sort_posts_top_today,
-				UserCommentListingURL.Sort.TOP_DAY);
-		addSort(
-				activity,
-				sortCommentsTop,
-				R.string.sort_posts_top_week,
-				UserCommentListingURL.Sort.TOP_WEEK);
-		addSort(
-				activity,
-				sortCommentsTop,
-				R.string.sort_posts_top_month,
-				UserCommentListingURL.Sort.TOP_MONTH);
-		addSort(
-				activity,
-				sortCommentsTop,
-				R.string.sort_posts_top_year,
-				UserCommentListingURL.Sort.TOP_YEAR);
-		addSort(
-				activity,
-				sortCommentsTop,
-				R.string.sort_posts_top_all,
-				UserCommentListingURL.Sort.TOP_ALL);
+		addSortsToNewSubmenu(activity, sortComments, CONTROVERSIAL_COMMENT_SORTS);
+		addSortsToNewSubmenu(activity, sortComments, TOP_COMMENT_SORTS);
 	}
 
 	private static void addSort(
 			final AppCompatActivity activity,
 			final Menu menu,
-			final int name,
-			final UserCommentListingURL.Sort order) {
+			final Sort order) {
 
-		menu.add(activity.getString(name))
-				.setOnMenuItemClickListener(menuItem -> {
-					((OptionsMenuCommentsListener)activity).onSortSelected(order);
+		menu.add(activity.getString(order.getMenuTitle()))
+				.setOnMenuItemClickListener(item -> {
+					order.onSortSelected(activity);
 					return true;
 				});
+	}
+
+	private static void addSortsToNewSubmenu(
+			final AppCompatActivity activity,
+			final Menu menu,
+			final SortGroup sortGroup) {
+
+		final SubMenu subMenu = menu.addSubMenu(activity.getString(sortGroup.subMenuTitle));
+
+		for(final Sort sort : sortGroup.sorts) {
+			addSort(activity, subMenu, sort);
+		}
+	}
+
+	private static SubMenu addSortSubMenu(
+			final Menu menu,
+			@StringRes final int subMenuTitle,
+			final int showAsAction) {
+
+		final SubMenu sortMenu = menu.addSubMenu(
+				Menu.NONE,
+				AppbarItemsPref.SORT.ordinal(),
+				Menu.NONE,
+				subMenuTitle);
+
+		if(showAsAction != MenuItem.SHOW_AS_ACTION_NEVER) {
+			sortMenu.getItem().setIcon(R.drawable.ic_sort_dark);
+			sortMenu.getItem().setShowAsAction(handleShowAsActionIfRoom(showAsAction));
+		}
+
+		return sortMenu;
 	}
 
 	private static class QuickAccountsSort {
@@ -1536,9 +1382,9 @@ public final class OptionsMenuUtility {
 
 		void onPastComments();
 
-		void onSortSelected(PostCommentListingURL.Sort order);
+		void onSortSelected(PostCommentSort order);
 
-		void onSortSelected(UserCommentListingURL.Sort order);
+		void onSortSelected(UserCommentSort order);
 
 		void onSearchComments();
 	}

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -31,13 +31,13 @@ import org.quantumbadger.redreader.activities.OptionsMenuUtility;
 import org.quantumbadger.redreader.adapters.MainMenuListingManager;
 import org.quantumbadger.redreader.fragments.MainMenuFragment;
 import org.quantumbadger.redreader.io.WritableHashSet;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
 import org.quantumbadger.redreader.reddit.PostSort;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 import org.quantumbadger.redreader.reddit.api.RedditAPICommentAction;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.things.InvalidSubredditNameException;
 import org.quantumbadger.redreader.reddit.things.SubredditCanonicalId;
-import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
-import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -1025,14 +1025,14 @@ public final class PrefsUtility {
 				"hot")));
 	}
 
-	public static PostCommentListingURL.Sort pref_behaviour_commentsort() {
-		return PostCommentListingURL.Sort.valueOf(StringUtils.asciiUppercase(getString(
+	public static PostCommentSort pref_behaviour_commentsort() {
+		return PostCommentSort.valueOf(StringUtils.asciiUppercase(getString(
 				R.string.pref_behaviour_commentsort_key,
 				"best")));
 	}
 
-	public static UserCommentListingURL.Sort pref_behaviour_user_commentsort() {
-		return UserCommentListingURL.Sort.valueOf(StringUtils.asciiUppercase(getString(
+	public static UserCommentSort pref_behaviour_user_commentsort() {
+		return UserCommentSort.valueOf(StringUtils.asciiUppercase(getString(
 				R.string.pref_behaviour_user_commentsort_key,
 				"new")));
 	}

--- a/src/main/java/org/quantumbadger/redreader/listingcontrollers/CommentListingController.java
+++ b/src/main/java/org/quantumbadger/redreader/listingcontrollers/CommentListingController.java
@@ -23,10 +23,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 import org.quantumbadger.redreader.reddit.url.CommentListingURL;
-import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
-import org.quantumbadger.redreader.reddit.url.UserCommentListingURL;
 
 import java.util.UUID;
 
@@ -64,27 +64,27 @@ public class CommentListingController {
 		this.mUrl = (CommentListingURL)url;
 	}
 
-	private PostCommentListingURL.Sort defaultOrder() {
+	private PostCommentSort defaultOrder() {
 		return PrefsUtility.pref_behaviour_commentsort();
 	}
 
-	private UserCommentListingURL.Sort defaultUserOrder() {
+	private UserCommentSort defaultUserOrder() {
 		return PrefsUtility.pref_behaviour_user_commentsort();
 	}
 
-	public void setSort(final PostCommentListingURL.Sort s) {
+	public void setSort(final PostCommentSort s) {
 		if(mUrl.pathType() == RedditURLParser.POST_COMMENT_LISTING_URL) {
 			mUrl = mUrl.asPostCommentListURL().order(s);
 		}
 	}
 
-	public void setSort(final UserCommentListingURL.Sort s) {
+	public void setSort(final UserCommentSort s) {
 		if(mUrl.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL) {
 			mUrl = mUrl.asUserCommentListURL().order(s);
 		}
 	}
 
-	public PostCommentListingURL.Sort getSort() {
+	public PostCommentSort getSort() {
 
 		if(mUrl.pathType() == RedditURLParser.POST_COMMENT_LISTING_URL) {
 			return mUrl.asPostCommentListURL().order;

--- a/src/main/java/org/quantumbadger/redreader/reddit/PostCommentSort.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/PostCommentSort.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.quantumbadger.redreader.reddit;
+
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatActivity;
+import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.activities.OptionsMenuUtility;
+import org.quantumbadger.redreader.common.StringUtils;
+
+public enum PostCommentSort implements OptionsMenuUtility.Sort {
+
+	BEST("confidence", R.string.sort_comments_best),
+	HOT("hot", R.string.sort_comments_hot),
+	NEW("new", R.string.sort_comments_new),
+	OLD("old", R.string.sort_comments_old),
+	TOP("top", R.string.sort_comments_top),
+	CONTROVERSIAL("controversial", R.string.sort_comments_controversial),
+	QA("qa", R.string.sort_comments_qa);
+
+	public final String key;
+	@StringRes
+	private final int menuTitle;
+
+	PostCommentSort(final String key, @StringRes final int menuTitle) {
+		this.key = key;
+		this.menuTitle = menuTitle;
+	}
+
+	public static PostCommentSort lookup(String name) {
+
+		name = StringUtils.asciiUppercase(name);
+
+		if (name.equals("CONFIDENCE")) {
+			return BEST; // oh, reddit...
+		}
+
+		try {
+			return PostCommentSort.valueOf(name);
+		} catch (final IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public int getMenuTitle() {
+		return menuTitle;
+	}
+
+	@Override
+	public void onSortSelected(final AppCompatActivity activity) {
+		((OptionsMenuUtility.OptionsMenuCommentsListener)activity).onSortSelected(this);
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/reddit/PostSort.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/PostSort.java
@@ -20,50 +20,59 @@ package org.quantumbadger.redreader.reddit;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatActivity;
+import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.activities.OptionsMenuUtility;
 import org.quantumbadger.redreader.common.StringUtils;
 
-public enum PostSort {
-	HOT,
-	NEW,
-	RISING,
-	TOP_HOUR,
-	TOP_DAY,
-	TOP_WEEK,
-	TOP_MONTH,
-	TOP_YEAR,
-	TOP_ALL,
-	CONTROVERSIAL_HOUR,
-	CONTROVERSIAL_DAY,
-	CONTROVERSIAL_WEEK,
-	CONTROVERSIAL_MONTH,
-	CONTROVERSIAL_YEAR,
-	CONTROVERSIAL_ALL,
-	BEST,
+public enum PostSort implements OptionsMenuUtility.Sort {
+	HOT(R.string.sort_posts_hot),
+	NEW(R.string.sort_posts_new),
+	RISING(R.string.sort_posts_rising),
+	TOP_HOUR(R.string.sort_posts_top_hour),
+	TOP_DAY(R.string.sort_posts_top_today),
+	TOP_WEEK(R.string.sort_posts_top_week),
+	TOP_MONTH(R.string.sort_posts_top_month),
+	TOP_YEAR(R.string.sort_posts_top_year),
+	TOP_ALL(R.string.sort_posts_top_all),
+	CONTROVERSIAL_HOUR(R.string.sort_posts_controversial_hour),
+	CONTROVERSIAL_DAY(R.string.sort_posts_controversial_today),
+	CONTROVERSIAL_WEEK(R.string.sort_posts_controversial_week),
+	CONTROVERSIAL_MONTH(R.string.sort_posts_controversial_month),
+	CONTROVERSIAL_YEAR(R.string.sort_posts_controversial_year),
+	CONTROVERSIAL_ALL(R.string.sort_posts_controversial_all),
+	BEST(R.string.sort_posts_best),
 	// Sorts related to Search Listings
-	RELEVANCE_HOUR,
-	RELEVANCE_DAY,
-	RELEVANCE_WEEK,
-	RELEVANCE_MONTH,
-	RELEVANCE_YEAR,
-	RELEVANCE_ALL,
-	NEW_HOUR,
-	NEW_DAY,
-	NEW_WEEK,
-	NEW_MONTH,
-	NEW_YEAR,
-	NEW_ALL,
-	COMMENTS_HOUR,
-	COMMENTS_DAY,
-	COMMENTS_WEEK,
-	COMMENTS_MONTH,
-	COMMENTS_YEAR,
-	COMMENTS_ALL,
-	HOT_HOUR,
-	HOT_DAY,
-	HOT_WEEK,
-	HOT_MONTH,
-	HOT_YEAR,
-	HOT_ALL;
+	RELEVANCE_HOUR(R.string.sort_posts_relevance_hour),
+	RELEVANCE_DAY(R.string.sort_posts_relevance_today),
+	RELEVANCE_WEEK(R.string.sort_posts_relevance_week),
+	RELEVANCE_MONTH(R.string.sort_posts_relevance_month),
+	RELEVANCE_YEAR(R.string.sort_posts_relevance_year),
+	RELEVANCE_ALL(R.string.sort_posts_relevance_all),
+	NEW_HOUR(R.string.sort_posts_new_hour),
+	NEW_DAY(R.string.sort_posts_new_today),
+	NEW_WEEK(R.string.sort_posts_new_week),
+	NEW_MONTH(R.string.sort_posts_new_month),
+	NEW_YEAR(R.string.sort_posts_new_year),
+	NEW_ALL(R.string.sort_posts_new_all),
+	COMMENTS_HOUR(R.string.sort_posts_comments_hour),
+	COMMENTS_DAY(R.string.sort_posts_comments_today),
+	COMMENTS_WEEK(R.string.sort_posts_comments_week),
+	COMMENTS_MONTH(R.string.sort_posts_comments_month),
+	COMMENTS_YEAR(R.string.sort_posts_comments_year),
+	COMMENTS_ALL(R.string.sort_posts_comments_all),
+	HOT_HOUR(R.string.sort_posts_hot_hour),
+	HOT_DAY(R.string.sort_posts_hot_today),
+	HOT_WEEK(R.string.sort_posts_hot_week),
+	HOT_MONTH(R.string.sort_posts_hot_month),
+	HOT_YEAR(R.string.sort_posts_hot_year),
+	HOT_ALL(R.string.sort_posts_hot_all);
+
+	@StringRes private final int menuTitle;
+	PostSort(@StringRes final int menuTitle) {
+		this.menuTitle = menuTitle;
+	}
 
 	@Nullable
 	public static PostSort valueOfOrNull(@NonNull final String string) {
@@ -311,5 +320,15 @@ public enum PostSort {
 				builder.appendQueryParameter("t", StringUtils.asciiLowercase(parts[1]));
 				break;
 		}
+	}
+
+	@Override
+	public int getMenuTitle() {
+		return menuTitle;
+	}
+
+	@Override
+	public void onSortSelected(final AppCompatActivity activity) {
+		((OptionsMenuUtility.OptionsMenuPostsListener)activity).onSortSelected(this);
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/reddit/UserCommentSort.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/UserCommentSort.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.quantumbadger.redreader.reddit;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AppCompatActivity;
+import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.activities.OptionsMenuUtility;
+import org.quantumbadger.redreader.common.StringUtils;
+
+public enum UserCommentSort implements OptionsMenuUtility.Sort {
+	NEW(R.string.sort_comments_new),
+	HOT(R.string.sort_comments_hot),
+	CONTROVERSIAL_HOUR(R.string.sort_posts_controversial_hour),
+	CONTROVERSIAL_DAY(R.string.sort_posts_controversial_today),
+	CONTROVERSIAL_WEEK(R.string.sort_posts_controversial_week),
+	CONTROVERSIAL_MONTH(R.string.sort_posts_controversial_month),
+	CONTROVERSIAL_YEAR(R.string.sort_posts_controversial_year),
+	CONTROVERSIAL_ALL(R.string.sort_posts_controversial_all),
+	TOP_HOUR(R.string.sort_posts_top_hour),
+	TOP_DAY(R.string.sort_posts_top_today),
+	TOP_WEEK(R.string.sort_posts_top_week),
+	TOP_MONTH(R.string.sort_posts_top_month),
+	TOP_YEAR(R.string.sort_posts_top_year),
+	TOP_ALL(R.string.sort_posts_top_all);
+
+	@StringRes
+	private final int menuTitle;
+
+	UserCommentSort(@StringRes final int menuTitle) {
+		this.menuTitle = menuTitle;
+	}
+
+	@Nullable
+	public static UserCommentSort parse(@Nullable String sort, @Nullable String t) {
+
+		if (sort == null) {
+			return null;
+		}
+
+		sort = StringUtils.asciiLowercase(sort);
+		t = t != null ? StringUtils.asciiLowercase(t) : null;
+
+		if (sort.equals("hot")) {
+			return HOT;
+
+		} else if (sort.equals("new")) {
+			return NEW;
+
+		} else if (sort.equals("controversial")) {
+			if (t == null) {
+				return CONTROVERSIAL_ALL;
+			} else if (t.equals("all")) {
+				return CONTROVERSIAL_ALL;
+			} else if (t.equals("hour")) {
+				return CONTROVERSIAL_HOUR;
+			} else if (t.equals("day")) {
+				return CONTROVERSIAL_DAY;
+			} else if (t.equals("week")) {
+				return CONTROVERSIAL_WEEK;
+			} else if (t.equals("month")) {
+				return CONTROVERSIAL_MONTH;
+			} else if (t.equals("year")) {
+				return CONTROVERSIAL_YEAR;
+			} else {
+				return CONTROVERSIAL_ALL;
+			}
+
+		} else if (sort.equals("top")) {
+
+			if (t == null) {
+				return TOP_ALL;
+			} else if (t.equals("all")) {
+				return TOP_ALL;
+			} else if (t.equals("hour")) {
+				return TOP_HOUR;
+			} else if (t.equals("day")) {
+				return TOP_DAY;
+			} else if (t.equals("week")) {
+				return TOP_WEEK;
+			} else if (t.equals("month")) {
+				return TOP_MONTH;
+			} else if (t.equals("year")) {
+				return TOP_YEAR;
+			} else {
+				return TOP_ALL;
+			}
+
+		} else {
+			return null;
+		}
+	}
+
+	public void addToUserCommentListingUri(@NonNull final Uri.Builder builder) {
+
+		switch (this) {
+			case HOT:
+			case NEW:
+				builder.appendQueryParameter("sort", StringUtils.asciiLowercase(name()));
+				break;
+
+			case CONTROVERSIAL_HOUR:
+			case CONTROVERSIAL_DAY:
+			case CONTROVERSIAL_WEEK:
+			case CONTROVERSIAL_MONTH:
+			case CONTROVERSIAL_YEAR:
+			case CONTROVERSIAL_ALL:
+			case TOP_HOUR:
+			case TOP_DAY:
+			case TOP_WEEK:
+			case TOP_MONTH:
+			case TOP_YEAR:
+			case TOP_ALL:
+				final String[] parts = name().split("_");
+				builder.appendQueryParameter(
+						"sort",
+						StringUtils.asciiLowercase(parts[0]));
+				builder.appendQueryParameter("t", StringUtils.asciiLowercase(parts[1]));
+				break;
+		}
+	}
+
+	@Override
+	public int getMenuTitle() {
+		return menuTitle;
+	}
+
+	@Override
+	public void onSortSelected(final AppCompatActivity activity) {
+		((OptionsMenuUtility.OptionsMenuCommentsListener)activity).onSortSelected(this);
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/PostCommentListingURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/PostCommentListingURL.java
@@ -23,6 +23,7 @@ import androidx.annotation.NonNull;
 import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.StringUtils;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +38,7 @@ public class PostCommentListingURL extends CommentListingURL {
 	public final Integer context;
 	public final Integer limit;
 
-	public final Sort order;
+	public final PostCommentSort order;
 
 	public static PostCommentListingURL forPostId(final String postId) {
 		return new PostCommentListingURL(null, postId, null, null, null, null);
@@ -49,7 +50,7 @@ public class PostCommentListingURL extends CommentListingURL {
 			String commentId,
 			final Integer context,
 			final Integer limit,
-			final Sort order) {
+			final PostCommentSort order) {
 
 		if(postId != null && postId.startsWith("t3_")) {
 			postId = postId.substring(3);
@@ -81,7 +82,7 @@ public class PostCommentListingURL extends CommentListingURL {
 		return new PostCommentListingURL(after, postId, commentId, context, limit, order);
 	}
 
-	public PostCommentListingURL order(final Sort order) {
+	public PostCommentListingURL order(final PostCommentSort order) {
 		return new PostCommentListingURL(after, postId, commentId, context, limit, order);
 	}
 
@@ -208,7 +209,7 @@ public class PostCommentListingURL extends CommentListingURL {
 		String after = null;
 		Integer limit = null;
 		Integer context = null;
-		Sort order = null;
+		PostCommentSort order = null;
 
 		for(final String parameterKey : General.getUriQueryParameterNames(uri)) {
 
@@ -228,7 +229,7 @@ public class PostCommentListingURL extends CommentListingURL {
 				}
 
 			} else if(parameterKey.equalsIgnoreCase("sort")) {
-				order = Sort.lookup(uri.getQueryParameter(parameterKey));
+				order = PostCommentSort.lookup(uri.getQueryParameter(parameterKey));
 			}
 		}
 
@@ -246,35 +247,4 @@ public class PostCommentListingURL extends CommentListingURL {
 		return super.humanReadableName(context, shorter);
 	}
 
-	public enum Sort {
-
-		BEST("confidence"),
-		HOT("hot"),
-		NEW("new"),
-		OLD("old"),
-		TOP("top"),
-		CONTROVERSIAL("controversial"),
-		QA("qa");
-
-		public final String key;
-
-		Sort(final String key) {
-			this.key = key;
-		}
-
-		public static Sort lookup(String name) {
-
-			name = StringUtils.asciiUppercase(name);
-
-			if(name.equals("CONFIDENCE")) {
-				return BEST; // oh, reddit...
-			}
-
-			try {
-				return Sort.valueOf(name);
-			} catch(final IllegalArgumentException e) {
-				return null;
-			}
-		}
-	}
 }

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/UserCommentListingURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/UserCommentListingURL.java
@@ -19,12 +19,11 @@ package org.quantumbadger.redreader.reddit.url;
 
 import android.content.Context;
 import android.net.Uri;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.StringUtils;
+import org.quantumbadger.redreader.reddit.UserCommentSort;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,13 +31,13 @@ import java.util.List;
 public class UserCommentListingURL extends CommentListingURL {
 
 	public final String user;
-	public final Sort order;
+	public final UserCommentSort order;
 	public final Integer limit;
 	public final String after;
 
 	UserCommentListingURL(
 			final String user,
-			final Sort order,
+			final UserCommentSort order,
 			final Integer limit,
 			final String after) {
 		this.user = user;
@@ -57,7 +56,7 @@ public class UserCommentListingURL extends CommentListingURL {
 		return new UserCommentListingURL(user, order, newLimit, after);
 	}
 
-	public UserCommentListingURL order(final Sort newOrder) {
+	public UserCommentListingURL order(final UserCommentSort newOrder) {
 		return new UserCommentListingURL(user, newOrder, limit, after);
 	}
 
@@ -85,9 +84,10 @@ public class UserCommentListingURL extends CommentListingURL {
 					= pathSegmentsFiltered.toArray(new String[0]);
 		}
 
-		final Sort order;
+		final UserCommentSort order;
 		if(pathSegments.length > 0) {
-			order = Sort.parse(uri.getQueryParameter("sort"), uri.getQueryParameter("t"));
+			order = UserCommentSort.parse(
+					uri.getQueryParameter("sort"), uri.getQueryParameter("t"));
 		} else {
 			order = null;
 		}
@@ -174,109 +174,4 @@ public class UserCommentListingURL extends CommentListingURL {
 		}
 	}
 
-	public enum Sort {
-		NEW,
-		HOT,
-		CONTROVERSIAL_HOUR,
-		CONTROVERSIAL_DAY,
-		CONTROVERSIAL_WEEK,
-		CONTROVERSIAL_MONTH,
-		CONTROVERSIAL_YEAR,
-		CONTROVERSIAL_ALL,
-		TOP_HOUR,
-		TOP_DAY,
-		TOP_WEEK,
-		TOP_MONTH,
-		TOP_YEAR,
-		TOP_ALL;
-
-		@Nullable
-		public static Sort parse(@Nullable String sort, @Nullable String t) {
-
-			if(sort == null) {
-				return null;
-			}
-
-			sort = StringUtils.asciiLowercase(sort);
-			t = t != null ? StringUtils.asciiLowercase(t) : null;
-
-			if(sort.equals("hot")) {
-				return HOT;
-
-			} else if(sort.equals("new")) {
-				return NEW;
-
-			} else if(sort.equals("controversial")) {
-				if(t == null) {
-					return CONTROVERSIAL_ALL;
-				} else if(t.equals("all")) {
-					return CONTROVERSIAL_ALL;
-				} else if(t.equals("hour")) {
-					return CONTROVERSIAL_HOUR;
-				} else if(t.equals("day")) {
-					return CONTROVERSIAL_DAY;
-				} else if(t.equals("week")) {
-					return CONTROVERSIAL_WEEK;
-				} else if(t.equals("month")) {
-					return CONTROVERSIAL_MONTH;
-				} else if(t.equals("year")) {
-					return CONTROVERSIAL_YEAR;
-				} else {
-					return CONTROVERSIAL_ALL;
-				}
-
-			} else if(sort.equals("top")) {
-
-				if(t == null) {
-					return TOP_ALL;
-				} else if(t.equals("all")) {
-					return TOP_ALL;
-				} else if(t.equals("hour")) {
-					return TOP_HOUR;
-				} else if(t.equals("day")) {
-					return TOP_DAY;
-				} else if(t.equals("week")) {
-					return TOP_WEEK;
-				} else if(t.equals("month")) {
-					return TOP_MONTH;
-				} else if(t.equals("year")) {
-					return TOP_YEAR;
-				} else {
-					return TOP_ALL;
-				}
-
-			} else {
-				return null;
-			}
-		}
-
-		public void addToUserCommentListingUri(@NonNull final Uri.Builder builder) {
-
-			switch(this) {
-				case HOT:
-				case NEW:
-					builder.appendQueryParameter("sort", StringUtils.asciiLowercase(name()));
-					break;
-
-				case CONTROVERSIAL_HOUR:
-				case CONTROVERSIAL_DAY:
-				case CONTROVERSIAL_WEEK:
-				case CONTROVERSIAL_MONTH:
-				case CONTROVERSIAL_YEAR:
-				case CONTROVERSIAL_ALL:
-				case TOP_HOUR:
-				case TOP_DAY:
-				case TOP_WEEK:
-				case TOP_MONTH:
-				case TOP_YEAR:
-				case TOP_ALL:
-					final String[] parts = name().split("_");
-					builder.appendQueryParameter(
-							"sort",
-							StringUtils.asciiLowercase(parts[0]));
-					builder.appendQueryParameter("t", StringUtils.asciiLowercase(parts[1]));
-					break;
-			}
-		}
-	}
 }


### PR DESCRIPTION
I started to work on adding ratio buttons to the sort menus, but the code to make it work was becoming increasingly ugly and unmanageable, so I took a stab at refactoring the handling of sorts in `OptionsMenuUtility`. While at it, it looked best to move the comment sorts to their own files, for consistency.