### PR TITLE
Enhancing support for blocking users

### DIFF
--- a/assets/changelog-alpha.txt
+++ b/assets/changelog-alpha.txt
@@ -1,5 +1,8 @@
 /Alpha 300 (2022-01-21)
+Highlight suggested sort in sort menu (thanks to Cameron Merkel)
 Prevent replying to locked posts (thanks to Cameron Merkel)
+Block users (thanks to Joe Mahon)
+Preference to hide comments by blocked users (thanks to Joe Mahon)
 
 /Alpha 299 (2022-01-09)
 Allows reporting uncaught exceptions

--- a/assets/changelog-alpha.txt
+++ b/assets/changelog-alpha.txt
@@ -1,7 +1,7 @@
 /Alpha 300 (2022-01-21)
 Highlight suggested sort in sort menu (thanks to Cameron Merkel)
 Prevent replying to locked posts (thanks to Cameron Merkel)
-Block users (thanks to Joe Mahon)
+Added "Block user" option to user profile (May require re-login to get permission. Thanks to Joe Mahon)
 Preference to hide comments by blocked users (thanks to Joe Mahon)
 
 /Alpha 299 (2022-01-09)

--- a/assets/changelog.txt
+++ b/assets/changelog.txt
@@ -1,6 +1,8 @@
 103/1.19
 Highlight suggested sort in sort menu (thanks to Cameron Merkel)
 Prevent replying to locked posts (thanks to Cameron Merkel)
+Block users (thanks to Joe Mahon)
+Preference to hide comments by blocked users (thanks to Joe Mahon)
 Allows reporting uncaught exceptions
 Fix to sample flag handling when saving Reddit videos
 Dependency updates

--- a/assets/changelog.txt
+++ b/assets/changelog.txt
@@ -1,7 +1,7 @@
 103/1.19
 Highlight suggested sort in sort menu (thanks to Cameron Merkel)
 Prevent replying to locked posts (thanks to Cameron Merkel)
-Added "Block user" option to user profile (thanks to Joe Mahon)
+Added "Block user" option to user profile (May require re-login to get permission. Thanks to Joe Mahon)
 Preference to hide comments by blocked users (thanks to Joe Mahon)
 Allows reporting uncaught exceptions
 Fix to sample flag handling when saving Reddit videos

--- a/assets/changelog.txt
+++ b/assets/changelog.txt
@@ -1,7 +1,7 @@
 103/1.19
 Highlight suggested sort in sort menu (thanks to Cameron Merkel)
 Prevent replying to locked posts (thanks to Cameron Merkel)
