### PR TITLE
Highlight suggested sort in sort menu

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/CommentListingActivity.java
@@ -282,4 +282,13 @@ public class CommentListingActivity extends RefreshableActivity
 	public OptionsMenuUtility.Sort getCommentSort() {
 		return controller.getSort();
 	}
+
+	@Override
+	public PostCommentSort getSuggestedCommentSort() {
+		if(mFragment == null || mFragment.getPost() == null) {
+			return null;
+		}
+
+		return mFragment.getPost().src.getSuggestedCommentSort();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -1101,4 +1101,13 @@ public class MainActivity extends RefreshableActivity
 
 		return commentListingController.getSort();
 	}
+
+	@Override
+	public PostCommentSort getSuggestedCommentSort() {
+		if(commentListingFragment == null || commentListingFragment.getPost() == null) {
+			return null;
+		}
+
+		return commentListingFragment.getPost().src.getSuggestedCommentSort();
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MoreCommentsListingActivity.java
@@ -211,4 +211,9 @@ public class MoreCommentsListingActivity extends RefreshableActivity
 	public OptionsMenuUtility.Sort getCommentSort() {
 		return null;
 	}
+
+	@Override
+	public PostCommentSort getSuggestedCommentSort() {
+		return null;
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -1234,7 +1234,17 @@ public final class OptionsMenuUtility {
 			final Menu menu,
 			final Sort order) {
 
-		final MenuItem menuItem = menu.add(activity.getString(order.getMenuTitle()))
+		@StringRes final int menuTitle;
+		if(activity instanceof OptionsMenuCommentsListener
+				&& ((OptionsMenuCommentsListener)activity).getSuggestedCommentSort() != null
+				&& ((OptionsMenuCommentsListener)activity).getSuggestedCommentSort()
+				.equals(order)) {
+			menuTitle = ((PostCommentSort)order).getSuggestedTitle();
+		} else {
+			menuTitle = order.getMenuTitle();
+		}
+
+		final MenuItem menuItem = menu.add(activity.getString(menuTitle))
 				.setOnMenuItemClickListener(item -> {
 					order.onSortSelected(activity);
 					return true;
@@ -1436,5 +1446,7 @@ public final class OptionsMenuUtility {
 		void onSearchComments();
 
 		Sort getCommentSort();
+
+		PostCommentSort getSuggestedCommentSort();
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -489,6 +489,9 @@ public class CommentListingFragment extends RRFragment
 			mPost = post;
 			isArchived = post.isArchived;
 
+			// Invalidate the options menu, so the suggested sort will be shown if needed.
+			activity.invalidateOptionsMenu();
+
 			final RedditPostHeaderView postHeader = new RedditPostHeaderView(
 					activity,
 					this.mPost);

--- a/src/main/java/org/quantumbadger/redreader/reddit/PostCommentSort.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/PostCommentSort.java
@@ -25,21 +25,27 @@ import org.quantumbadger.redreader.common.StringUtils;
 
 public enum PostCommentSort implements OptionsMenuUtility.Sort {
 
-	BEST("confidence", R.string.sort_comments_best),
-	HOT("hot", R.string.sort_comments_hot),
-	NEW("new", R.string.sort_comments_new),
-	OLD("old", R.string.sort_comments_old),
-	TOP("top", R.string.sort_comments_top),
-	CONTROVERSIAL("controversial", R.string.sort_comments_controversial),
-	QA("qa", R.string.sort_comments_qa);
+	BEST("confidence", R.string.sort_comments_best, R.string.sort_comments_best_suggested),
+	HOT("hot", R.string.sort_comments_hot, R.string.sort_comments_hot_suggested),
+	NEW("new", R.string.sort_comments_new, R.string.sort_comments_new_suggested),
+	OLD("old", R.string.sort_comments_old, R.string.sort_comments_old_suggested),
+	TOP("top", R.string.sort_comments_top, R.string.sort_comments_top_suggested),
+	CONTROVERSIAL("controversial",
+			R.string.sort_comments_controversial,
+			R.string.sort_comments_controversial_suggested),
+	QA("qa", R.string.sort_comments_qa, R.string.sort_comments_qa_suggested);
 
 	public final String key;
-	@StringRes
-	private final int menuTitle;
+	@StringRes private final int menuTitle;
+	@StringRes private final int suggestedTitle;
 
-	PostCommentSort(final String key, @StringRes final int menuTitle) {
+	PostCommentSort(
+			final String key,
+			@StringRes final int menuTitle,
+			@StringRes final int suggestedTitle) {
 		this.key = key;
 		this.menuTitle = menuTitle;
+		this.suggestedTitle = suggestedTitle;
 	}
 
 	public static PostCommentSort lookup(String name) {
@@ -60,6 +66,10 @@ public enum PostCommentSort implements OptionsMenuUtility.Sort {
 	@Override
 	public int getMenuTitle() {
 		return menuTitle;
+	}
+
+	public int getSuggestedTitle() {
+		return suggestedTitle;
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
@@ -24,6 +24,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.quantumbadger.redreader.common.Optional;
 import org.quantumbadger.redreader.jsonwrap.JsonArray;
 import org.quantumbadger.redreader.jsonwrap.JsonObject;
+import org.quantumbadger.redreader.reddit.PostCommentSort;
 import org.quantumbadger.redreader.reddit.prepared.bodytext.BodyElement;
 import org.quantumbadger.redreader.reddit.prepared.html.HtmlReader;
 import org.quantumbadger.redreader.reddit.things.RedditPost;
@@ -246,6 +247,14 @@ public class RedditParsedPost implements RedditThingWithIdAndType {
 				StringEscapeUtils.unescapeHtml4(bestUrl),
 				bestWidth,
 				bestHeight);
+	}
+
+	public PostCommentSort getSuggestedCommentSort() {
+		if(mSrc.suggested_sort == null) {
+			return null;
+		}
+
+		return PostCommentSort.lookup(mSrc.suggested_sort);
 	}
 
 	public boolean isArchived() {

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditPost.java
@@ -75,6 +75,7 @@ public final class RedditPost implements
 	@Nullable public Boolean is_video;
 
 	@Nullable public String distinguished;
+	@Nullable public String suggested_sort;
 
 	public RedditPost() {
 	}
@@ -161,6 +162,7 @@ public final class RedditPost implements
 		locked = ParcelUtils.readNullableBoolean(in);
 		rr_internal_dash_url = in.readString();
 		distinguished = in.readString();
+		suggested_sort = in.readString();
 	}
 
 	@Override
@@ -213,6 +215,7 @@ public final class RedditPost implements
 		getDashUrl();
 		parcel.writeString(rr_internal_dash_url);
 		parcel.writeString(distinguished);
+		parcel.writeString(suggested_sort);
 	}
 
 	public static final Parcelable.Creator<RedditPost> CREATOR

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1621,5 +1621,14 @@
 	<string name="search_listing_header_limit_location">Limit to Location</string>
 	<string name="search_results_query_and_location">Search for \"%1$s\" on %2$s</string>
 	<string name="search_results_location_only">Search on %s</string>
+
+	<!-- 2021-10-23 -->
+	<string name="sort_comments_best_suggested">Best (suggested)</string>
+	<string name="sort_comments_hot_suggested">Hot (suggested)</string>
+	<string name="sort_comments_new_suggested">New (suggested)</string>
+	<string name="sort_comments_old_suggested">Old (suggested)</string>
+	<string name="sort_comments_controversial_suggested">Controversial (suggested)</string>
+	<string name="sort_comments_top_suggested">Top (suggested)</string>
+	<string name="sort_comments_qa_suggested">Q&amp;A (suggested)</string>
 	
 </resources>


### PR DESCRIPTION
This shows which sort is the suggested comment sort in the sort menu, when applicable.

I initially started on this with the intention of also making it possible to automatically apply the suggested sort if desired, but realized there are some thorny questions and implementation details to deal with (some discussed in #513). However, simply being able to see which sort is suggested is still useful, so I'll put this forward as is.