### PR TITLE
Replace default subs r/announcements and r/blog with the new r/reddit

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/Constants.java
+++ b/src/main/java/org/quantumbadger/redreader/common/Constants.java
@@ -63,12 +63,10 @@ public final class Constants {
 
 		static {
 			final String[] defaultSubredditStrings = {
-					"/r/announcements",
 					"/r/Art",
 					"/r/AskReddit",
 					"/r/askscience",
 					"/r/aww",
-					"/r/blog",
 					"/r/books",
 					"/r/creepy",
 					"/r/dataisbeautiful",
@@ -101,6 +99,7 @@ public final class Constants {
 					"/r/philosophy",
 					"/r/photoshopbattles",
 					"/r/pics",
+					"/r/reddit",
 					"/r/science",
 					"/r/Showerthoughts",
 					"/r/space",


### PR DESCRIPTION
Reddit has recently decided to archive r/announcements, r/blog, and r/changelog, and post all new official Reddit news at r/reddit. With that in mind, we should probably replace those old subreddits with the new one in the default list.