### PR TITLE
Improve time and subtitle/header formatting with non-breaking spaces

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/RRTime.java
+++ b/src/main/java/org/quantumbadger/redreader/common/RRTime.java
@@ -92,6 +92,7 @@ public class RRTime {
 			final int unitsToDisplay) {
 
 		final String space = " ";
+		final String nbsp = String.valueOf(BetterSSB.NBSP);
 		final String comma = ",";
 		final String separator = comma + space;
 
@@ -101,43 +102,43 @@ public class RRTime {
 
 		final PeriodFormatter periodFormatter = new PeriodFormatterBuilder()
 				.appendYears()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(
 						context.getString(R.string.time_year),
 						context.getString(R.string.time_years))
 				.appendSeparator(separator)
 				.appendMonths()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(
 						context.getString(R.string.time_month),
 						context.getString(R.string.time_months))
 				.appendSeparator(separator)
 				.appendDays()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(
 						context.getString(R.string.time_day),
 						context.getString(R.string.time_days))
 				.appendSeparator(separator)
 				.appendHours()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(
 						context.getString(R.string.time_hour),
 						context.getString(R.string.time_hours))
 				.appendSeparator(separator)
 				.appendMinutes()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(
 						context.getString(R.string.time_min),
 						context.getString(R.string.time_mins))
 				.appendSeparator(separator)
 				.appendSeconds()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(
 						context.getString(R.string.time_sec),
 						context.getString(R.string.time_secs))
 				.appendSeparator(separator)
 				.appendMillis()
-				.appendSuffix(space)
+				.appendSuffix(nbsp)
 				.appendSuffix(context.getString(R.string.time_ms))
 				.toFormatter();
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -1079,7 +1079,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 					0,
 					1f);
 			postListDescSb.append(
-					" " + context.getString(R.string.subtitle_points) + " ",
+					BetterSSB.NBSP + context.getString(R.string.subtitle_points) + " ",
 					0);
 		}
 
@@ -1092,7 +1092,7 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 					0,
 					1f);
 			postListDescSb.append(
-					" " + context.getString(R.string.subtitle_upvote_ratio) + ") ", 0);
+					BetterSSB.NBSP + context.getString(R.string.subtitle_upvote_ratio) + ") ", 0);
 		}
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.GOLD)) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -206,7 +206,7 @@ public class RedditRenderableComment
 						1f);
 			}
 
-			sb.append(" " + context.getString(R.string.subtitle_points), 0);
+			sb.append(BetterSSB.NBSP + context.getString(R.string.subtitle_points), 0);
 
 			if(!theme.shouldShow(PrefsUtility.AppearanceCommentHeaderItem.CONTROVERSIALITY)) {
 				sb.append(" ", 0);


### PR DESCRIPTION
Noticed the time periods, and a few subtitle/header entries, could use non-breaking spaces to occasionally improve readability.