### PR TITLE
Prevent replying to locked posts and comments

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -89,7 +89,6 @@ public class CommentListingFragment extends RRFragment
 	private final DownloadStrategy mDownloadStrategy;
 
 	private RedditPreparedPost mPost = null;
-	private boolean isArchived;
 
 	private final FilteredCommentListingManager mCommentListingManager;
 
@@ -418,8 +417,7 @@ public class CommentListingFragment extends RRFragment
 							this,
 							item.asComment(),
 							view,
-							RedditChangeDataManager.getInstance(mUser),
-							isArchived);
+							RedditChangeDataManager.getInstance(mUser));
 				}
 				break;
 			}
@@ -438,8 +436,7 @@ public class CommentListingFragment extends RRFragment
 							this,
 							item.asComment(),
 							view,
-							RedditChangeDataManager.getInstance(mUser),
-							isArchived);
+							RedditChangeDataManager.getInstance(mUser));
 				}
 				break;
 			}
@@ -484,7 +481,6 @@ public class CommentListingFragment extends RRFragment
 			final RRThemeAttributes attr = new RRThemeAttributes(activity);
 
 			mPost = post;
-			isArchived = post.isArchived;
 
 			final RedditPostHeaderView postHeader = new RedditPostHeaderView(
 					activity,

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -19,7 +19,6 @@ package org.quantumbadger.redreader.fragments;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -34,7 +33,6 @@ import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -43,7 +41,6 @@ import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.activities.BaseActivity;
-import org.quantumbadger.redreader.activities.CommentReplyActivity;
 import org.quantumbadger.redreader.activities.OptionsMenuUtility;
 import org.quantumbadger.redreader.adapters.FilteredCommentListingManager;
 import org.quantumbadger.redreader.adapters.GroupedRecyclerViewAdapter;
@@ -687,35 +684,14 @@ public class CommentListingFragment extends RRFragment
 				&& item.getTitle()
 				.equals(getActivity().getString(R.string.action_reply))) {
 
-			onParentReply();
+			RedditPreparedPost.onActionMenuItemSelected(
+					mPost,
+					(BaseActivity)getActivity(),
+					RedditPreparedPost.Action.REPLY);
 			return true;
 		}
 
 		return false;
-	}
-
-	private void onParentReply() {
-
-		if(mPost != null) {
-			if(mPost.isArchived) {
-				General.quickToast(getContext(), R.string.error_archived_reply, Toast.LENGTH_SHORT);
-				return;
-			}
-
-			final Intent intent = new Intent(getActivity(), CommentReplyActivity.class);
-			intent.putExtra(
-					CommentReplyActivity.PARENT_ID_AND_TYPE_KEY,
-					mPost.src.getIdAndType());
-			intent.putExtra(
-					CommentReplyActivity.PARENT_MARKDOWN_KEY,
-					mPost.src.getUnescapedSelfText());
-			startActivity(intent);
-
-		} else {
-			General.quickToast(
-					getActivity(),
-					R.string.error_toast_parent_post_not_downloaded);
-		}
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -417,7 +417,8 @@ public class CommentListingFragment extends RRFragment
 							this,
 							item.asComment(),
 							view,
-							RedditChangeDataManager.getInstance(mUser));
+							RedditChangeDataManager.getInstance(mUser),
+							mPost != null && mPost.isLocked);
 				}
 				break;
 			}
@@ -436,7 +437,8 @@ public class CommentListingFragment extends RRFragment
 							this,
 							item.asComment(),
 							view,
