### PR TITLE
Further refinements to accessibility actions

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -523,15 +523,13 @@ public class CommentListingFragment extends RRFragment
 					((ViewGroup)selfText).setDescendantFocusability(
 							ViewGroup.FOCUS_BLOCK_DESCENDANTS);
 
-				RedditPostActions.INSTANCE.setupAccessibilityActions(
-					new AccessibilityActionManager(
-						selfText,
-						activity.getResources()
-					),
-					post,
-					activity,
-					true
-				);
+					RedditPostActions.INSTANCE.setupAccessibilityActions(
+						new AccessibilityActionManager(
+							selfText,
+							activity.getResources()),
+						post,
+						activity,
+						true);
 				}
 
 				final int paddingPx = General.dpToPixels(activity, 10);

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -522,14 +522,6 @@ public class CommentListingFragment extends RRFragment
 				if(selfText instanceof ViewGroup) {
 					((ViewGroup)selfText).setDescendantFocusability(
 							ViewGroup.FOCUS_BLOCK_DESCENDANTS);
-
-					RedditPostActions.INSTANCE.setupAccessibilityActions(
-						new AccessibilityActionManager(
-							selfText,
-							activity.getResources()),
-						post,
-						activity,
-						true);
 				}
 
 				final int paddingPx = General.dpToPixels(activity, 10);
@@ -571,6 +563,14 @@ public class CommentListingFragment extends RRFragment
 					RedditPostActions.INSTANCE.showActionMenu(activity, mPost);
 					return true;
 				});
+
+				RedditPostActions.INSTANCE.setupAccessibilityActions(
+						new AccessibilityActionManager(
+								paddingLayout,
+								activity.getResources()),
+						post,
+						activity,
+						true);
 
 				mCommentListingManager.addPostSelfText(paddingLayout);
 			}

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -62,6 +62,7 @@ import org.quantumbadger.redreader.reddit.prepared.RedditChangeDataManager;
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost;
 import org.quantumbadger.redreader.reddit.prepared.RedditRenderableComment;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
+import org.quantumbadger.redreader.views.AccessibilityActionManager;
 import org.quantumbadger.redreader.views.RedditCommentView;
 import org.quantumbadger.redreader.views.RedditPostHeaderView;
 import org.quantumbadger.redreader.views.RedditPostView;
@@ -521,6 +522,16 @@ public class CommentListingFragment extends RRFragment
 				if(selfText instanceof ViewGroup) {
 					((ViewGroup)selfText).setDescendantFocusability(
 							ViewGroup.FOCUS_BLOCK_DESCENDANTS);
+
+				RedditPostActions.INSTANCE.setupAccessibilityActions(
+					new AccessibilityActionManager(
+						selfText,
+						activity.getResources()
+					),
+					post,
+					activity,
+					true
+				);
 				}
 
 				final int paddingPx = General.dpToPixels(activity, 10);

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
@@ -239,6 +239,13 @@ object RedditPostActions {
 			}
 		}
 
+		val isOP = RedditAccountManager.getInstance(
+			activity
+		).defaultAccount.username.equals(
+			post.src.author,
+			ignoreCase = true
+		)
+
 		accessibilityActionManager.removeAllActions()
 
 		if (isOpen) {
@@ -251,12 +258,26 @@ object RedditPostActions {
 						R.string.action_reply
 					)
 				)
+			if (isOP && post.isSelf)
+				addAccessibilityActionFromDescriptionPair(
+					ActionDescriptionPair(
+						Action.EDIT,
+						R.string.action_edit
+					)
+				)
 		} else {
 			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.COMMENTS))
 		}
 
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.SAVE))
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.USER_PROFILE))
+		if (isOP)
+			addAccessibilityActionFromDescriptionPair(
+				ActionDescriptionPair(
+					Action.DELETE,
+					R.string.action_delete
+				)
+			)
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.REPORT))
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.SHARE))
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.DOWNVOTE))

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
@@ -239,37 +239,40 @@ object RedditPostActions {
 			}
 		}
 
-		val isOP = RedditAccountManager.getInstance(
-			activity
-		).defaultAccount.username.equals(
+		val defaultAccount = RedditAccountManager.getInstance(activity).defaultAccount
+		val isOP = defaultAccount.username.equals(
 			post.src.author,
 			ignoreCase = true
 		)
+		val isAuthenticated = defaultAccount.isNotAnonymous
 
 		accessibilityActionManager.removeAllActions()
 
 		if (isOpen) {
 			// TODO: add an action here to jump focus from the body of the post to its comments.
 			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.GOTO_SUBREDDIT))
