### PR TITLE
Simplify and add additional accessibility actions

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -463,50 +463,39 @@ public class RedditCommentView extends FlingableItemView
 			return;
 		}
 
-		final RedditParsedComment comment = mComment.asComment().getParsedComment();
-
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditAPICommentAction.RedditCommentAction.COLLAPSE, R.string.action_collapse
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.COLLAPSE)
+		);
 
 		// TODO Bill: Implement "collapse thread" here.
 		// May need to do this as a custom runnable.
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditAPICommentAction.RedditCommentAction.REPLY, R.string.action_reply
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY)
+		);
 
 		// #136: When "save" is implemented for comments, add an a11y action here.
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditAPICommentAction.RedditCommentAction.USER_PROFILE, R.string.action_user_profile
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.USER_PROFILE)
+		);
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditAPICommentAction.RedditCommentAction.REPORT, R.string.action_report
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.REPORT)
+		);
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditAPICommentAction.RedditCommentAction.SHARE, R.string.action_share
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.SHARE)
+		);
 
-		if(mChangeDataManager.isDownvoted(comment))
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditAPICommentAction.RedditCommentAction.UNVOTE, R.string.action_downvote_remove
-			));
-		else
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditAPICommentAction.RedditCommentAction.DOWNVOTE, R.string.action_downvote
-			));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.DOWNVOTE)
+		);
 
-		if(mChangeDataManager.isUpvoted(comment))
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditAPICommentAction.RedditCommentAction.UNVOTE, R.string.action_upvote_remove
-			));
-		else
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditAPICommentAction.RedditCommentAction.UPVOTE, R.string.action_upvote
-			));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.CommentFlingAction.UPVOTE)
+		);
+
 	}
 
 	public RedditCommentListItem getComment() {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -465,6 +465,31 @@ public class RedditCommentView extends FlingableItemView
 
 		final RedditParsedComment comment = mComment.asComment().getParsedComment();
 
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditAPICommentAction.RedditCommentAction.COLLAPSE, R.string.action_collapse
+		));
+
+		// TODO Bill: Implement "collapse thread" here.
+		// May need to do this as a custom runnable.
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditAPICommentAction.RedditCommentAction.REPLY, R.string.action_reply
+		));
+
+		// #136: When "save" is implemented for comments, add an a11y action here.
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditAPICommentAction.RedditCommentAction.USER_PROFILE, R.string.action_user_profile
+		));
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditAPICommentAction.RedditCommentAction.REPORT, R.string.action_report
+		));
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditAPICommentAction.RedditCommentAction.SHARE, R.string.action_share
+		));
+
 		if(mChangeDataManager.isDownvoted(comment))
 			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
 				RedditAPICommentAction.RedditCommentAction.UNVOTE, R.string.action_downvote_remove

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -34,7 +34,6 @@ import org.quantumbadger.redreader.common.Optional;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRThemeAttributes;
 import org.quantumbadger.redreader.fragments.CommentListingFragment;
-import org.quantumbadger.redreader.reddit.RedditAPI;
 import org.quantumbadger.redreader.reddit.RedditCommentListItem;
 import org.quantumbadger.redreader.reddit.api.RedditAPICommentAction;
 import org.quantumbadger.redreader.reddit.prepared.RedditChangeDataManager;
@@ -466,44 +465,39 @@ public class RedditCommentView extends FlingableItemView
 
 		final RedditParsedComment comment = mComment.asComment().getParsedComment();
 
-		if(mChangeDataManager.isUpvoted(comment)) {
-			mAccessibilityActionManager.addAction(R.string.action_upvote_remove, () -> {
-				RedditAPICommentAction.action(
-						mActivity,
-						comment.getRawComment(),
-						RedditAPI.ACTION_UNVOTE,
-						mChangeDataManager);
-			});
-		} else {
-			mAccessibilityActionManager.addAction(R.string.action_upvote, () -> {
-				RedditAPICommentAction.action(
-						mActivity,
-						comment.getRawComment(),
-						RedditAPI.ACTION_UPVOTE,
-						mChangeDataManager);
-			});
-		}
+		if(mChangeDataManager.isDownvoted(comment))
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditAPICommentAction.RedditCommentAction.UNVOTE, R.string.action_downvote_remove
+			));
+		else
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditAPICommentAction.RedditCommentAction.DOWNVOTE, R.string.action_downvote
+			));
 
