### PR TITLE
Add accessibility actions for jumping between level 1 comments

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -754,11 +754,13 @@ public class CommentListingFragment extends RRFragment
 
 	private void setFocusDelayed(final int pos) {
 		AndroidCommon.UI_THREAD_HANDLER.postDelayed(() -> {
-			RecyclerView.ViewHolder view = mRecyclerView.findViewHolderForAdapterPosition(pos);
+			final RecyclerView.ViewHolder view
+					= mRecyclerView.findViewHolderForAdapterPosition(pos);
 			if (view != null) {
-				view.itemView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
-				view.itemView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_SELECTED);
-				view.itemView.performAccessibilityAction(
+				final View item = view.itemView;
+				item.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+				item.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_SELECTED);
+				item.performAccessibilityAction(
 						AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS,
 						null);
 			}

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -26,6 +26,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.animation.OvershootInterpolator;
@@ -48,6 +50,7 @@ import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategy;
 import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyAlways;
 import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyIfNotCached;
 import org.quantumbadger.redreader.cache.downloadstrategy.DownloadStrategyIfTimestampOutsideBounds;
+import org.quantumbadger.redreader.common.AndroidCommon;
 import org.quantumbadger.redreader.common.General;
 import org.quantumbadger.redreader.common.PrefsUtility;
 import org.quantumbadger.redreader.common.RRError;
@@ -245,7 +248,7 @@ public class CommentListingFragment extends RRFragment
 				mFloatingToolbar.addView(nextButton);
 
 				nextButton.setOnClickListener(view -> {
-					onNextParent(); 
+					onNextParent();
 				});
 
 				nextButton.setOnLongClickListener(view -> {
@@ -717,11 +720,13 @@ public class CommentListingFragment extends RRFragment
 				&& ((RedditCommentListItem)item).getIndent() == 0
 			) {
 				layoutManager.scrollToPositionWithOffset(pos, 0);
+				setFocusDelayed(pos);
 				return;
 			}
 		}
 
 		layoutManager.scrollToPositionWithOffset(0, 0);
+		setFocusDelayed(0);
 	}
 
 	public void onNextParent() {
@@ -741,8 +746,22 @@ public class CommentListingFragment extends RRFragment
 				&& ((RedditCommentListItem)item).getIndent() == 0
 			) {
 				layoutManager.scrollToPositionWithOffset(pos, 0);
+				setFocusDelayed(pos);
 				break;
 			}
 		}