-			if (!post.isArchived && !(post.isLocked && !post.canModerate))
-				addAccessibilityActionFromDescriptionPair(
-					ActionDescriptionPair(
-						Action.REPLY,
-						R.string.action_reply
+			if (isAuthenticated) {
+				if (!post.isArchived && !(post.isLocked && !post.canModerate))
+					addAccessibilityActionFromDescriptionPair(
+						ActionDescriptionPair(
+							Action.REPLY,
+							R.string.action_reply
+						)
 					)
-				)
-			if (isOP && post.isSelf)
-				addAccessibilityActionFromDescriptionPair(
-					ActionDescriptionPair(
-						Action.EDIT,
-						R.string.action_edit
+				if (isOP && post.isSelf)
+					addAccessibilityActionFromDescriptionPair(
+						ActionDescriptionPair(
+							Action.EDIT,
+							R.string.action_edit
+						)
 					)
-				)
+			}
 		} else {
 			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.COMMENTS))
 		}
 
-		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.SAVE))
+		if (isAuthenticated)
+			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.SAVE))
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.USER_PROFILE))
 		if (isOP)
 			addAccessibilityActionFromDescriptionPair(
@@ -278,10 +281,13 @@ object RedditPostActions {
 					R.string.action_delete
 				)
 			)
-		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.REPORT))
+		if (isAuthenticated)
+			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.REPORT))
 		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.SHARE))
-		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.DOWNVOTE))
-		addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.UPVOTE))
+		if (isAuthenticated) {
+			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.DOWNVOTE))
+			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.UPVOTE))
+		}
 	}
 
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
@@ -222,7 +222,7 @@ object RedditPostActions {
 		accessibilityActionManager: AccessibilityActionManager,
 		post: RedditPreparedPost,
 		activity: BaseActivity,
-		showCommentsOption: Boolean
+		isOpen: Boolean
 	) {
 		fun addAccessibilityActionFromDescriptionPair(
 			pair: ActionDescriptionPair?
@@ -241,7 +241,17 @@ object RedditPostActions {
 
 		accessibilityActionManager.removeAllActions()
 
-		if (showCommentsOption) {
+		if (isOpen) {
+			// TODO: add an action here to jump focus from the body of the post to its comments.
+			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.GOTO_SUBREDDIT))
+			if (!post.isArchived && !(post.isLocked && !post.canModerate))
+				addAccessibilityActionFromDescriptionPair(
+					ActionDescriptionPair(
+						Action.REPLY,
+						R.string.action_reply
+					)
+				)
+		} else {
 			addAccessibilityActionFromDescriptionPair(from(post, PostFlingAction.COMMENTS))
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -458,7 +458,8 @@ public class RedditCommentView extends FlingableItemView
 
 	private void setupAccessibilityActions() {
 
-		final RedditAccount defaultAccount = RedditAccountManager.getInstance(mActivity).getDefaultAccount();
+		final RedditAccount defaultAccount
+				= RedditAccountManager.getInstance(mActivity).getDefaultAccount();
 		final boolean isAuthenticated = defaultAccount.isNotAnonymous();
 
 		mAccessibilityActionManager.removeAllActions();
@@ -468,58 +469,47 @@ public class RedditCommentView extends FlingableItemView
 		}
 
 		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.COLLAPSE)
-		);
-
-		if (isAuthenticated)
-			addAccessibilityActionFromDescriptionPair(
-				chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY)
-		);
-
-		if (
-			mComment.asComment()
-			.getParsedComment().getRawComment()
-			.author.equalsIgnoreCase(
-				defaultAccount.username
-			)
-		) {
-			addAccessibilityActionFromDescriptionPair(
-				new ActionDescriptionPair(
-					RedditAPICommentAction.RedditCommentAction.EDIT,
-					R.string.action_edit
-				)
-			);
-			addAccessibilityActionFromDescriptionPair(
-				new ActionDescriptionPair(
-					RedditAPICommentAction.RedditCommentAction.DELETE,
-					R.string.action_delete
-				)
-			);
-		}
-
-		// #136: When "save" is implemented for comments, add an a11y action here (behind an isAuthenticated guard).
-
-		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.USER_PROFILE)
-		);
-
-		if (isAuthenticated)
-			addAccessibilityActionFromDescriptionPair(
-				chooseFlingAction(PrefsUtility.CommentFlingAction.REPORT)
-			);
-
-		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.SHARE)
-		);
+			chooseFlingAction(PrefsUtility.CommentFlingAction.COLLAPSE));
 
 		if (isAuthenticated) {
 			addAccessibilityActionFromDescriptionPair(
-				chooseFlingAction(PrefsUtility.CommentFlingAction.DOWNVOTE)
-			);
+					chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY));
+		}
+
+		if (mComment.asComment().getParsedComment().getRawComment()
+				.author.equalsIgnoreCase(defaultAccount.username)) {
 
 			addAccessibilityActionFromDescriptionPair(
-				chooseFlingAction(PrefsUtility.CommentFlingAction.UPVOTE)
-			);
+				new ActionDescriptionPair(
+					RedditAPICommentAction.RedditCommentAction.EDIT,
+					R.string.action_edit));
+
+			addAccessibilityActionFromDescriptionPair(
+				new ActionDescriptionPair(
+					RedditAPICommentAction.RedditCommentAction.DELETE,
+					R.string.action_delete));
+		}
+
+		// #136: When "save" is implemented for comments, add an a11y action
+		// here (behind an isAuthenticated guard).
+
+		addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.USER_PROFILE));
+
+		if (isAuthenticated) {
+			addAccessibilityActionFromDescriptionPair(
+					chooseFlingAction(PrefsUtility.CommentFlingAction.REPORT));
+		}
+
+		addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.SHARE));
+
+		if (isAuthenticated) {
+			addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.DOWNVOTE));
+
+			addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.UPVOTE));
 		}
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -471,6 +471,27 @@ public class RedditCommentView extends FlingableItemView
 			chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY)
 		);
 