-		if(mChangeDataManager.isDownvoted(comment)) {
-			mAccessibilityActionManager.addAction(R.string.action_downvote_remove, () -> {
-				RedditAPICommentAction.action(
-						mActivity,
-						comment.getRawComment(),
-						RedditAPI.ACTION_UNVOTE,
-						mChangeDataManager);
-			});
-		} else {
-			mAccessibilityActionManager.addAction(R.string.action_downvote, () -> {
-				RedditAPICommentAction.action(
-						mActivity,
-						comment.getRawComment(),
-						RedditAPI.ACTION_DOWNVOTE,
-						mChangeDataManager);
-			});
-		}
+		if(mChangeDataManager.isUpvoted(comment))
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditAPICommentAction.RedditCommentAction.UNVOTE, R.string.action_upvote_remove
+			));
+		else
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditAPICommentAction.RedditCommentAction.UPVOTE, R.string.action_upvote
+			));
 	}
 
 	public RedditCommentListItem getComment() {
 		return mComment;
+	}
+
+	private void addAccessibilityActionFromDescriptionPair(final ActionDescriptionPair pair) {
+		mAccessibilityActionManager.addAction(pair.descriptionRes, () -> {
+			RedditAPICommentAction.onActionMenuItemSelected(
+				mComment.asComment(),
+				this,
+				mActivity,
+				mFragment,
+				pair.action,
+				mChangeDataManager
+			);
+		});
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -591,37 +591,33 @@ public final class RedditPostView extends FlingableItemView
 
 		mAccessibilityActionManager.removeAllActions();
 
-		if(mPost.isUpvoted()) {
-			mAccessibilityActionManager.addAction(R.string.action_upvote_remove, () -> {
-				RedditPreparedPost.onActionMenuItemSelected(
-						mPost,
-						mActivity,
-						RedditPreparedPost.Action.UNVOTE);
-			});
-		} else {
-			mAccessibilityActionManager.addAction(R.string.action_upvote, () -> {
-				RedditPreparedPost.onActionMenuItemSelected(
-						mPost,
-						mActivity,
-						RedditPreparedPost.Action.UPVOTE);
-			});
-		}
+		if(mPost.isDownvoted())
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditPreparedPost.Action.UNVOTE, R.string.action_downvote_remove
+			));
+		else
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditPreparedPost.Action.DOWNVOTE, R.string.action_downvote
+			));
 
-		if(mPost.isDownvoted()) {
-			mAccessibilityActionManager.addAction(R.string.action_downvote_remove, () -> {
-				RedditPreparedPost.onActionMenuItemSelected(
-						mPost,
-						mActivity,
-						RedditPreparedPost.Action.UNVOTE);
-			});
-		} else {
-			mAccessibilityActionManager.addAction(R.string.action_downvote, () -> {
-				RedditPreparedPost.onActionMenuItemSelected(
-						mPost,
-						mActivity,
-						RedditPreparedPost.Action.DOWNVOTE);
-			});
-		}
+		if(mPost.isUpvoted())
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditPreparedPost.Action.UNVOTE, R.string.action_upvote_remove
+			));
+		else
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditPreparedPost.Action.UPVOTE, R.string.action_upvote
+			));
+	}
+
+	private void addAccessibilityActionFromDescriptionPair(final ActionDescriptionPair pair) {
+		mAccessibilityActionManager.addAction(pair.descriptionRes, () -> {
+			RedditPreparedPost.onActionMenuItemSelected(
+				mPost,
+				mActivity,
+				pair.action
+			);
+		});
 	}
 
 	@Override

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -591,48 +591,34 @@ public final class RedditPostView extends FlingableItemView
 
 		mAccessibilityActionManager.removeAllActions();
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditPreparedPost.Action.COMMENTS, R.string.action_comments
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.COMMENTS)
+		);
 
-		if(mPost.isSaved())
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditPreparedPost.Action.UNSAVE, R.string.action_unsave
-			));
-		else
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditPreparedPost.Action.SAVE, R.string.action_save
-			));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.SAVE)
+		);
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditPreparedPost.Action.USER_PROFILE, R.string.action_user_profile
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.USER_PROFILE)
+		);
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditPreparedPost.Action.REPORT, R.string.action_report
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.REPORT)
+		);
 
-		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-			RedditPreparedPost.Action.SHARE, R.string.action_share
-		));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.SHARE)
+		);
 
-		if(mPost.isDownvoted())
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditPreparedPost.Action.UNVOTE, R.string.action_downvote_remove
-			));
-		else
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditPreparedPost.Action.DOWNVOTE, R.string.action_downvote
-			));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.DOWNVOTE)
+		);
 
-		if(mPost.isUpvoted())
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditPreparedPost.Action.UNVOTE, R.string.action_upvote_remove
-			));
-		else
-			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
-				RedditPreparedPost.Action.UPVOTE, R.string.action_upvote
-			));
+		addAccessibilityActionFromDescriptionPair(
+			chooseFlingAction(PrefsUtility.PostFlingAction.UPVOTE)
+		);
+
 	}
 
 	private void addAccessibilityActionFromDescriptionPair(final ActionDescriptionPair pair) {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -591,6 +591,31 @@ public final class RedditPostView extends FlingableItemView
 
 		mAccessibilityActionManager.removeAllActions();
 
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditPreparedPost.Action.COMMENTS, R.string.action_comments
+		));
+
+		if(mPost.isSaved())
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditPreparedPost.Action.UNSAVE, R.string.action_unsave
+			));
+		else
+			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+				RedditPreparedPost.Action.SAVE, R.string.action_save
+			));
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditPreparedPost.Action.USER_PROFILE, R.string.action_user_profile
+		));
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditPreparedPost.Action.REPORT, R.string.action_report
+		));
+
+		addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
+			RedditPreparedPost.Action.SHARE, R.string.action_share
+		));
+
 		if(mPost.isDownvoted())
 			addAccessibilityActionFromDescriptionPair(new ActionDescriptionPair(
 				RedditPreparedPost.Action.UNVOTE, R.string.action_downvote_remove


### PR DESCRIPTION
Thanks @QuantumBadger for your work on accessibility actions. This is huge!

This PR simplifies some of the accessibility action logic introduced in 702aac39514c6e4037d3870263a4c675c7ce1f9d and adds a richer suite of actions on posts and comments.

To allow for very easy collapsing and up-voting, the "upvote" action has been moved to the end, so it's reachable with one swipe up, and collapse with one swipe down. It might be nice to make the list of actions presented (and its order) customizable in a future change, but that's intentionally out-of-scope/not considered by me to be part of #964.