### PR TITLE
Fix copying links

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -846,7 +846,7 @@ public class MainMenuListingManager {
 				final ClipboardManager clipboardManager
 						= (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
 				if(clipboardManager != null) {
-					final ClipData data = ClipData.newRawUri(null, Uri.parse(url));
+					final ClipData data = ClipData.newPlainText(null, url);
 					clipboardManager.setPrimaryClip(data);
 
 					General.quickToast(

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditAPICommentAction.java
@@ -457,9 +457,9 @@ public class RedditAPICommentAction {
 				final ClipboardManager clipboardManager =
 						(ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
 				if(clipboardManager != null) {
-					final ClipData data = ClipData.newRawUri(
+					final ClipData data = ClipData.newPlainText(
 							null,
-							comment.getContextUrl().context(null).generateNonJsonUri());
+							comment.getContextUrl().context(null).generateNonJsonUri().toString());
 					clipboardManager.setPrimaryClip(data);
 
 					General.quickToast(

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -709,9 +709,9 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 				final ClipboardManager clipboardManager =
 						(ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
 				if(clipboardManager != null) {
-					final ClipData data = ClipData.newRawUri(
+					final ClipData data = ClipData.newPlainText(
 							post.src.getAuthor(),
-							Uri.parse(post.src.getUrl()));
+							post.src.getUrl());
 					clipboardManager.setPrimaryClip(data);
 
 					General.quickToast(


### PR DESCRIPTION
Myself, and at least [one other person](https://github.com/QuantumBadger/RedReader/issues/874), have been experiencing an issue where trying to paste a copied link does nothing.

I saw a recommendation [here](https://stackoverflow.com/questions/59188104/how-come-items-i-put-on-the-clipboard-dont-show-up-on-the-swiftkey-clipboard-hi) to use `ClipData.newPlainText()` over `ClipData.newRawUri()` for copying links, and switching to this has fixed copying links on my phone (Blackberry KEY2 running 8.1) with no ill effects. I believe this *should* fix the problem for everyone experiencing it.

Closes #874.