### PR TITLE
Show read user posts, even if "Hide read posts" is enabled

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -694,8 +694,12 @@ public class PostListingFragment extends RRFragment
 							final JsonArray posts = listing.getArray("children");
 
 							final boolean isNsfwAllowed = PrefsUtility.pref_behaviour_nsfw();
+
 							final boolean hideReadPosts
-									= PrefsUtility.pref_behaviour_hide_read_posts();
+									= PrefsUtility.pref_behaviour_hide_read_posts()
+									&& mPostListingURL.pathType()
+									!= RedditURLParser.USER_POST_LISTING_URL;
+
 							final boolean isConnectionWifi = General.isConnectionWifi(activity);
 
 							final boolean inlinePreviews
@@ -827,8 +831,7 @@ public class PostListingFragment extends RRFragment
 											downloadThisPreview);
 
 									// Skip adding this post (go to next iteration) if it
-									// has been clicked on AND user preference
-									// "hideReadPosts" is true
+									// has been clicked on AND read posts should be hidden
 									if(hideReadPosts && preparedPost.isRead()) {
 										mPostsNotShown = true;
 										continue;


### PR DESCRIPTION
This prevents read posts on any User Post Listing URL (upvoted/downvoted/submitted/saved/hidden posts) from being hidden if **Hide read posts** is enabled.

While I'm certain we don't want to hide the user's own posts from them, I'm not 100% on whether other users' posts should be hidden. I think it's probably more in line with the user's expectations to not hide either, but I could add a check so that *only* the logged-in user's posts are exempt from the hiding.

Closes #915.