### PR TITLE
Move accessibility "embellishments" before title in concise mode, adding read state as a post embellishment

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/ScreenreaderPronunciation.java
+++ b/src/main/java/org/quantumbadger/redreader/common/ScreenreaderPronunciation.java
@@ -63,7 +63,7 @@ public class ScreenreaderPronunciation {
 		}
 
 		// Replace "read" with the English homophone "red" to work around bad speech synth handling
-		if(res == R.string.accessibility_read_withperiod) {
+		if(res == R.string.accessibility_post_already_read_withperiod) {
 			return "Red.";
 
 		} else {

--- a/src/main/java/org/quantumbadger/redreader/common/ScreenreaderPronunciation.java
+++ b/src/main/java/org/quantumbadger/redreader/common/ScreenreaderPronunciation.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.common;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import org.quantumbadger.redreader.R;
 
 import java.util.Locale;
@@ -50,6 +51,24 @@ public class ScreenreaderPronunciation {
 		}
 
 		return pronounceSubreddit(textLowercase);
+	}
+
+	public static String getAccessibilityString(
+			@NonNull final Context context,
+			@StringRes final int res) {
+
+		// Only override for English for now
+		if(!Locale.getDefault().getDisplayLanguage().equals("en")) {
+			return context.getString(res);
+		}
+
+		// Replace "read" with the English homophone "red" to work around bad speech synth handling
+		if(res == R.string.accessibility_read_withperiod) {
+			return "Red.";
+
+		} else {
+			return context.getString(res);
+		}
 	}
 
 	@NonNull

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1379,6 +1379,26 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		return accessibilitySubtitle.toString();
 	}
 
+	public String buildAccessibilityTitle(final Context context) {
+		final StringBuilder a11yTitle = new StringBuilder();
+		final String separator = " \n";
+
+		if (isRead()) {
+				a11yTitle
+						.append(
+								ScreenreaderPronunciation.getAccessibilityString(
+										context,
+										R.string.accessibility_read_withperiod
+								)
+						)
+						.append(separator);
+		}
+
+		a11yTitle.append(src.getTitle());
+
+		return a11yTitle.toString();
+	}
+
 	// lol, reddit api
 	private static boolean hasThumbnail(final RedditParsedPost post) {
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1210,46 +1210,10 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 		final String separator = " \n";
 
-		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.SPOILER)) {
-			if(src.isSpoiler()) {
-				accessibilitySubtitle
-						.append(context.getString(
-								R.string.accessibility_subtitle_spoiler_withperiod))
-						.append(separator);
-			}
-		}
-
-		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.STICKY)) {
-			if(src.isStickied()) {
-				accessibilitySubtitle
-						.append(context.getString(
-								R.string.accessibility_subtitle_sticky_withperiod))
-						.append(separator);
-			}
-		}
-
-		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.NSFW)) {
-			if(src.isNsfw()) {
-				accessibilitySubtitle
-						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
-										? R.string.accessibility_subtitle_nsfw_withperiod_concise
-										: R.string.accessibility_subtitle_nsfw_withperiod))
-						.append(separator);
-			}
-		}
-
-		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.FLAIR)) {
-			if(src.getFlairText() != null) {
-				accessibilitySubtitle
-						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
-										? R.string.accessibility_subtitle_flair_withperiod_concise
-										: R.string.accessibility_subtitle_flair_withperiod,
-								src.getFlairText()
-										+ General.LTR_OVERRIDE_MARK))
-						.append(separator);
-			}
+		// When not in concise mode, add embellishments to the subtitle for greater clarity and
+		// retention of familiar behaviour.
+		if (!PrefsUtility.pref_accessibility_concise_mode()) {
+			accessibilitySubtitle.append(buildAccessibilityEmbellishments(context, headerMode));
 		}
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.SCORE)) {
@@ -1379,12 +1343,41 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		return accessibilitySubtitle.toString();
 	}
 
