### PR TITLE
Remove unneeded resource parameter in PrefsUtility init

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/RedReader.java
+++ b/src/main/java/org/quantumbadger/redreader/RedReader.java
@@ -37,7 +37,7 @@ public class RedReader extends Application {
 
 		Log.i("RedReader", "Application created.");
 
-		PrefsUtility.init(this, getResources());
+		PrefsUtility.init(this);
 
 		Fonts.onAppCreate(getAssets());
 

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -55,9 +55,9 @@ public final class PrefsUtility {
 	private static SharedPrefsWrapper sharedPrefs;
 	private static Resources mRes;
 
-	public static void init(final Context context, final Resources res) {
+	public static void init(final Context context) {
 		sharedPrefs = General.getSharedPrefs(context);
-		mRes = res;
+		mRes = context.getResources();
 	}
 
 	private static String getPrefKey(@StringRes final int prefKey) {


### PR DESCRIPTION
Cause I'm a dum dum and didn't realize I could've just done this instead lol.