### PR TITLE
Separate body text lines by default

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -1644,7 +1644,7 @@ public final class PrefsUtility {
 	public static boolean pref_accessibility_separate_body_text_lines() {
 		return getBoolean(
 				R.string.pref_accessibility_separate_body_text_lines_key,
-				false);
+				true);
 	}
 
 	public static int pref_accessibility_min_comment_height() {

--- a/src/main/res/xml/prefs_accessibility.xml
+++ b/src/main/res/xml/prefs_accessibility.xml
@@ -22,7 +22,7 @@
 	<CheckBoxPreference android:title="@string/pref_accessibility_separate_body_text_lines_title"
 						android:summary="@string/pref_accessibility_separate_body_text_lines_summary"
 						android:key="@string/pref_accessibility_separate_body_text_lines_key"
-						android:defaultValue="false"/>
+						android:defaultValue="true"/>
 
 	<CheckBoxPreference android:title="@string/pref_accessibility_say_comment_indent_level_title"
 						android:summary="@string/pref_accessibility_say_comment_indent_level_summary"


### PR DESCRIPTION
This PR changes the default value of "separate body text lines" to `true`.

You might also want to consider disabling "show link buttons" by default to address https://github.com/QuantumBadger/RedReader/issues/962#issuecomment-1069844482, but I haven't included that in this PR.