### PR TITLE
Preserve the letter case of search queries

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/DialogUtils.java
+++ b/src/main/java/org/quantumbadger/redreader/common/DialogUtils.java
@@ -75,7 +75,7 @@ public class DialogUtils {
 	private static void performSearch(
 			final EditText editText,
 			final OnSearchListener listener) {
-		final String query = StringUtils.asciiLowercase(editText.getText().toString()).trim();
+		final String query = editText.getText().toString().trim();
 		if(StringUtils.isEmpty(query)) {
 			listener.onSearch(null);
 		} else {


### PR DESCRIPTION
This stops searches from dialog boxes from being forced to lowercase. This is a minor annoyance, since boolean operators [must be uppercase](https://reddit.com/wiki/search) to function, and keeping the case has no ill effects.