### PR TITLE
Fix-up of #977: fix  pronunciation of "read" state in English

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/ScreenreaderPronunciation.java
+++ b/src/main/java/org/quantumbadger/redreader/common/ScreenreaderPronunciation.java
@@ -58,7 +58,7 @@ public class ScreenreaderPronunciation {
 			@StringRes final int res) {
 
 		// Only override for English for now
-		if(!Locale.getDefault().getDisplayLanguage().equals("en")) {
+		if(!Locale.getDefault().getLanguage().equals(new Locale("en").getLanguage())) {
 			return context.getString(res);
 		}
 


### PR DESCRIPTION
This PR makes `getAccessibilityString` function properly by fixing the locale check, based on the usage described [in the Android documentation](https://developer.android.com/reference/java/util/Locale#getLanguage()).

Please add a changelog entry stating that read posts are now indicated in accessibility.