### PR TITLE
Show radio buttons on sort menus

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -55,6 +55,7 @@ public class CommentListingActivity extends RefreshableActivity
 
 	private static final String SAVEDSTATE_SESSION = "cla_session";
 	private static final String SAVEDSTATE_SORT = "cla_sort";
+	private static final String SAVEDSTATE_SORT_IS_USER = "cla_sort_user";
 	private static final String SAVEDSTATE_FRAGMENT = "cla_fragment";
 
 	private CommentListingController controller;
@@ -92,8 +93,13 @@ public class CommentListingActivity extends RefreshableActivity
 				}
 
 				if(savedInstanceState.containsKey(SAVEDSTATE_SORT)) {
-					controller.setSort(PostCommentSort.valueOf(
-							savedInstanceState.getString(SAVEDSTATE_SORT)));
+					if(savedInstanceState.getBoolean(SAVEDSTATE_SORT_IS_USER)) {
+						controller.setSort(UserCommentSort.valueOf(
+								savedInstanceState.getString(SAVEDSTATE_SORT)));
+					} else {
+						controller.setSort(PostCommentSort.valueOf(
+								savedInstanceState.getString(SAVEDSTATE_SORT)));
+					}
 				}
 
 				if(savedInstanceState.containsKey(SAVEDSTATE_FRAGMENT)) {
@@ -118,8 +124,9 @@ public class CommentListingActivity extends RefreshableActivity
 			outState.putString(SAVEDSTATE_SESSION, session.toString());
 		}
 
-		final PostCommentSort sort = controller.getSort();
+		final OptionsMenuUtility.Sort sort = controller.getSort();
 		if(sort != null) {
+			outState.putBoolean(SAVEDSTATE_SORT_IS_USER, controller.isUserCommentListing());
 			outState.putString(SAVEDSTATE_SORT, sort.name());
 		}
 
@@ -269,5 +276,10 @@ public class CommentListingActivity extends RefreshableActivity
 	@Override
 	protected boolean baseActivityAllowToolbarHideOnScroll() {
 		return true;
+	}
+
+	@Override
+	public OptionsMenuUtility.Sort getCommentSort() {
+		return controller.getSort();
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -1083,4 +1083,22 @@ public class MainActivity extends RefreshableActivity
 	private void showBackButton(final boolean isVisible) {
 		configBackButton(isVisible, v -> onBackPressed());
 	}
+
+	@Override
+	public PostSort getPostSort() {
+		if(postListingController == null) {
+			return null;
+		}
+
+		return postListingController.getSort();
+	}
+
+	@Override
+	public OptionsMenuUtility.Sort getCommentSort() {
+		if(commentListingController == null) {
+			return null;
+		}
+
+		return commentListingController.getSort();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -206,4 +206,9 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 			super.onBackPressed();
 		}
 	}
+
+	@Override
+	public OptionsMenuUtility.Sort getCommentSort() {
+		return null;
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/PostListingActivity.java
@@ -340,6 +340,7 @@ public class PostListingActivity extends RefreshableActivity
 	public void onSortSelected(final PostSort order) {
 		controller.setSort(order);
 		requestRefresh(RefreshableFragment.POSTS, false);
+		invalidateOptionsMenu();
 	}
 
 	@Override
@@ -581,5 +582,10 @@ public class PostListingActivity extends RefreshableActivity
 	@Override
 	protected boolean baseActivityAllowToolbarHideOnScroll() {
 		return true;
+	}
+
+	@Override
+	public PostSort getPostSort() {
+		return controller.getSort();
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/listingcontrollers/CommentListingController.java
+++ b/src/main/java/org/quantumbadger/redreader/listingcontrollers/CommentListingController.java
@@ -20,6 +20,7 @@ package org.quantumbadger.redreader.listingcontrollers;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import org.quantumbadger.redreader.activities.OptionsMenuUtility;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
@@ -84,10 +85,12 @@ public class CommentListingController {
 		}
 	}
 
-	public PostCommentSort getSort() {
+	public OptionsMenuUtility.Sort getSort() {
 
 		if(mUrl.pathType() == RedditURLParser.POST_COMMENT_LISTING_URL) {
 			return mUrl.asPostCommentListURL().order;
+		} else if(mUrl.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL) {
+			return mUrl.asUserCommentListURL().order;
 		}
 
 		return null;


### PR DESCRIPTION
This adds radio buttons to the sort menus, showing which sort is currently selected.

While working on this, I discovered that state changes do not preserve the sort when viewing a user's comments. If the activity is destroyed and restored, the sort will revert to the default user comment sort. It seemed more elegant to fix this here and now, rather than workaround it and fix it later, so I have.

Closes #28, closes #680.