### PR TITLE
Make comment level announcement more concise

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1659,7 +1659,7 @@
 	<string name="pref_accessibility_say_comment_indent_level_key">pref_accessibility_say_comment_indent_level</string>
 	<string name="pref_accessibility_say_comment_indent_level_title">Announce comment indent</string>
 	<string name="pref_accessibility_say_comment_indent_level_summary">Announce relative level (indent) of comments within a thread</string>
-	<string name="accessibility_comment_indent_level">Comment reply, level %d.</string>
+	<string name="accessibility_comment_indent_level">Level %d comment.</string>
 	<string name="accessibility_comment_indent_level_top">Top level comment.</string>
 
 </resources>


### PR DESCRIPTION
Thanks so much for 461e638! This PR makes the comment level announcement string a bit more speech friendly: dynamic content should be placed as early as possible so users can easily interrupt (for instance, scrolling past comments quickly of a particular level without having to listen to "comment reply" first).