### PR TITLE
Make videos loop more smoothly

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -93,6 +93,8 @@ public class ExoPlayerWrapperView extends FrameLayout {
 
 		mVideoPlayer.prepare(mediaSource);
 
+		mVideoPlayer.setRepeatMode(Player.REPEAT_MODE_ONE);
+
 		mVideoPlayer.setPlayWhenReady(true);
 		videoPlayerView.setUseController(false);
 
@@ -302,19 +304,6 @@ public class ExoPlayerWrapperView extends FrameLayout {
 				ViewGroup.LayoutParams.MATCH_PARENT));
 
 		mVideoPlayer.addListener(new Player.EventListener() {
-			@Override
-			public void onPlayerStateChanged(
-					final boolean playWhenReady,
-					final int playbackState) {
-
-				// Loop
-				if(playbackState == Player.STATE_ENDED) {
-					mVideoPlayer.seekTo(0);
-				}
-
-				updateProgress();
-			}
-
 			@Override
 			public void onPlayerError(final ExoPlaybackException error) {
 


### PR DESCRIPTION
I've noticed that videos show a loading icon in the center for a split second when looping. Using the ExoPlayer's method to enable the looping instead seems to fix this.