### PR TITLE
Implemented Keep Screen Awake Toggleable Setting Functionality

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/BaseActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/BaseActivity.java
@@ -189,8 +189,7 @@ public abstract class BaseActivity extends AppCompatActivity
 
 		if(PrefsUtility.pref_behaviour_keep_screen_awake()) {
 			getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-		}
-		else{
+		} else{
 			getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/activities/BaseActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/BaseActivity.java
@@ -187,6 +187,13 @@ public abstract class BaseActivity extends AppCompatActivity
 			getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
 		}
 
+		if(PrefsUtility.pref_behaviour_keep_screen_awake()) {
+			getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		}
+		else{
+			getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		}
+
 		mSharedPreferences.registerOnSharedPreferenceChangeListener(this);
 		setOrientationFromPrefs();
 		closeIfNecessary();

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -158,7 +158,8 @@ public final class PrefsUtility {
 				|| context.getString(R.string.pref_appearance_bottom_toolbar_key).equals(key)
 				|| context.getString(R.string.pref_appearance_hide_toolbar_on_scroll_key)
 						.equals(key)
-				|| context.getString(R.string.pref_behaviour_block_screenshots_key).equals(key);
+				|| context.getString(R.string.pref_behaviour_block_screenshots_key).equals(key)
+				|| context.getString(R.string.pref_behaviour_keep_screen_awake_key).equals(key);
 	}
 
 	///////////////////////////////
@@ -1676,6 +1677,12 @@ public final class PrefsUtility {
 	public static boolean pref_accessibility_concise_mode() {
 		return getBoolean(
 				R.string.pref_accessibility_concise_mode_key,
+				false);
+	}
+
+	public static boolean pref_behaviour_keep_screen_awake() {
+		return getBoolean(
+				R.string.pref_behaviour_keep_screen_awake_key,
 				false);
 	}
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1702,4 +1702,9 @@
 	<!-- 2022-04-10 -->
 	<string name="accessibility_post_already_read_withperiod">Read.</string>
 
+	<!-- 2022-05-17 -->
+	<string name="pref_behaviour_keep_screen_awake_key">pref_behaviour_keep_screen_awake</string>
+	<string name="pref_behaviour_keep_screen_awake_title">Keep screen awake</string>
+	<string name="pref_behaviour_keep_screen_awake_summary">Keep screen awake when RedReader is running in the foreground</string>
+
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -58,6 +58,11 @@
 						android:summary="@string/pref_behaviour_block_screenshots_summary"
 						android:defaultValue="false" />
 
+	<CheckBoxPreference android:title="@string/pref_behaviour_keep_screen_awake_title"
+			android:key="@string/pref_behaviour_keep_screen_awake_key"
+			android:summary="@string/pref_behaviour_keep_screen_awake_summary"
+			android:defaultValue="false" />
+
     <PreferenceCategory android:title="@string/pref_behaviour_sort_header">
 
 		<ListPreference android:title="@string/pref_behaviour_postsort"


### PR DESCRIPTION
CheckBoxPreference is used for the Keep Screen Awake setting with "pref_behaviour_keep_screen_awake" as its key, and it is set to false by default. The CheckBoxPreference is added to prefs_behavior.xml.

SharedPreferences "pref_behaviour_keep_screen_awake" boolean value is checked to determine if the setting is enabled or not.

getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON); is used to keep the screen awake while the app is running in the foreground.

getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) is used to clear the FLAG_KEEP_SCREEN_ON flag to allow the screen to turn off according to the user's screen sleep settings of their device.

context.getString(R.string.pref_behaviour_keep_screen_awake_key).equals(key) is added to isRestartRequired() to ensure that on-the-fly toggling of the function works without needing the user to exit the app for the changes to be reflected.

Tested on Xiaomi POCO X3 Pro running MIUI Version 12.5.9 (Android 11) and working as intended.
Passed all local automated code checks using "./gradlew pmd checkstyle lint test".

![Screenshot_2022-05-18-13-29-34-088_org quantumbadger redreader](https://user-images.githubusercontent.com/64062732/168964020-9c097e5d-24a7-4ef0-8d1e-f3ce5b940268.jpg)

![Screenshot_2022-05-18-13-29-29-821_org quantumbadger redreader](https://user-images.githubusercontent.com/64062732/168964009-fbd0428f-fcf9-42db-b598-448e85a88dd8.jpg)

![BuildSuccessfulAfterDowngradingGradle](https://user-images.githubusercontent.com/64062732/168964104-247521bd-dc3e-407a-bd20-1aa75ddbbdc8.PNG)