+		if (
+			mComment.asComment()
+			.getParsedComment().getRawComment()
+			.author.equalsIgnoreCase(
+				RedditAccountManager.getInstance(mActivity).getDefaultAccount().username
+			)
+		) {
+			addAccessibilityActionFromDescriptionPair(
+				new ActionDescriptionPair(
+					RedditAPICommentAction.RedditCommentAction.EDIT,
+					R.string.action_edit
+				)
+			);
+			addAccessibilityActionFromDescriptionPair(
+				new ActionDescriptionPair(
+					RedditAPICommentAction.RedditCommentAction.DELETE,
+					R.string.action_delete
+				)
+			);
+		}
+
 		// #136: When "save" is implemented for comments, add an a11y action here.
 
 		addAccessibilityActionFromDescriptionPair(

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.activities.BaseActivity;
 import org.quantumbadger.redreader.common.General;
@@ -457,6 +458,9 @@ public class RedditCommentView extends FlingableItemView
 
 	private void setupAccessibilityActions() {
 
+		final RedditAccount defaultAccount = RedditAccountManager.getInstance(mActivity).getDefaultAccount();
+		final boolean isAuthenticated = defaultAccount.isNotAnonymous();
+
 		mAccessibilityActionManager.removeAllActions();
 
 		if(!mComment.isComment()) {
@@ -467,15 +471,16 @@ public class RedditCommentView extends FlingableItemView
 			chooseFlingAction(PrefsUtility.CommentFlingAction.COLLAPSE)
 		);
 
-		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY)
+		if (isAuthenticated)
+			addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY)
 		);
 
 		if (
 			mComment.asComment()
 			.getParsedComment().getRawComment()
 			.author.equalsIgnoreCase(
-				RedditAccountManager.getInstance(mActivity).getDefaultAccount().username
+				defaultAccount.username
 			)
 		) {
 			addAccessibilityActionFromDescriptionPair(
@@ -492,28 +497,30 @@ public class RedditCommentView extends FlingableItemView
 			);
 		}
 
-		// #136: When "save" is implemented for comments, add an a11y action here.
+		// #136: When "save" is implemented for comments, add an a11y action here (behind an isAuthenticated guard).
 
 		addAccessibilityActionFromDescriptionPair(
 			chooseFlingAction(PrefsUtility.CommentFlingAction.USER_PROFILE)
 		);
 
-		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.REPORT)
-		);
+		if (isAuthenticated)
+			addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.REPORT)
+			);
 
 		addAccessibilityActionFromDescriptionPair(
 			chooseFlingAction(PrefsUtility.CommentFlingAction.SHARE)
 		);
 
-		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.DOWNVOTE)
-		);
+		if (isAuthenticated) {
+			addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.DOWNVOTE)
+			);
 
-		addAccessibilityActionFromDescriptionPair(
-			chooseFlingAction(PrefsUtility.CommentFlingAction.UPVOTE)
-		);
-
+			addAccessibilityActionFromDescriptionPair(
+				chooseFlingAction(PrefsUtility.CommentFlingAction.UPVOTE)
+			);
+		}
 	}
 
 	public RedditCommentListItem getComment() {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostHeaderView.java
@@ -61,7 +61,7 @@ public class RedditPostHeaderView extends LinearLayout {
 						activity.getResources()),
 				post,
 				activity,
-				false);
+				true);
 
 		greyHeader.setOrientation(LinearLayout.VERTICAL);
 

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -448,7 +448,7 @@ public final class RedditPostView extends FlingableItemView
 				mAccessibilityActionManager,
 				mPost,
 				mActivity,
-				true);
+				false);
 	}
 
 	@Override


### PR DESCRIPTION
This PR:

* Adds additional accessibility actions when viewing a post.
* Adds accessibility actions for editing and deleting posts and comments.
* Hides actions that require authentication from anonymous users.
* Attempts to fix actions from the self text view, but this isn't working (did I connect it to the wrong view?).

Checkstyle is failing and I'm not sure why (the output is now apparently in HTML and, while a file is referenced in the log, I can't find it).

Follow-up of #1045. Re #964.