### PR TITLE
Add optional indicator (†) for comments voted controversial

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -598,7 +598,7 @@ public final class PrefsUtility {
 	}
 
 	public enum AppearanceCommentHeaderItem {
-		AUTHOR, FLAIR, SCORE, AGE, GOLD, SUBREDDIT
+		AUTHOR, FLAIR, SCORE, CONTROVERSIALITY, AGE, GOLD, SUBREDDIT
 	}
 
 	public static EnumSet<AppearanceCommentHeaderItem> appearance_comment_header_items() {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -205,7 +205,25 @@ public class RedditRenderableComment
 						1f);
 			}
 
-			sb.append(" " + context.getString(R.string.subtitle_points) + " ", 0);
+			sb.append(" " + context.getString(R.string.subtitle_points), 0);
+
+			if(!theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.CONTROVERSIALITY)) {
+				sb.append(" ", 0);
+			}
+		}
+
+		if(theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.CONTROVERSIALITY)) {
+
+			if(rawComment.isControversial()) {
+				sb.append(
+						context.getString(R.string.props_controversial_symbol),
+						BetterSSB.FOREGROUND_COLOR | BetterSSB.BOLD,
+						theme.rrCommentHeaderBoldCol,
+						0,
+						1f);
+			}
+
+			sb.append(" ", 0);
 		}
 
 		if(theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.GOLD)) {
@@ -357,6 +375,16 @@ public class RedditRenderableComment
 						.append(context.getString(
 								R.string.accessibility_subtitle_points_withperiod,
 								computeScore(changeDataManager)))
+						.append(separator);
+			}
+		}
+
+		if(theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.CONTROVERSIALITY)) {
+
+			if(rawComment.isControversial()) {
+				accessibilityHeader
+						.append(context.getString(
+								R.string.accessibility_subtitle_controversiality_withperiod))
 						.append(separator);
 			}
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
@@ -58,6 +58,7 @@ public final class RedditComment implements
 	public int ups;
 	public int downs;
 	public int gilded;
+	public int controversiality;
 
 	@Nullable public JsonValue edited;
 
@@ -118,6 +119,7 @@ public final class RedditComment implements
 
 		saved = in.readInt() != 0;
 		gilded = in.readInt();
+		controversiality = in.readInt();
 
 		distinguished = in.readString();
 	}
@@ -159,6 +161,7 @@ public final class RedditComment implements
 
 		parcel.writeInt(saved ? 1 : 0);
 		parcel.writeInt(gilded);
+		parcel.writeInt(controversiality);
 
 		parcel.writeString(distinguished);
 	}
@@ -229,5 +232,9 @@ public final class RedditComment implements
 
 	public boolean wasEdited() {
 		return edited != null && !Boolean.FALSE.equals(edited.asBoolean());
+	}
+
+	public boolean isControversial() {
+		return controversiality == 1;
 	}
 }

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -578,6 +578,7 @@
         <item>@string/pref_appearance_comment_header_items_author</item>
         <item>@string/pref_appearance_comment_header_items_flair</item>
         <item>@string/pref_appearance_comment_header_items_score</item>
+		<item>@string/pref_appearance_comment_header_items_controversiality</item>
         <item>@string/pref_appearance_comment_header_items_age</item>
         <item>@string/pref_appearance_comment_header_items_gold</item>
         <item>@string/pref_appearance_post_subtitle_items_subreddit</item>
@@ -588,6 +589,7 @@
         <item>author</item>
         <item>flair</item>
         <item>score</item>
+		<item>controversiality</item>
         <item>age</item>
         <item>gold</item>
         <item>subreddit</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1605,5 +1605,10 @@
 	<string name="sort_posts_comments_month">Comments: This Month</string>
 	<string name="sort_posts_comments_year">Comments: This Year</string>
 	<string name="sort_posts_comments_all">Comments: All Time</string>
+
+	<!-- 2021-09-22 -->
+	<string name="pref_appearance_comment_header_items_controversiality">Controversial indicator (†)</string>
+	<string name="props_controversial_symbol">†</string>
+	<string name="accessibility_subtitle_controversiality_withperiod">Voted controversial.</string>
 	
 </resources>


### PR DESCRIPTION
This adds the ability to show a dagger (or speak a notice) on comments that are voted controversial (lots of upvotes and downvotes), like the website does when enabled in the user's settings.