-	public String buildAccessibilityTitle(final Context context) {
+	public String buildAccessibilityTitle(
+			final Context context,
+			final boolean headerMode) {
+
 		final StringBuilder a11yTitle = new StringBuilder();
+
+		// When in concise mode, add embellishments to the title for greater interruptability when
+		// navigating quickly.
+		if (PrefsUtility.pref_accessibility_concise_mode()) {
+			a11yTitle.append(buildAccessibilityEmbellishments(context, headerMode));
+		}
+
+		a11yTitle.append(src.getTitle());
+
+		return a11yTitle.toString();
+	}
+
+	private String buildAccessibilityEmbellishments(
+			final Context context,
+			final boolean headerMode) {
+
+		final EnumSet<PrefsUtility.AppearancePostSubtitleItem> mPostSubtitleItems;
+		if(headerMode
+				&& PrefsUtility.appearance_post_subtitle_items_use_different_settings()) {
+			mPostSubtitleItems = PrefsUtility.appearance_post_header_subtitle_items();
+		} else {
+			mPostSubtitleItems = PrefsUtility.appearance_post_subtitle_items();
+		}
+
+		final StringBuilder a11yEmbellish = new StringBuilder();
+
 		final String separator = " \n";
 
 		if (isRead()) {
-				a11yTitle
+				a11yEmbellish
 						.append(
 								ScreenreaderPronunciation.getAccessibilityString(
 										context,
@@ -1394,9 +1387,49 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 						.append(separator);
 		}
 
-		a11yTitle.append(src.getTitle());
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.SPOILER)) {
+			if(src.isSpoiler()) {
+				a11yEmbellish
+						.append(context.getString(
+								R.string.accessibility_subtitle_spoiler_withperiod))
+						.append(separator);
+			}
+		}
 
-		return a11yTitle.toString();
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.STICKY)) {
+			if(src.isStickied()) {
+				a11yEmbellish
+						.append(context.getString(
+								R.string.accessibility_subtitle_sticky_withperiod))
+						.append(separator);
+			}
+		}
+
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.NSFW)) {
+			if(src.isNsfw()) {
+				a11yEmbellish
+						.append(context.getString(
+								PrefsUtility.pref_accessibility_concise_mode()
+										? R.string.accessibility_subtitle_nsfw_withperiod_concise
+										: R.string.accessibility_subtitle_nsfw_withperiod))
+						.append(separator);
+			}
+		}
+
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.FLAIR)) {
+			if(src.getFlairText() != null) {
+				a11yEmbellish
+						.append(context.getString(
+								PrefsUtility.pref_accessibility_concise_mode()
+										? R.string.accessibility_subtitle_flair_withperiod_concise
+										: R.string.accessibility_subtitle_flair_withperiod,
+								src.getFlairText()
+										+ General.LTR_OVERRIDE_MARK))
+						.append(separator);
+			}
+		}
+
+		return a11yEmbellish.toString();
 	}
 
 	// lol, reddit api

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1377,6 +1377,8 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 		final String separator = " \n";
 