-Block users (thanks to Joe Mahon)
+Added "Block user" option to user profile (thanks to Joe Mahon)
 Preference to hide comments by blocked users (thanks to Joe Mahon)
 Allows reporting uncaught exceptions
 Fix to sample flag handling when saving Reddit videos

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -116,6 +116,8 @@ public final class PrefsUtility {
 				|| key.equals(context.getString(
 						R.string.pref_appearance_hide_headertoolbar_commentlist_key))
 				|| key.equals(context.getString(
+						R.string.pref_appearance_hide_comments_from_blocked_users_key))
+				|| key.equals(context.getString(
 						R.string.pref_appearance_hide_headertoolbar_postlist_key))
 				|| key.equals(context.getString(R.string.pref_images_thumbnail_size_key))
 				|| key.equals(context.getString(R.string.pref_images_inline_image_previews_key))
@@ -533,6 +535,12 @@ public final class PrefsUtility {
 	public static boolean pref_appearance_hide_headertoolbar_commentlist() {
 		return getBoolean(
 				R.string.pref_appearance_hide_headertoolbar_commentlist_key,
+				false);
+	}
+
+	public static boolean pref_appearance_hide_comments_from_blocked_users() {
+		return getBoolean(
+				R.string.pref_appearance_hide_comments_from_blocked_users_key,
 				false);
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
@@ -27,8 +27,12 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.activities.BaseActivity;
 import org.quantumbadger.redreader.activities.BugReportActivity;
@@ -50,11 +54,6 @@ import org.quantumbadger.redreader.reddit.things.RedditUser;
 import org.quantumbadger.redreader.reddit.url.UserPostListingURL;
 import org.quantumbadger.redreader.views.liststatus.ErrorView;
 import org.quantumbadger.redreader.views.liststatus.LoadingView;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.FragmentActivity;
 
 public class UserProfileDialog extends PropertiesDialog {
 
@@ -236,9 +235,11 @@ public class UserProfileDialog extends PropertiesDialog {
 							// TODO use margin? or framelayout? scale padding dp
 							postsButton.setPadding(20, 20, 20, 20);
 
-							if(!RedditAccountManager.getInstance(context)
-									.getDefaultAccount()
-									.isAnonymous()) {
+							final RedditAccount defaultAccount
+									= RedditAccountManager.getInstance(context)
+											.getDefaultAccount();
+
+							if(!defaultAccount.isAnonymous()) {
 								final Button pmButton = new Button(context);
 								pmButton.setText(R.string.userprofile_pm);
 								pmButton.setOnClickListener(v -> {
@@ -253,7 +254,7 @@ public class UserProfileDialog extends PropertiesDialog {
 								items.addView(pmButton);
 								pmButton.setPadding(20, 20, 20, 20);
 
-								if (!username.equals(RedditAccountManager.getInstance(context).getDefaultAccount().username)) {
+								if (!username.equals(defaultAccount.username)) {
 									blockButton = new Button(context);
 									blockLoadingView = new LoadingView(
 											context,
@@ -429,7 +430,8 @@ public class UserProfileDialog extends PropertiesDialog {
 				context);
 	}
 
-	private APIResponseHandler.UserResponseHandler unblockPreparedHandler(final String usernameToUnblock) {
+	private APIResponseHandler.UserResponseHandler unblockPreparedHandler(
+			final String usernameToUnblock) {
 		return new APIResponseHandler.UserResponseHandler((AppCompatActivity) getActivity()) {
 			@Override
 			protected void onDownloadStarted() { }
@@ -452,7 +454,13 @@ public class UserProfileDialog extends PropertiesDialog {
 			}
 
 			@Override
-			protected void onFailure(final int type, final @Nullable Throwable t, final @Nullable Integer status, final @Nullable String readableMessage, final @NonNull Optional<FailedRequestBody> response) {
+			protected void onFailure(
+					final int type,
+					final @Nullable Throwable t,
+					final @Nullable Integer status,
+					final @Nullable String readableMessage,
+					final @NonNull Optional<FailedRequestBody> response) {
+
 				Toast.makeText(
 						context,
 						getString(R.string.unblock_user_failed),
@@ -461,7 +469,10 @@ public class UserProfileDialog extends PropertiesDialog {
 			}
 
 			@Override
-			protected void onFailure(final @NonNull APIFailureType type, final @Nullable String debuggingContext, final @NonNull Optional<FailedRequestBody> response) {
+			protected void onFailure(
+					final @NonNull APIFailureType type,
+					final @Nullable String debuggingContext,
+					final @NonNull Optional<FailedRequestBody> response) {
 				Toast.makeText(
 						context,
 						getString(R.string.unblock_user_failed),
@@ -485,7 +496,12 @@ public class UserProfileDialog extends PropertiesDialog {
 			}
 
 			@Override
-			protected void onFailure(final int type, final @Nullable Throwable t, final @Nullable Integer status, final @Nullable String readableMessage, final @NonNull Optional<FailedRequestBody> response) {
+			protected void onFailure(
+					final int type,
+					final @Nullable Throwable t,
+					final @Nullable Integer status,
+					final @Nullable String readableMessage,
+					final @NonNull Optional<FailedRequestBody> response) {
 				Toast.makeText(
 						context,
 						getString(R.string.unblock_user_failed),
@@ -494,7 +510,10 @@ public class UserProfileDialog extends PropertiesDialog {
 			}
 
 			@Override
-			protected void onFailure(final @NonNull APIFailureType type, final @Nullable String debuggingContext, final @NonNull Optional<FailedRequestBody> response) {
+			protected void onFailure(
+					final @NonNull APIFailureType type,
+					final @Nullable String debuggingContext,
+					final @NonNull Optional<FailedRequestBody> response) {
 				Toast.makeText(
 						context,
 						getString(R.string.unblock_user_failed),

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
@@ -26,7 +26,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -42,6 +41,7 @@ import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyAlways;
 import org.quantumbadger.redreader.common.AndroidCommon;
 import org.quantumbadger.redreader.common.Constants;
+import org.quantumbadger.redreader.common.DialogUtils;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.LinkHandler;
 import org.quantumbadger.redreader.common.Optional;
@@ -397,10 +397,10 @@ public class UserProfileDialog extends PropertiesDialog {
 					final Integer status,
 					final String readableMessage,
 					@NonNull final Optional<FailedRequestBody> response) {
-				Toast.makeText(
+				DialogUtils.showDialog(
 						context,
-						getString(R.string.block_user_failed),
-						Toast.LENGTH_SHORT).show();
+						R.string.block_user_failed_title,
+						R.string.block_user_failed_message);
 				setBlockButtonText(R.string.block);
 			}
 
@@ -409,10 +409,10 @@ public class UserProfileDialog extends PropertiesDialog {
 					@NonNull final APIFailureType type,
 					@Nullable final String readableMessage,
 					@NonNull final Optional<FailedRequestBody> response) {
-				Toast.makeText(
+				DialogUtils.showDialog(
 						context,
-						getString(R.string.block_user_failed),
-						Toast.LENGTH_SHORT).show();
+						R.string.block_user_failed_title,
+						R.string.block_user_failed_message);
 				setBlockButtonText(R.string.block);
 			}
 		};
@@ -461,10 +461,10 @@ public class UserProfileDialog extends PropertiesDialog {
 					final @Nullable String readableMessage,
 					final @NonNull Optional<FailedRequestBody> response) {
 
-				Toast.makeText(
+				DialogUtils.showDialog(
 						context,
-						getString(R.string.unblock_user_failed),
-						Toast.LENGTH_SHORT).show();
+						R.string.unblock_user_failed_title,
+						R.string.unblock_user_failed_message);
 				setBlockButtonText(R.string.unblock);
 			}
 
@@ -473,10 +473,10 @@ public class UserProfileDialog extends PropertiesDialog {
 					final @NonNull APIFailureType type,
 					final @Nullable String debuggingContext,
 					final @NonNull Optional<FailedRequestBody> response) {
-				Toast.makeText(
+				DialogUtils.showDialog(
 						context,
-						getString(R.string.unblock_user_failed),
-						Toast.LENGTH_SHORT).show();
+						R.string.unblock_user_failed_title,
+						R.string.unblock_user_failed_message);
 				setBlockButtonText(R.string.unblock);
 			}
 		};
@@ -502,10 +502,10 @@ public class UserProfileDialog extends PropertiesDialog {
 					final @Nullable Integer status,
 					final @Nullable String readableMessage,
 					final @NonNull Optional<FailedRequestBody> response) {
-				Toast.makeText(
+				DialogUtils.showDialog(
 						context,
-						getString(R.string.unblock_user_failed),
-						Toast.LENGTH_SHORT).show();
+						R.string.unblock_user_failed_title,
+						R.string.unblock_user_failed_message);
 				setBlockButtonText(R.string.unblock);
 			}
 
@@ -514,10 +514,10 @@ public class UserProfileDialog extends PropertiesDialog {
 					final @NonNull APIFailureType type,
 					final @Nullable String debuggingContext,
 					final @NonNull Optional<FailedRequestBody> response) {
-				Toast.makeText(
+				DialogUtils.showDialog(
 						context,
-						getString(R.string.unblock_user_failed),
-						Toast.LENGTH_SHORT).show();
+						R.string.unblock_user_failed_title,
+						R.string.unblock_user_failed_message);
 				setBlockButtonText(R.string.unblock);
 			}
 		};

--- a/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
@@ -317,6 +317,10 @@ public class CommentListingRequest {
 					mActivity,
 					mCommentListingURL);
 
+			if (comment.isBlockedByUser() && PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
+				return;
+			}
+
 			output.add(item);
 
 			if(comment.replies.asObject() != null) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
@@ -317,7 +317,8 @@ public class CommentListingRequest {
 					mActivity,
 					mCommentListingURL);
 
-			if (comment.isBlockedByUser() && PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
+			if (comment.isBlockedByUser()
+					&& PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
 				return;
 			}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
@@ -733,6 +733,46 @@ public final class RedditAPI {
 				}));
 	}
 
+	public static void unblockUser(
+			final CacheManager cm,
+			final String usernameToUnblock,
+			final String currentUserFullname,
+			final APIResponseHandler.ActionResponseHandler responseHandler,
+			final RedditAccount user,
+			final Context context
+	) {
+		final LinkedList<PostField> postFields = new LinkedList<>();
+		postFields.add(new PostField("name", usernameToUnblock));
+		postFields.add(new PostField("container", currentUserFullname));
+		postFields.add(new PostField("type", "enemy"));
+
+		cm.makeRequest(createPostRequest(
+				Constants.Reddit.getUri("/api/unfriend"),
+				user,
+				postFields,
+				context,
+				new GenericResponseHandler(responseHandler)));
+	}
+
+	public static void blockUser(
+		final CacheManager cm,
+		final String usernameToBlock,
+		final APIResponseHandler.ActionResponseHandler responseHandler,
+		final RedditAccount user,
+		final Context context
+	) {
+		final LinkedList<PostField> postFields = new LinkedList<>();
+		postFields.add(new PostField("name", usernameToBlock));
+		postFields.add(new PostField("api_type", "json"));
+
+		cm.makeRequest(createPostRequest(
+				Constants.Reddit.getUri("/api/block_user"),
+				user,
+				postFields,
+				context,
+				new GenericResponseHandler(responseHandler)));
+	}
+
 	public static void sendReplies(
 			final CacheManager cm,
 			final APIResponseHandler.ActionResponseHandler responseHandler,
@@ -744,6 +784,7 @@ public final class RedditAPI {
 		final LinkedList<PostField> postFields = new LinkedList<>();
 		postFields.add(new PostField("id", fullname));
 		postFields.add(new PostField("state", String.valueOf(state)));
+
 		cm.makeRequest(createPostRequest(
 				Constants.Reddit.getUri("/api/sendreplies"),
 				user,

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditOAuth.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditOAuth.java
@@ -61,7 +61,7 @@ public final class RedditOAuth {
 	private static final String ALL_SCOPES = "identity,edit,flair,history,"
 			+ "modconfig,modflair,modlog,modposts,modwiki,mysubreddits,"
 			+ "privatemessages,read,report,save,submit,subscribe,vote,"
-			+ "wikiedit,wikiread";
+			+ "wikiedit,wikiread,account";
 
 	private static final String ACCESS_TOKEN_URL =
 			"https://www.reddit.com/api/v1/access_token";

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditComment.java
@@ -37,6 +37,7 @@ public final class RedditComment implements
 		Parcelable,
 		RedditThingWithIdAndType,
 		JsonObject.JsonDeserializable {
+	private static final String COLLAPSED_REASON_BLOCKED_AUTHOR = "BLOCKED_AUTHOR";
 
 	public String body;
 	public String body_html;
@@ -71,6 +72,9 @@ public final class RedditComment implements
 	@Nullable public Boolean saved;
 
 	@Nullable public String distinguished;
+
+	@Nullable public String collapsed_reason;
+	@Nullable public String collapsed_reason_code;
 
 	public RedditComment() {
 	}
@@ -116,6 +120,9 @@ public final class RedditComment implements
 		controversiality = in.readInt();
 
 		distinguished = in.readString();
+
+		collapsed_reason = in.readString();
+		collapsed_reason_code = in.readString();
 	}
 
 	@Override
@@ -157,6 +164,9 @@ public final class RedditComment implements
 		parcel.writeInt(controversiality);
 
 		parcel.writeString(distinguished);
+
+		parcel.writeString(collapsed_reason);
+		parcel.writeString(collapsed_reason_code);
 	}
 
 	@Override
@@ -237,5 +247,9 @@ public final class RedditComment implements
 
 	public boolean isControversial() {
 		return controversiality == 1;
+	}
+
+	public boolean isBlockedByUser() {
+		return COLLAPSED_REASON_BLOCKED_AUTHOR.equals(collapsed_reason_code);
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditThing.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditThing.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 public final class RedditThing implements JsonObject.JsonDeserializable {
 
+	public static final String KIND_USER = "t2";
+
 	public enum Kind {
 		POST, USER, COMMENT, MESSAGE, SUBREDDIT, MORE_COMMENTS, LISTING
 	}
@@ -35,7 +37,7 @@ public final class RedditThing implements JsonObject.JsonDeserializable {
 	static {
 		kinds = new HashMap<>();
 		kinds.put("t1", Kind.COMMENT);
-		kinds.put("t2", Kind.USER);
+		kinds.put(KIND_USER, Kind.USER);
 		kinds.put("t3", Kind.POST);
 		kinds.put("t4", Kind.MESSAGE);
 		kinds.put("t5", Kind.SUBREDDIT);

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.reddit.things;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+
 import org.quantumbadger.redreader.jsonwrap.JsonObject;
 
 public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
@@ -35,6 +36,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 	public boolean is_gold;
 	public boolean is_mod;
 	public boolean over_18;
+	public boolean is_blocked;
 
 	public String id;
 	public String modhash;
@@ -75,6 +77,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		is_gold = in.readInt() == 1;
 		is_mod = in.readInt() == 1;
 		over_18 = in.readInt() == 1;
+		is_blocked = in.readInt() == 1;
 
 		id = in.readString();
 		modhash = in.readString();
@@ -106,6 +109,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		parcel.writeInt(is_gold ? 1 : 0);
 		parcel.writeInt(is_mod ? 1 : 0);
 		parcel.writeInt(over_18 ? 1 : 0);
+		parcel.writeInt(is_blocked ? 1 : 0);
 
 		parcel.writeString(id);
 		parcel.writeString(modhash);

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -128,4 +128,8 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 			return new RedditUser[size];
 		}
 	};
+
+	public String fullname() {
+		return String.format("%s_%s", RedditThing.KIND_USER, id);
+	}
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1633,7 +1633,6 @@
 	<!-- 2021-01-21 -->
 	<string name="error_locked_reply">This has been locked and can no longer be replied to.</string>
 
-	<!-- 2021-10-23 -->
 	<string name="sort_comments_best_suggested">Best (suggested)</string>
 	<string name="sort_comments_hot_suggested">Hot (suggested)</string>
 	<string name="sort_comments_new_suggested">New (suggested)</string>
@@ -1641,5 +1640,8 @@
 	<string name="sort_comments_controversial_suggested">Controversial (suggested)</string>
 	<string name="sort_comments_top_suggested">Top (suggested)</string>
 	<string name="sort_comments_qa_suggested">Q&amp;A (suggested)</string>
+
+	<string name="pref_appearance_hide_comments_from_blocked_users_key" translatable="false">pref_appearance_hide_comments_from_blocked_users</string>
+	<string name="pref_appearance_hide_comments_from_blocked_users_title">Hide comment chains from blocked users</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1643,5 +1643,10 @@
 
 	<string name="pref_appearance_hide_comments_from_blocked_users_key" translatable="false">pref_appearance_hide_comments_from_blocked_users</string>
 	<string name="pref_appearance_hide_comments_from_blocked_users_title">Hide comment chains from blocked users</string>
+	<string name="block_user_failed">Failed to block user. You may have to log out and re-add your account.</string>
+	<string name="unblock_user_failed">Failed to unblock user</string>
+	<string name="block_loading">Loading</string>
+	<string name="block">Block User</string>
+	<string name="unblock">Unblock User</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1643,9 +1643,11 @@
 
 	<string name="pref_appearance_hide_comments_from_blocked_users_key" translatable="false">pref_appearance_hide_comments_from_blocked_users</string>
 	<string name="pref_appearance_hide_comments_from_blocked_users_title">Hide comment chains from blocked users</string>
-	<string name="block_user_failed">Failed to block user. You may have to log out and re-add your account.</string>
-	<string name="unblock_user_failed">Failed to unblock user</string>
-	<string name="block_loading">Loading</string>
+	<string name="block_user_failed_title">Failed to block user</string>
+	<string name="block_user_failed_message">Could not block user. You may have to log out and re-add your account to give RedReader the necessary permissions.</string>
+	<string name="unblock_user_failed_title">Failed to unblock user</string>
+	<string name="unblock_user_failed_message">Could not unblock user. You may have to log out and re-add your account to give RedReader the necessary permissions.</string>
+	<string name="block_loading">Loading…</string>
 	<string name="block">Block User</string>
 	<string name="unblock">Unblock User</string>
 

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -165,6 +165,11 @@
 				android:key="@string/pref_appearance_hide_headertoolbar_commentlist_key"
 				android:defaultValue="false"/>
 
+		<CheckBoxPreference
+				android:title="@string/pref_appearance_hide_comments_from_blocked_users_title"
+				android:key="@string/pref_appearance_hide_comments_from_blocked_users_key"
+				android:defaultValue="false"/>
+
     </PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/pref_appearance_inbox_header">


### PR DESCRIPTION
**Context:** Last year, reddit altered functionality such that content from blocked users was now being shown. Their claim was that this helped alleviate confusion people would have from missing context for particular things. To me, that's contradictory to the purpose of blocking users in the first place. Fortunately, they asserted that they would maintain an API that allows 3rd party integrations to update the blocking behavior according to how they see fit, as noted [here](https://www.reddit.com/r/changelog/comments/p2ezy4/bringing_more_visibility_to_comments_from_blocked/h8k5yn7/?context=3).

**Solution:** This PR contains two commits: the first enables an option in Settings such that a user can opt into hiding chains of comments that come from users they have blocked. This mostly relies on the reddit API, and is relatively little frontend code.

The second commit implements in-app functionality to block or unblock users from the User Profile dialog.

**Additional notes:**

* An issue I'm not sure how to get around: in order to be able to block users, the OAuth scope needs to be upgraded to include `account` - I wasn't sure how to accomplish that without a user simply having to log out and log back in again.

* *Mostly for my future self, or anyone curious - I drew a handful of inspiration from how [the PRAW utility works](https://github.com/praw-dev/praw/blob/b009cbfa54fc115777a4ff70eb9b3bcee33a683f/praw/models/reddit/redditor.py#L400-L406) - as I don't find the reddit API documentation to be very straightforward, haha*

@QuantumBadger Feel free to let me know if you have any questions or feedback!