### PR TITLE
Preserve self-text collapse state on state change

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -84,6 +84,7 @@ public class CommentListingFragment extends RRFragment
 		CommentListingRequest.Listener {
 
 	private static final String SAVEDSTATE_FIRST_VISIBLE_POS = "firstVisiblePosition";
+	private static final String SAVEDSTATE_SELFTEXT_VISIBLE = "selftextVisible";
 
 	private final RedditAccount mUser;
 	private final ArrayList<RedditURLParser.RedditURL> mAllUrls;
@@ -93,6 +94,8 @@ public class CommentListingFragment extends RRFragment
 
 	private RedditPreparedPost mPost = null;
 	private boolean isArchived;
+
+	private boolean mSelfTextVisible = true;
 
 	private final FilteredCommentListingManager mCommentListingManager;
 
@@ -122,6 +125,10 @@ public class CommentListingFragment extends RRFragment
 		if(savedInstanceState != null) {
 			mPreviousFirstVisibleItemPosition = savedInstanceState.getInt(
 					SAVEDSTATE_FIRST_VISIBLE_POS);
+
+			if(savedInstanceState.containsKey(SAVEDSTATE_SELFTEXT_VISIBLE)) {
+				mSelfTextVisible = savedInstanceState.getBoolean(SAVEDSTATE_SELFTEXT_VISIBLE);
+			}
 		}
 
 		mCommentListingManager = new FilteredCommentListingManager(parent, searchString);
@@ -383,6 +390,10 @@ public class CommentListingFragment extends RRFragment
 				SAVEDSTATE_FIRST_VISIBLE_POS,
 				layoutManager.findFirstVisibleItemPosition());
 
+		if(mPost != null && mPost.isSelf()) {
+			bundle.putBoolean(SAVEDSTATE_SELFTEXT_VISIBLE, mSelfTextVisible);
+		}
+
 		return bundle;
 	}
 
@@ -529,14 +540,22 @@ public class CommentListingFragment extends RRFragment
 				if(actionOnClick == PrefsUtility.SelfpostAction.COLLAPSE) {
 					paddingLayout.setOnClickListener(v -> {
 						if(selfText.getVisibility() == View.GONE) {
+							mSelfTextVisible = true;
 							selfText.setVisibility(View.VISIBLE);
 							collapsedView.setVisibility(View.GONE);
 						} else {
+							mSelfTextVisible = false;
 							selfText.setVisibility(View.GONE);
 							collapsedView.setVisibility(View.VISIBLE);
 							layoutManager.scrollToPositionWithOffset(0, 0);
 						}
 					});
+				}
+
+				if(!mSelfTextVisible) {
+					selfText.setVisibility(View.GONE);
+					collapsedView.setVisibility(View.VISIBLE);
+					layoutManager.scrollToPositionWithOffset(0, 0);
 				}
 
 				paddingLayout.setOnLongClickListener(v -> {


### PR DESCRIPTION
This preserves the status of the self-text on self posts (visible or collapsed) across state changes.

Currently, its state is lost, so if a state change occurs (by entering multi-window, (un)folding a folding phone, etc.) the self-text reverts to being opened.