### PR TITLE
Move subreddit and domain before author in accessibility subtitle

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1276,32 +1276,6 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 					.append(separator);
 		}
 
-		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.AUTHOR)) {
-			@StringRes final int authorString;
-
-			if("moderator".equals(src.getDistinguished())) {
-				authorString = conciseMode
-					? R.string.accessibility_subtitle_author_moderator_withperiod_concise_post
-					: R.string.accessibility_subtitle_author_moderator_withperiod;
-			} else if("admin".equals(src.getDistinguished())) {
-				authorString = conciseMode
-					? R.string.accessibility_subtitle_author_admin_withperiod_concise_post
-					: R.string.accessibility_subtitle_author_admin_withperiod;
-			} else {
-				authorString = conciseMode
-					? R.string.accessibility_subtitle_author_withperiod_concise_post
-					: R.string.accessibility_subtitle_author_withperiod;
-			}
-
-			accessibilitySubtitle
-					.append(context.getString(
-							authorString,
-							ScreenreaderPronunciation.getPronunciation(
-									context,
-									src.getAuthor())))
-					.append(separator);
-		}
-
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.SUBREDDIT)) {
 			if(showSubreddit) {
 				accessibilitySubtitle
@@ -1339,6 +1313,32 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 								ScreenreaderPronunciation.getPronunciation(context, domain)))
 						.append(separator);
 			}
+		}
+
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.AUTHOR)) {
+			@StringRes final int authorString;
+
+			if("moderator".equals(src.getDistinguished())) {
+				authorString = conciseMode
+					? R.string.accessibility_subtitle_author_moderator_withperiod_concise_post
+					: R.string.accessibility_subtitle_author_moderator_withperiod;
+			} else if("admin".equals(src.getDistinguished())) {
+				authorString = conciseMode
+					? R.string.accessibility_subtitle_author_admin_withperiod_concise_post
+					: R.string.accessibility_subtitle_author_admin_withperiod;
+			} else {
+				authorString = conciseMode
+					? R.string.accessibility_subtitle_author_withperiod_concise_post
+					: R.string.accessibility_subtitle_author_withperiod;
+			}
+
+			accessibilitySubtitle
+					.append(context.getString(
+							authorString,
+							ScreenreaderPronunciation.getPronunciation(
+									context,
+									src.getAuthor())))
+					.append(separator);
 		}
 
 		return accessibilitySubtitle.toString();


### PR DESCRIPTION
For speech/Braille users, the most salient items should be placed first in the accessibility subtitle to ease interruptability and make navigation more efficient. To that end, this PR moves the subreddit and domain before the author in the accessibility subtitle.

While salience of these items is a bit subjective, I've discussed this with some other blind users who agree that subreddit and domain should be presented before author.

This probably doesn't deserve its own item in `changelog.txt` (can just be considered an "accessibility text improvement").