### PR TITLE
Add option to show comment count in post subtitle

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -545,7 +545,18 @@ public final class PrefsUtility {
 	}
 
 	public enum AppearancePostSubtitleItem {
-		AUTHOR, FLAIR, SCORE, AGE, GOLD, SUBREDDIT, DOMAIN, STICKY, SPOILER, NSFW, UPVOTE_RATIO
+		AUTHOR,
+		FLAIR,
+		SCORE,
+		AGE,
+		GOLD,
+		SUBREDDIT,
+		DOMAIN,
+		STICKY,
+		SPOILER,
+		NSFW,
+		UPVOTE_RATIO,
+		COMMENTS
 	}
 
 	public static EnumSet<AppearancePostSubtitleItem> appearance_post_subtitle_items() {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.java
@@ -307,6 +307,10 @@ public class RedditParsedPost implements RedditThingWithIdAndType {
 		return score;
 	}
 
+	public int getCommentCount() {
+		return mSrc.num_comments;
+	}
+
 	public int getGoldAmount() {
 		return mSrc.gilded;
 	}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1095,6 +1095,18 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 					" " + context.getString(R.string.subtitle_upvote_ratio) + ") ", 0);
 		}
 
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.COMMENTS)) {
+			postListDescSb.append(
+					String.valueOf(src.getCommentCount()),
+					BetterSSB.BOLD | BetterSSB.FOREGROUND_COLOR,
+					boldCol,
+					0,
+					1f);
+			postListDescSb.append(
+					BetterSSB.NBSP + context.getString(R.string.subtitle_comments) + " ",
+					0);
+		}
+
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.GOLD)) {
 			if(src.getGoldAmount() > 0) {
 				if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.SCORE)
@@ -1251,6 +1263,15 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 									?R.string.accessibility_subtitle_upvote_ratio_withperiod_concise
 									: R.string.accessibility_subtitle_upvote_ratio_withperiod,
 							src.getUpvotePercentage()))
+					.append(separator);
+		}
+
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.COMMENTS)) {
+			accessibilitySubtitle
+					.append(context.getResources().getQuantityString(
+							R.plurals.accessibility_subtitle_comments_withperiod_plural,
+							src.getCommentCount(),
+							src.getCommentCount()))
 					.append(separator);
 		}
 

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -864,6 +864,7 @@
 		<item>@string/pref_appearance_comment_header_items_flair</item>
 		<item>@string/pref_appearance_comment_header_items_score</item>
 		<item>@string/pref_appearance_post_subtitle_items_upvote_ratio</item>
+		<item>@string/pref_appearance_post_subtitle_items_comments</item>
 		<item>@string/pref_appearance_comment_header_items_age</item>
 		<item>@string/pref_appearance_comment_header_items_gold</item>
 		<item>@string/pref_appearance_post_subtitle_items_subreddit</item>
@@ -879,6 +880,7 @@
 		<item>flair</item>
 		<item>score</item>
 		<item>upvote_ratio</item>
+		<item>comments</item>
 		<item>age</item>
 		<item>gold</item>
 		<item>subreddit</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1707,4 +1707,12 @@
 	<string name="pref_behaviour_keep_screen_awake_title">Keep screen awake</string>
 	<string name="pref_behaviour_keep_screen_awake_summary">Keep screen awake when RedReader is running in the foreground</string>
 
+	<!-- 2022-05-23 -->
+	<string name="subtitle_comments">cmts</string>
+	<string name="pref_appearance_post_subtitle_items_comments">Comments</string>
+	<plurals name="accessibility_subtitle_comments_withperiod_plural">
+		<item quantity="one">%d comment.</item>
+		<item quantity="other">%d comments.</item>
+	</plurals>
+
 </resources>


### PR DESCRIPTION
Several notes:
- I put this right after the score and upvote ratio, which struck me as a good spot.
- I used "cmts" for the visible text, since using the entire word "comments" adds a lot of length to the post subtitle, but maybe that's not a good abbreviation?
- I don't think the accessibility version could really be any more compact than `"%d comment(s)."`, so I always used that string.

Closes #989.