-							RedditChangeDataManager.getInstance(mUser));
+							RedditChangeDataManager.getInstance(mUser),
+							mPost != null && mPost.isLocked);
 				}
 				break;
 			}

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -329,9 +329,21 @@ public class RedditAPICommentAction {
 				break;
 
 			case REPLY: {
-				if(renderableComment.getParsedComment().getRawComment().isArchived()) {
+				if(comment.isArchived()) {
 					General.quickToast(activity, R.string.error_archived_reply, Toast.LENGTH_SHORT);
 					break;
+				} else {
+					final boolean postLocked = commentListingFragment != null
+							&& commentListingFragment.getPost() != null
+							&& commentListingFragment.getPost().isLocked;
+
+					if((comment.isLocked() || postLocked) && !comment.canModerate()) {
+						General.quickToast(
+								activity,
+								R.string.error_locked_reply,
+								Toast.LENGTH_SHORT);
+						break;
+					}
 				}
 
 				final Intent intent = new Intent(activity, CommentReplyActivity.class);

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -100,8 +100,7 @@ public class RedditAPICommentAction {
 			final CommentListingFragment commentListingFragment,
 			final RedditRenderableComment comment,
 			final RedditCommentView commentView,
-			final RedditChangeDataManager changeDataManager,
-			final boolean isArchived) {
+			final RedditChangeDataManager changeDataManager) {
 
 		final EnumSet<RedditCommentAction> itemPref
 				= PrefsUtility.pref_menus_comment_context_items();
@@ -109,6 +108,10 @@ public class RedditAPICommentAction {
 		if(itemPref.isEmpty()) {
 			return;
 		}
+
+		// These will be false for comments in the inbox. There seems to be no way around this,
+		// unless we do a lot of work to download the associated post and check there.
+		final boolean isArchived = comment.getParsedComment().getRawComment().isArchived();
 
 		final RedditAccount user =
 				RedditAccountManager.getInstance(activity).getDefaultAccount();
@@ -499,8 +502,7 @@ public class RedditAPICommentAction {
 						commentListingFragment,
 						renderableComment,
 						commentView,
-						changeDataManager,
-						comment.isArchived());
+						changeDataManager);
 				break;
 
 			case BACK:

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -344,14 +344,9 @@ public class RedditAPICommentAction {
 				if(comment.isArchived()) {
 					General.quickToast(activity, R.string.error_archived_reply, Toast.LENGTH_SHORT);
 					break;
-				} else {
-					if((comment.isLocked() || postLocked) && !comment.canModerate()) {
-						General.quickToast(
-								activity,
-								R.string.error_locked_reply,
-								Toast.LENGTH_SHORT);
-						break;
-					}
+				} else if((comment.isLocked() || postLocked) && !comment.canModerate()) {
+					General.quickToast(activity, R.string.error_locked_reply, Toast.LENGTH_SHORT);
+					break;
 				}
 
 				final Intent intent = new Intent(activity, CommentReplyActivity.class);

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
@@ -252,6 +252,14 @@ public class RedditParsedPost implements RedditThingWithIdAndType {
 		return mSrc.archived;
 	}
 
+	public boolean isLocked() {
+		return Boolean.TRUE.equals(mSrc.locked);
+	}
+
+	public boolean canModerate() {
+		return mSrc.can_mod_post;
+	}
+
 	public String getAuthor() {
 		return mSrc.author;
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -341,7 +341,9 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 						Action.REPORT));
 			}
 
-			if(itemPref.contains(Action.REPLY) && !post.isArchived) {
+			if(itemPref.contains(Action.REPLY)
+					&& !post.isArchived
+					&& !(post.isLocked && !post.canModerate)) {
 				menu.add(new RPVMenuItem(
 						activity,
 						R.string.action_reply,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -101,6 +101,8 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 	private final RedditChangeDataManager mChangeDataManager;
 
 	public final boolean isArchived;
+	public final boolean isLocked;
+	public final boolean canModerate;
 	public final boolean hasThumbnail;
 	public final boolean mIsProbablyAnImage;
 
@@ -183,6 +185,8 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		mChangeDataManager = RedditChangeDataManager.getInstance(user);
 
 		isArchived = post.isArchived();
+		isLocked = post.isLocked();
+		canModerate = post.canModerate();
 
 		mIsProbablyAnImage = LinkHandler.isProbablyAnImage(post.getUrl());
 
@@ -800,6 +804,9 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			case REPLY:
 				if(post.isArchived) {
 					General.quickToast(activity, R.string.error_archived_reply, Toast.LENGTH_SHORT);
+					break;
+				} else if(post.isLocked && !post.canModerate) {
+					General.quickToast(activity, R.string.error_locked_reply, Toast.LENGTH_SHORT);
 					break;
 				}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -510,10 +510,7 @@ public class RedditRenderableComment
 				null,
 				this,
 				null,
-				changeDataManager,
-				// TODO instead of assuming that it isn't an archived post,
-				//  somehow find out if it actually is
-				false);
+				changeDataManager);
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -510,7 +510,9 @@ public class RedditRenderableComment
 				null,
 				this,
 				null,
-				changeDataManager);
+				changeDataManager,
+				// There's no reasonable way for us to know from here.
+				false);
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
@@ -45,6 +45,8 @@ public final class RedditComment implements
 	public Boolean archived;
 	public Boolean likes;
 	public Boolean score_hidden;
+	public Boolean locked;
+	public Boolean can_mod_post;
 
 	public JsonValue replies;
 
@@ -95,6 +97,9 @@ public final class RedditComment implements
 				break;
 		}
 
+		locked = in.readInt() == 1;
+		can_mod_post = in.readInt() == 1;
+
 		replies = null;
 
 		id = in.readString();
@@ -140,6 +145,9 @@ public final class RedditComment implements
 			parcel.writeInt(likes ? 1 : -1);
 		}
 
+		parcel.writeInt(locked ? 1 : 0);
+		parcel.writeInt(can_mod_post ? 1 : 0);
+
 		parcel.writeString(id);
 		parcel.writeString(subreddit_id);
 		parcel.writeString(link_id);
@@ -178,6 +186,14 @@ public final class RedditComment implements
 
 	public boolean isArchived() {
 		return Boolean.TRUE.equals(archived);
+	}
+
+	public boolean isLocked() {
+		return Boolean.TRUE.equals(locked);
+	}
+
+	public boolean canModerate() {
+		return Boolean.TRUE.equals(can_mod_post);
 	}
 
 	@Nullable

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -53,6 +53,7 @@ public final class RedditPost implements
 	public boolean is_self;
 	public boolean clicked;
 	public boolean stickied;
+	public boolean can_mod_post;
 	@Nullable public JsonValue edited;
 	@Nullable public Boolean likes;
 	@Nullable public Boolean spoiler;
@@ -140,6 +141,7 @@ public final class RedditPost implements
 		is_self = in.readInt() == 1;
 		clicked = in.readInt() == 1;
 		stickied = in.readInt() == 1;
+		can_mod_post = in.readInt() == 1;
 
 		final long inEdited = in.readLong();
 		if(inEdited == -1) {
@@ -191,6 +193,7 @@ public final class RedditPost implements
 		parcel.writeInt(is_self ? 1 : 0);
 		parcel.writeInt(clicked ? 1 : 0);
 		parcel.writeInt(stickied ? 1 : 0);
+		parcel.writeInt(can_mod_post ? 1 : 0);
 
 		if(edited instanceof JsonLong) {
 			parcel.writeLong(edited.asLong());

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1621,5 +1621,8 @@
 	<string name="search_listing_header_limit_location">Limit to Location</string>
 	<string name="search_results_query_and_location">Search for \"%1$s\" on %2$s</string>
 	<string name="search_results_location_only">Search on %s</string>
+
+	<!-- 2021-10-20 -->
+	<string name="error_locked_reply">This has been locked and can no longer be replied to.</string>
 	
 </resources>


### PR DESCRIPTION
This prevents you from trying to reply to a locked post or comment, and hides the **Reply** option in action menus if possible. Moderators should still be able to reply to locked items on subreddits they moderate.

This resolves part of #303. (This PR doesn't add any indication that something is locked until you try to reply to it. That'd be something nice to add as well.)

PS: I noticed that in **RedditComment**, `score_hidden` is never parceled. Is this intentional?