### PR TITLE
Show user avatar in User Profile dialog

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
@@ -32,7 +32,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.activities.BaseActivity;
@@ -130,10 +129,12 @@ public class UserProfileDialog extends PropertiesDialog {
 
 							loadingView.setDone(R.string.download_done);
 
-							if (user.getIconUrl() != "") {
+							final String iconUrl = user.getIconUrl();
+
+							if (iconUrl != null && !iconUrl.equals("")) {
 								final LinearLayout avatarLayout
 										= (LinearLayout) context.getLayoutInflater()
-										.inflate(R.layout.avatar, null);
+												.inflate(R.layout.avatar, null);
 								items.addView(avatarLayout);
 
 								final ImageView avatarImage
@@ -141,7 +142,7 @@ public class UserProfileDialog extends PropertiesDialog {
 										.findViewById(R.id.layout_avatar_image);
 
 								try {
-									assignUserAvatar(user.getIconUrl(), avatarImage, context);
+									assignUserAvatar(iconUrl, avatarImage, context);
 								} catch (final URISyntaxException e) {
 									Log.d("UserProfileDialog", "Error decoding uri: " + e);
 								}
@@ -151,7 +152,7 @@ public class UserProfileDialog extends PropertiesDialog {
 
 							final LinearLayout karmaLayout
 									= (LinearLayout)context.getLayoutInflater()
-									.inflate(R.layout.karma, null);
+											.inflate(R.layout.karma, null);
 							items.addView(karmaLayout);
 
 							final LinearLayout linkKarmaLayout

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
@@ -21,8 +21,14 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -49,6 +55,10 @@ import org.quantumbadger.redreader.reddit.things.RedditUser;
 import org.quantumbadger.redreader.reddit.url.UserPostListingURL;
 import org.quantumbadger.redreader.views.liststatus.ErrorView;
 import org.quantumbadger.redreader.views.liststatus.LoadingView;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class UserProfileDialog extends PropertiesDialog {
 
@@ -114,6 +124,34 @@ public class UserProfileDialog extends PropertiesDialog {
 							}
 
 							loadingView.setDone(R.string.download_done);
+
+							if (user.getIconUrl() != "") {
+								final LinearLayout avatarLayout
+										= (LinearLayout) context.getLayoutInflater()
+										.inflate(R.layout.avatar, null);
+								items.addView(avatarLayout);
+
+								final ImageView avatarImage
+										= avatarLayout
+										.findViewById(R.id.layout_avatar_image);
+
+								ExecutorService executor = Executors.newSingleThreadExecutor();
+								executor.execute(() -> {
+									try {
+										URL splitUrl = new URL(user.getIconUrl());
+										InputStream stream = splitUrl.openStream();
+										Bitmap img = BitmapFactory.decodeStream(stream);
+
+										new Handler(Looper.getMainLooper()).post(() -> {
+											avatarImage.setImageBitmap(img);
+										});
+									} catch (Exception e) {
+										e.printStackTrace();
+									}
+								});
+							} else {
+								Log.d("UserDialog", "Unknown icon url: " + user.icon_img);
+							}
 
 							final LinearLayout karmaLayout
 									= (LinearLayout)context.getLayoutInflater()

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.java
@@ -135,22 +135,22 @@ public class UserProfileDialog extends PropertiesDialog {
 										= avatarLayout
 										.findViewById(R.id.layout_avatar_image);
 
-								ExecutorService executor = Executors.newSingleThreadExecutor();
-								executor.execute(() -> {
+								final ExecutorService exec = Executors.newSingleThreadExecutor();
+								exec.execute(() -> {
 									try {
-										URL splitUrl = new URL(user.getIconUrl());
-										InputStream stream = splitUrl.openStream();
-										Bitmap img = BitmapFactory.decodeStream(stream);
+										final URL splitUrl = new URL(user.getIconUrl());
+										final InputStream stream = splitUrl.openStream();
+										final Bitmap img = BitmapFactory.decodeStream(stream);
 
 										new Handler(Looper.getMainLooper()).post(() -> {
 											avatarImage.setImageBitmap(img);
 										});
-									} catch (Exception e) {
-										e.printStackTrace();
+									} catch (final Exception e) {
+										Log.e("UserProfileDialog", String.valueOf(e));
 									}
 								});
 							} else {
-								Log.d("UserDialog", "Unknown icon url: " + user.icon_img);
+								Log.d("UserProfileDialog", "Unknown icon url: " + user.icon_img);
 							}
 
 							final LinearLayout karmaLayout

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.reddit.things;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+
 import org.quantumbadger.redreader.jsonwrap.JsonObject;
 
 public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
@@ -39,6 +40,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 	public String id;
 	public String modhash;
 	public String name;
+	public String icon_img; // URL, use helper function otherwise it returns 'not authorized'
 
 	@Override
 	public int describeContents() {
@@ -79,6 +81,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		id = in.readString();
 		modhash = in.readString();
 		name = in.readString();
+		icon_img = in.readString();
 	}
 
 	@Override
@@ -110,6 +113,18 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		parcel.writeString(id);
 		parcel.writeString(modhash);
 		parcel.writeString(name);
+		parcel.writeString(icon_img);
+	}
+
+	public String getIconUrl() {
+		if (icon_img.contains(".png"))
+			return icon_img.split(".png")[0] + ".png";
+		else if (icon_img.contains(".jpg"))
+			return icon_img.split(".jpg")[0] + ".jpg";
+		else if (icon_img.contains(".jpeg"))
+			return icon_img.split(".jpeg")[0] + ".jpeg";
+		else
+			return "";
 	}
 
 	public static final Parcelable.Creator<RedditUser> CREATOR

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -19,7 +19,8 @@ package org.quantumbadger.redreader.reddit.things;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-
+import androidx.annotation.Nullable;
+import org.apache.commons.text.StringEscapeUtils;
 import org.quantumbadger.redreader.jsonwrap.JsonObject;
 
 public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
@@ -40,7 +41,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 	public String id;
 	public String modhash;
 	public String name;
-	public String icon_img; // URL, use helper function otherwise it returns 'not authorized'
+	public String icon_img;
 
 	@Override
 	public int describeContents() {
@@ -116,15 +117,12 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		parcel.writeString(icon_img);
 	}
 
+	@Nullable
 	public String getIconUrl() {
-		if (icon_img.contains(".png")) {
-			return icon_img.split(".png")[0] + ".png";
-		} else if (icon_img.contains(".jpg")) {
-			return icon_img.split(".jpg")[0] + ".jpg";
-		} else if (icon_img.contains(".jpeg")) {
-			return icon_img.split(".jpeg")[0] + ".jpeg";
+		if(icon_img == null) {
+			return null;
 		} else {
-			return "";
+			return StringEscapeUtils.unescapeHtml4(icon_img);
 		}
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -117,14 +117,15 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 	}
 
 	public String getIconUrl() {
-		if (icon_img.contains(".png"))
+		if (icon_img.contains(".png")) {
 			return icon_img.split(".png")[0] + ".png";
-		else if (icon_img.contains(".jpg"))
+		} else if (icon_img.contains(".jpg")) {
 			return icon_img.split(".jpg")[0] + ".jpg";
-		else if (icon_img.contains(".jpeg"))
+		} else if (icon_img.contains(".jpeg")) {
 			return icon_img.split(".jpeg")[0] + ".jpeg";
-		else
+		} else {
 			return "";
+		}
 	}
 
 	public static final Parcelable.Creator<RedditUser> CREATOR

--- a/src/main/res/layout/avatar.xml
+++ b/src/main/res/layout/avatar.xml
@@ -18,43 +18,23 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-		xmlns:app="http://schemas.android.com/apk/res-auto"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:baselineAligned="false"
-		android:orientation="vertical">
-
-	<TextView
-			android:id="@+id/layout_avatar_text"
-			android:layout_width="match_parent"
-			android:layout_height="0dp"
-			android:layout_gravity="center"
-			android:layout_weight="1"
-			android:paddingStart="12dp"
-			android:paddingLeft="12dp"
-			android:paddingTop="12dp"
-			android:paddingEnd="12dp"
-			android:paddingBottom="5dp"
-			android:text="@string/userprofile_avatar"
-			android:textAllCaps="true"
-			android:textColor="?rrListHeaderTextCol"
-			android:textSize="12sp" />
+			  android:layout_width="match_parent"
+			  android:layout_height="wrap_content"
+			  android:baselineAligned="false"
+			  android:orientation="vertical">
 
 	<ImageView
 			android:id="@+id/layout_avatar_image"
 			android:layout_width="150dp"
 			android:layout_height="150dp"
 			android:layout_gravity="center"
-			android:layout_marginStart="12dp"
-			android:layout_marginLeft="12dp"
-			android:layout_marginEnd="12dp"
-			android:layout_marginRight="12dp"
-			android:contentDescription="@string/userprofile_avatar" />
+			android:layout_margin="12dp"
+			android:contentDescription="@string/userprofile_avatar"
+			android:scaleType="fitCenter"/>
 
 	<View
-			android:id="@+id/view"
 			android:layout_width="match_parent"
 			android:layout_height="1dp"
-			android:background="?rrListDividerCol" />
+			android:background="?rrListDividerCol"/>
 
 </LinearLayout>

--- a/src/main/res/layout/avatar.xml
+++ b/src/main/res/layout/avatar.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ This file is part of RedReader.
+  ~
+  ~ RedReader is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ RedReader is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:baselineAligned="false"
+		android:orientation="vertical">
+
+	<TextView
+			android:id="@+id/layout_avatar_text"
+			android:layout_width="match_parent"
+			android:layout_height="0dp"
+			android:layout_gravity="center"
+			android:layout_weight="1"
+			android:paddingStart="12dp"
+			android:paddingLeft="12dp"
+			android:paddingTop="12dp"
+			android:paddingEnd="12dp"
+			android:paddingBottom="5dp"
+			android:text="@string/userprofile_avatar"
+			android:textAllCaps="true"
+			android:textColor="?rrListHeaderTextCol"
+			android:textSize="12sp" />
+
+	<ImageView
+			android:id="@+id/layout_avatar_image"
+			android:layout_width="150dp"
+			android:layout_height="150dp"
+			android:layout_marginStart="12dp"
+			android:layout_marginLeft="12dp"
+			android:layout_marginEnd="12dp"
+			android:layout_marginRight="12dp"
+			android:contentDescription="@string/userprofile_avatar" />
+
+	<View
+			android:id="@+id/view"
+			android:layout_width="match_parent"
+			android:layout_height="1dp"
+			android:background="?rrListDividerCol" />
+
+</LinearLayout>

--- a/src/main/res/layout/avatar.xml
+++ b/src/main/res/layout/avatar.xml
@@ -44,6 +44,7 @@
 			android:id="@+id/layout_avatar_image"
 			android:layout_width="150dp"
 			android:layout_height="150dp"
+			android:layout_gravity="center"
 			android:layout_marginStart="12dp"
 			android:layout_marginLeft="12dp"
 			android:layout_marginEnd="12dp"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1730,4 +1730,7 @@
 	<!-- 2022-09-10 -->
 	<string name="post_domain_deleted">deleted</string>
 
+	<!-- 2023-01-15 -->
+	<string name="userprofile_avatar">Avatar</string>
+
 </resources>


### PR DESCRIPTION
This commit adds the icon_img key to the RedditUser class as well as a helper function to strip problematic parts of the URL. I also created an avatar layout which is added to the User Profile dialog. The code to download the image and put it into the imageview is very hacky and I'm sure there is a better way to do it. If the URL returns some kind of error the avatar layout is never added.

Here's a screenshot of the final product:
![image](https://user-images.githubusercontent.com/15272379/188531431-fc61fbb0-9a95-470f-9c54-0f2c1520d05e.png)