+		final boolean conciseMode = PrefsUtility.pref_accessibility_concise_mode();
+
 		if (isRead()) {
 				a11yEmbellish
 						.append(
@@ -1410,7 +1412,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			if(src.isNsfw()) {
 				a11yEmbellish
 						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
+								conciseMode
 										? R.string.accessibility_subtitle_nsfw_withperiod_concise
 										: R.string.accessibility_subtitle_nsfw_withperiod))
 						.append(separator);
@@ -1421,7 +1423,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			if(src.getFlairText() != null) {
 				a11yEmbellish
 						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
+								conciseMode
 										? R.string.accessibility_subtitle_flair_withperiod_concise
 										: R.string.accessibility_subtitle_flair_withperiod,
 								src.getFlairText()

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1210,20 +1210,21 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 		final String separator = " \n";
 
+		final boolean conciseMode = PrefsUtility.pref_accessibility_concise_mode();
+
 		// When not in concise mode, add embellishments to the subtitle for greater clarity and
 		// retention of familiar behaviour.
-		if (!PrefsUtility.pref_accessibility_concise_mode()) {
+		if (!conciseMode) {
 			accessibilitySubtitle.append(buildAccessibilityEmbellishments(context, headerMode));
 		}
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.SCORE)) {
 			accessibilitySubtitle
 					.append(context.getResources().getQuantityString(
-							PrefsUtility.pref_accessibility_concise_mode()
-									?(R.plurals.
+							conciseMode
+									? R.plurals.
 											accessibility_subtitle_points_withperiod_concise_plural
-									)
-									:R.plurals.accessibility_subtitle_points_withperiod_plural,
+									: R.plurals.accessibility_subtitle_points_withperiod_plural,
 							score,
 							score))
 					.append(separator);
@@ -1246,7 +1247,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.UPVOTE_RATIO)) {
 			accessibilitySubtitle
 					.append(context.getString(
-							PrefsUtility.pref_accessibility_concise_mode()
+							conciseMode
 									?R.string.accessibility_subtitle_upvote_ratio_withperiod_concise
 									: R.string.accessibility_subtitle_upvote_ratio_withperiod,
 							src.getUpvotePercentage()))
@@ -1279,15 +1280,15 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			@StringRes final int authorString;
 
 			if("moderator".equals(src.getDistinguished())) {
-				authorString = PrefsUtility.pref_accessibility_concise_mode()
+				authorString = conciseMode
 					? R.string.accessibility_subtitle_author_moderator_withperiod_concise_post
 					: R.string.accessibility_subtitle_author_moderator_withperiod;
 			} else if("admin".equals(src.getDistinguished())) {
-				authorString = PrefsUtility.pref_accessibility_concise_mode()
+				authorString = conciseMode
 					? R.string.accessibility_subtitle_author_admin_withperiod_concise_post
 					: R.string.accessibility_subtitle_author_admin_withperiod;
 			} else {
-				authorString = PrefsUtility.pref_accessibility_concise_mode()
+				authorString = conciseMode
 					? R.string.accessibility_subtitle_author_withperiod_concise_post
 					: R.string.accessibility_subtitle_author_withperiod;
 			}
@@ -1305,7 +1306,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			if(showSubreddit) {
 				accessibilitySubtitle
 						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
+								conciseMode
 										?(R.string.
 												accessibility_subtitle_subreddit_withperiod_concise
 										)
@@ -1324,7 +1325,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			if(src.isSelfPost()) {
 				accessibilitySubtitle
 						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
+								conciseMode
 										?R.string.accessibility_subtitle_selfpost_withperiod_concise
 										: R.string.accessibility_subtitle_selfpost_withperiod))
 						.append(separator);
@@ -1332,7 +1333,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			} else {
 				accessibilitySubtitle
 						.append(context.getString(
-								PrefsUtility.pref_accessibility_concise_mode()
+								conciseMode
 										?R.string.accessibility_subtitle_domain_withperiod_concise
 										: R.string.accessibility_subtitle_domain_withperiod,
 								ScreenreaderPronunciation.getPronunciation(context, domain)))
@@ -1381,7 +1382,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 						.append(
 								ScreenreaderPronunciation.getAccessibilityString(
 										context,
-										R.string.accessibility_read_withperiod
+										R.string.accessibility_post_already_read_withperiod
 								)
 						)
 						.append(separator);

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
@@ -66,7 +66,7 @@ public class RedditPostHeaderView extends LinearLayout {
 		title.setTextSize(19.0f * titleFontScale);
 		title.setTypeface(Fonts.getRobotoLightOrAlternative());
 		title.setText(post.src.getTitle());
-		title.setContentDescription(post.buildAccessibilityTitle(activity));
+		title.setContentDescription(post.buildAccessibilityTitle(activity, true));
 		title.setTextColor(Color.WHITE);
 		greyHeader.addView(title);
 

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
@@ -66,6 +66,7 @@ public class RedditPostHeaderView extends LinearLayout {
 		title.setTextSize(19.0f * titleFontScale);
 		title.setTypeface(Fonts.getRobotoLightOrAlternative());
 		title.setText(post.src.getTitle());
+		title.setContentDescription(post.buildAccessibilityTitle(activity));
 		title.setTextColor(Color.WHITE);
 		greyHeader.addView(title);
 

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -549,7 +549,7 @@ public final class RedditPostView extends FlingableItemView
 			title.setTextColor(rrPostTitleCol);
 		}
 
-		title.setContentDescription(mPost.buildAccessibilityTitle(mActivity));
+		title.setContentDescription(mPost.buildAccessibilityTitle(mActivity, false));
 
 		subtitle.setText(mPost.buildSubtitle(mActivity, false));
 		subtitle.setContentDescription(mPost.buildAccessibilitySubtitle(mActivity, false));

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -549,6 +549,8 @@ public final class RedditPostView extends FlingableItemView
 			title.setTextColor(rrPostTitleCol);
 		}
 
+		title.setContentDescription(mPost.buildAccessibilityTitle(mActivity));
+
 		subtitle.setText(mPost.buildSubtitle(mActivity, false));
 		subtitle.setContentDescription(mPost.buildAccessibilitySubtitle(mActivity, false));
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1700,6 +1700,6 @@
 	<string name="accessibility_subtitle_downvoted_withperiod">Downvoted.</string>
 
 	<!-- 2022-04-10 -->
-	<string name="accessibility_read_withperiod">Red.</string>
+	<string name="accessibility_post_already_read_withperiod">Read.</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1699,4 +1699,7 @@
 	<string name="accessibility_subtitle_upvoted_withperiod">Upvoted.</string>
 	<string name="accessibility_subtitle_downvoted_withperiod">Downvoted.</string>
 
+	<!-- 2022-04-10 -->
+	<string name="accessibility_read_withperiod">Red.</string>
+
 </resources>


### PR DESCRIPTION
This PR makes concise mode a bit more efficient by moving some "embellishments" (spoiler, sticky, NSFW, and flair) from after the title (in the accessibility subtitle) to before it (in the title) to ease rapid navigation. The reading order in standard (i.e. not concise) mode is unchanged.

I found a pair of eyes and answered my own question in https://github.com/QuantumBadger/RedReader/pull/975#issuecomment-1090762658. Apparently, submissions change colour in the list when read. This PR also adds the read state as an accessibility "embellishment", so it'll be read either before (concise) or after (standard) the title.

Note: this (and some of the other tricks employed in `org.quantumbadger.redreader.common.ScreenreaderPronunciation.getPronunciation`) are terrible for Braille, but Android's Braille support is a mess so my optimizing that in RedReader is low-pri. Ideally though, a "optimize for Braille" setting should be added that disables these hacks once Android gets decent Braille support or someone shouts.