### PR TITLE
Add up/down vote state to accessibility header

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1263,6 +1263,20 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 							score,
 							score))
 					.append(separator);
+
+			if(isUpvoted()) {
+				accessibilitySubtitle
+						.append(context.getString(
+								R.string.accessibility_subtitle_upvoted_withperiod))
+						.append(separator);
+			}
+
+			if(isDownvoted()) {
+				accessibilitySubtitle
+						.append(context.getString(
+								R.string.accessibility_subtitle_downvoted_withperiod))
+						.append(separator);
+			}
 		}
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.UPVOTE_RATIO)) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -424,6 +424,20 @@ public class RedditRenderableComment
 								score))
 						.append(separator);
 			}
+
+			if(changeDataManager.isUpvoted(mComment)) {
+				accessibilityHeader
+						.append(context.getString(
+								R.string.accessibility_subtitle_upvoted_withperiod))
+						.append(separator);
+			}
+
+			if(changeDataManager.isDownvoted(mComment)) {
+				accessibilityHeader
+						.append(context.getString(
+								R.string.accessibility_subtitle_downvoted_withperiod))
+						.append(separator);
+			}
 		}
 
 		if(theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.CONTROVERSIALITY)) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1696,5 +1696,7 @@
 	<string name="accessibility_subtitle_controversiality_withperiod_concise">Controversial.</string>
 	<string name="accessibility_subtitle_upvote_ratio_withperiod_concise" tools:ignore="PluralsCandidate">%d percent up.</string>
 	<string name="accessibility_comment_indent_level_concise" tools:ignore="PluralsCandidate">l%d.</string>
+	<string name="accessibility_subtitle_upvoted_withperiod">Upvoted.</string>
+	<string name="accessibility_subtitle_downvoted_withperiod">Downvoted.</string>
 
 </resources>


### PR DESCRIPTION
Currently, it is impossible to tell from the accessibility header whether a post or comment is up- or down-voted. Add this information whenever the score is set to display.