### PR TITLE
fix-up of #970: Remove age: from accessibility label

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1378,7 +1378,7 @@
 		<item quantity="other">"%d up votes."</item>
 	</plurals>
 	<string name="accessibility_subtitle_gold_withperiod">Gildings: %d.</string>
-	<string name="accessibility_subtitle_age_withperiod">Age: %s.</string>
+	<string name="accessibility_subtitle_age_withperiod">%s.</string>
 	<string name="accessibility_subtitle_author_withperiod">Author: %s.</string>
 	<string name="accessibility_subtitle_subreddit_withperiod">Sub-reddit: %s.</string>
 	<string name="accessibility_subtitle_domain_withperiod">Domain: %s.</string>


### PR DESCRIPTION
This PR removes "age:" from the accessibility label for concision, as it doesn't add any value and only slows down the user.