+	}
+
+	private void setFocusDelayed(final int pos) {
+		AndroidCommon.UI_THREAD_HANDLER.postDelayed(() -> {
+			RecyclerView.ViewHolder view = mRecyclerView.findViewHolderForAdapterPosition(pos);
+			if (view != null) {
+				view.itemView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+				view.itemView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_SELECTED);
+				view.itemView.performAccessibilityAction(
+						AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS,
+						null);
+			}
+		}, 500);
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/CommentListingFragment.java
@@ -219,27 +219,7 @@ public class CommentListingFragment extends RRFragment
 				mFloatingToolbar.addView(previousButton);
 
 				previousButton.setOnClickListener(view -> {
-
-					final LinearLayoutManager layoutManager
-							= (LinearLayoutManager)mRecyclerView.getLayoutManager();
-
-					for(int pos = layoutManager.findFirstVisibleItemPosition() - 1;
-						pos > 0;
-						pos--) {
-
-						final GroupedRecyclerViewAdapter.Item item
-								= mCommentListingManager.getItemAtPosition(pos);
-
-						if(item instanceof RedditCommentListItem
-								&& ((RedditCommentListItem)item).isComment()
-								&& ((RedditCommentListItem)item).getIndent() == 0) {
-
-							layoutManager.scrollToPositionWithOffset(pos, 0);
-							return;
-						}
-					}
-
-					layoutManager.scrollToPositionWithOffset(0, 0);
+					onPreviousParent();
 				});
 
 				previousButton.setOnLongClickListener(view -> {
@@ -265,25 +245,7 @@ public class CommentListingFragment extends RRFragment
 				mFloatingToolbar.addView(nextButton);
 
 				nextButton.setOnClickListener(view -> {
-
-					final LinearLayoutManager layoutManager
-							= (LinearLayoutManager)mRecyclerView.getLayoutManager();
-
-					for(int pos = layoutManager.findFirstVisibleItemPosition() + 1;
-						pos < layoutManager.getItemCount();
-						pos++) {
-
-						final GroupedRecyclerViewAdapter.Item item
-								= mCommentListingManager.getItemAtPosition(pos);
-
-						if(item instanceof RedditCommentListItem
-								&& ((RedditCommentListItem)item).isComment()
-								&& ((RedditCommentListItem)item).getIndent() == 0) {
-
-							layoutManager.scrollToPositionWithOffset(pos, 0);
-							break;
-						}
-					}
+					onNextParent(); 
 				});
 
 				nextButton.setOnLongClickListener(view -> {
@@ -735,5 +697,52 @@ public class CommentListingFragment extends RRFragment
 	@Override
 	public void onPostCommentsSelected(final RedditPreparedPost post) {
 		((RedditPostView.PostSelectionListener)getActivity()).onPostCommentsSelected(post);
+	}
+
+	public void onPreviousParent() {
+		final LinearLayoutManager layoutManager = (LinearLayoutManager)
+			mRecyclerView.getLayoutManager();
+
+		for(
+			int pos = layoutManager.findFirstVisibleItemPosition() - 1;
+			pos > 0;
+			pos--
+		) {
+			final GroupedRecyclerViewAdapter.Item item = mCommentListingManager.getItemAtPosition(
+				pos
+			);
+			if(
+				item instanceof RedditCommentListItem
+				&& ((RedditCommentListItem)item).isComment()
+				&& ((RedditCommentListItem)item).getIndent() == 0
+			) {
+				layoutManager.scrollToPositionWithOffset(pos, 0);
+				return;
+			}
+		}
+
+		layoutManager.scrollToPositionWithOffset(0, 0);
+	}
+
+	public void onNextParent() {
+		final LinearLayoutManager layoutManager = (LinearLayoutManager)
+			mRecyclerView.getLayoutManager();
+		for(
+			int pos = layoutManager.findFirstVisibleItemPosition() + 1;
+			pos < layoutManager.getItemCount();
+			pos++
+		) {
+			final GroupedRecyclerViewAdapter.Item item = mCommentListingManager.getItemAtPosition(
+				pos
+			);
+			if(
+				item instanceof RedditCommentListItem
+				&& ((RedditCommentListItem)item).isComment()
+				&& ((RedditCommentListItem)item).getIndent() == 0
+			) {
+				layoutManager.scrollToPositionWithOffset(pos, 0);
+				break;
+			}
+		}
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditCommentView.java
@@ -475,6 +475,14 @@ public class RedditCommentView extends FlingableItemView
 		addAccessibilityActionFromDescriptionPair(
 			chooseFlingAction(PrefsUtility.CommentFlingAction.COLLAPSE));
 
+		mAccessibilityActionManager.addAction(R.string.button_next_comment_parent, () -> {
+			mFragment.onNextParent();
+		});
+
+		mAccessibilityActionManager.addAction(R.string.button_prev_comment_parent, () -> {
+			mFragment.onPreviousParent();
+		});
+
 		if (isAuthenticated) {
 			addAccessibilityActionFromDescriptionPair(
 					chooseFlingAction(PrefsUtility.CommentFlingAction.REPLY));


### PR DESCRIPTION
This PR adds actions for jumping among level 1 comments, using the existing `previousButton`/`nextButton` logic. While it isn't quite my vision (collapsing the nearest l1), this will significantly ease navigation when it works properly.

While this does jump among l1s, focus is set extremely unreliably. @QuantumBadger might you be able to look into why?

Closes #964.