### PR TITLE
Don't set over18 cookie or parameter on SFW searches

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
@@ -39,6 +39,7 @@ import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.Optional;
+import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.TorCommon;
 import org.quantumbadger.redreader.common.Void;
 import org.quantumbadger.redreader.http.FailedRequestBody;
@@ -99,39 +100,41 @@ public class OKHTTPBackend extends HTTPBackend {
 			}
 		}
 
-		// here we set the over18 cookie and return it whenever the url contains search
+		// here we set the over18 cookie if needed, and return it whenever the url contains search
 		// this is necessary to get the reddit API to return NSFW search results
-		final List<Cookie> list = new ArrayList<>();
-		final Cookie.Builder cookieBuilder = new Cookie.Builder();
+		if(PrefsUtility.pref_behaviour_nsfw()) {
+			final List<Cookie> list = new ArrayList<>();
+			final Cookie.Builder cookieBuilder = new Cookie.Builder();
 
-		cookieBuilder.domain("reddit.com");
-		cookieBuilder.name("over18");
-		cookieBuilder.value("1");
-		cookieBuilder.path("/");
+			cookieBuilder.domain("reddit.com");
+			cookieBuilder.name("over18");
+			cookieBuilder.value("1");
+			cookieBuilder.path("/");
 
-		list.add(cookieBuilder.build());
+			list.add(cookieBuilder.build());
 
 
-		final CookieJar cookieJar = new CookieJar() {
-			@Override
-			public void saveFromResponse(
-					@NonNull final HttpUrl url,
-					@NonNull final List<Cookie> cookies) {
-				//LOL we do not care
-			}
-
-			@NonNull
-			@Override
-			public List<Cookie> loadForRequest(final HttpUrl url) {
-				if(url.toString().contains("search")) {
-					return list;
-				} else {
-					return Collections.emptyList();
+			final CookieJar cookieJar = new CookieJar() {
+				@Override
+				public void saveFromResponse(
+						@NonNull final HttpUrl url,
+						@NonNull final List<Cookie> cookies) {
+					//LOL we do not care
 				}
-			}
-		};
 
-		builder.cookieJar(cookieJar);
+				@NonNull
+				@Override
+				public List<Cookie> loadForRequest(final HttpUrl url) {
+					if(url.toString().contains("search")) {
+						return list;
+					} else {
+						return Collections.emptyList();
+					}
+				}
+			};
+
+			builder.cookieJar(cookieJar);
+		}
 
 		if(TorCommon.isTorEnabled()) {
 			final Proxy tor = new Proxy(

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/SearchPostListURL.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.General;
+import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.StringUtils;
 import org.quantumbadger.redreader.reddit.PostSort;
 
@@ -162,9 +163,10 @@ public class SearchPostListURL extends PostListingURL {
 
 		builder.appendEncodedPath(".json");
 
-		// if the user doesn't have NSFW content disabled, it won't show up anyway
-		// leaving this on by default doesn't hurt
-		builder.appendQueryParameter("include_over_18", "on");
+		// Only set over18 when NSFW content is enabled, to save on bandwidth and loading times
+		if(PrefsUtility.pref_behaviour_nsfw()) {
+			builder.appendQueryParameter("include_over_18", "on");
+		}
 
 		return builder.build();
 	}


### PR DESCRIPTION
This avoids setting the over18 cookie and parameter for searches when NSFW content is disabled. This can save a bit of bandwidth and loading time, since we're not downloading posts that will be filtered out anyway.

The difference is usually small, but can be very noticeable when making a search that has a lot of NSFW results.