### PR TITLE
Define accessibility hints to make click and long click actions more discoverable

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/views/AccessibilityActionManager.kt
+++ b/src/main/java/org/quantumbadger/redreader/views/AccessibilityActionManager.kt
@@ -21,6 +21,7 @@ import android.content.res.Resources
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 
 class AccessibilityActionManager(
 	private val view: View,
@@ -43,5 +44,24 @@ class AccessibilityActionManager(
 			ViewCompat.removeAccessibilityAction(view, it)
 		}
 		existingActions.clear()
+	}
+
+	fun setClickHint(@StringRes hint: Int) {
+		relabelAction(AccessibilityActionCompat.ACTION_CLICK, hint)
+	}
+
+	fun setLongClickHint(@StringRes hint: Int) {
+		relabelAction(AccessibilityActionCompat.ACTION_LONG_CLICK, hint)
+	}
+
+	private fun relabelAction(action: AccessibilityActionCompat, @StringRes label: Int) {
+		if (label == -1)
+			return
+		ViewCompat.replaceAccessibilityAction(
+			view,
+			action,
+			resources.getString(label),
+			null
+		)
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/views/AccessibilityActionManager.kt
+++ b/src/main/java/org/quantumbadger/redreader/views/AccessibilityActionManager.kt
@@ -46,22 +46,31 @@ class AccessibilityActionManager(
 		existingActions.clear()
 	}
 
-	fun setClickHint(@StringRes hint: Int) {
+	fun setClickHint(@StringRes hint: Int?) {
 		relabelAction(AccessibilityActionCompat.ACTION_CLICK, hint)
 	}
 
-	fun setLongClickHint(@StringRes hint: Int) {
+	fun setLongClickHint(@StringRes hint: Int?) {
 		relabelAction(AccessibilityActionCompat.ACTION_LONG_CLICK, hint)
 	}
 
-	private fun relabelAction(action: AccessibilityActionCompat, @StringRes label: Int) {
-		if (label == -1)
-			return
-		ViewCompat.replaceAccessibilityAction(
-			view,
-			action,
-			resources.getString(label),
-			null
-		)
+	private fun relabelAction(action: AccessibilityActionCompat, @StringRes label: Int?) {
+
+		if (label == null) {
+			ViewCompat.replaceAccessibilityAction(
+				view,
+				action,
+				null,
+				null
+			)
+		} else {
+			ViewCompat.replaceAccessibilityAction(
+				view,
+				action,
+				resources.getString(label),
+				null
+			)
+		}
+
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -511,6 +511,24 @@ public class RedditCommentView extends FlingableItemView
 			addAccessibilityActionFromDescriptionPair(
 				chooseFlingAction(PrefsUtility.CommentFlingAction.UPVOTE));
 		}
+
+		mAccessibilityActionManager.setClickHint(
+			getAccessibilityHintForActionPref(PrefsUtility.pref_behaviour_actions_comment_tap())
+		);
+
+		mAccessibilityActionManager.setLongClickHint(
+			getAccessibilityHintForActionPref(PrefsUtility.pref_behaviour_actions_comment_longclick())
+		);
+	}
+
+	private int getAccessibilityHintForActionPref(final PrefsUtility.CommentAction pref) {
+		switch (pref) {
+			case COLLAPSE:
+				return R.string.action_collapse;
+			case ACTION_MENU:
+				return R.string.action_actionmenu;
+		}
+	return -1;
 	}
 
 	public RedditCommentListItem getComment() {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -26,6 +26,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
@@ -522,14 +523,17 @@ public class RedditCommentView extends FlingableItemView
 		);
 	}
 
-	private int getAccessibilityHintForActionPref(final PrefsUtility.CommentAction pref) {
+	@Nullable
+	@StringRes
+	private Integer getAccessibilityHintForActionPref(
+			@NonNull final PrefsUtility.CommentAction pref) {
 		switch (pref) {
 			case COLLAPSE:
 				return R.string.action_collapse;
 			case ACTION_MENU:
 				return R.string.action_actionmenu;
 		}
-	return -1;
+		return null;
 	}
 
 	public RedditCommentListItem getComment() {

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -517,7 +517,8 @@ public class RedditCommentView extends FlingableItemView
 		);
 
 		mAccessibilityActionManager.setLongClickHint(
-			getAccessibilityHintForActionPref(PrefsUtility.pref_behaviour_actions_comment_longclick())
+			getAccessibilityHintForActionPref(
+					PrefsUtility.pref_behaviour_actions_comment_longclick())
 		);
 	}
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -220,7 +220,7 @@
     <string name="action_external">View in External Browser</string>
     <string name="action_external_short">In Browser</string>
     <string name="action_actionmenu_short">Actions</string>
-    <string name="action_actionmenu">Action Menu</string>
+    <string name="action_actionmenu">Open Action Menu</string>
     <string name="action_comment_links">Links in Comment</string>
     <string name="action_selftext_links">Links in Self Text</string>
     <string name="action_share">Share</string>


### PR DESCRIPTION
When I first started using RedReader, I didn't realize that you could double-tap comments to collapse them. This PR makes the configured click and long-click actions on comments more discoverable by overriding the TalkBack hint.