### PR TITLE
Show self-text of link posts, annouce self-text presence with link posts in TalkBack

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
@@ -730,8 +730,7 @@ object RedditPostActions {
 			menu.add(RPVMenuItem(activity, R.string.action_external, Action.EXTERNAL))
 		}
 		if (itemPref.contains(Action.SELFTEXT_LINKS)
-				&& post.src.rawSelfTextMarkdown != null
-				&& post.src.rawSelfTextMarkdown.length > 1) {
+				&& post.src.hasSelfText()) {
 			menu.add(RPVMenuItem(activity, R.string.action_selftext_links, Action.SELFTEXT_LINKS))
 		}
 		if (itemPref.contains(Action.SAVE_IMAGE) && post.mIsProbablyAnImage) {
@@ -853,7 +852,7 @@ object RedditPostActions {
 		if (itemPref.contains(Action.COPY)) {
 			menu.add(RPVMenuItem(activity, R.string.action_copy_link, Action.COPY))
 		}
-		if (itemPref.contains(Action.COPY_SELFTEXT) && post.src.rawSelfTextMarkdown != null && post.src.rawSelfTextMarkdown.length > 1) {
+		if (itemPref.contains(Action.COPY_SELFTEXT) && post.src.hasSelfText()) {
 			menu.add(
 				RPVMenuItem(
 					activity,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
@@ -145,6 +145,10 @@ class RedditParsedPost(
         return src.idAndType
     }
 
+	fun hasSelfText(): Boolean {
+		return rawSelfTextMarkdown != null && rawSelfTextMarkdown.length > 1
+	}
+
     data class ImagePreviewDetails(
 		@JvmField val url: String,
 		@JvmField val width: Int,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
@@ -122,7 +122,7 @@ class RedditParsedPost(
 
 		url = findUrl()
 
-		selfText = if (parseSelfText && isSelfPost && src.selftext_html != null) {
+		selfText = if (parseSelfText && src.selftext_html != null) {
 			HtmlReader.parse(src.selftext_html.decoded, activity)
 		} else {
 			null

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -530,6 +530,17 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 										: R.string.accessibility_subtitle_domain_withperiod,
 								ScreenreaderPronunciation.getPronunciation(context, domain)))
 						.append(separator);
+
+				if(src.hasSelfText()) {
+					accessibilitySubtitle
+							.append(context.getString(
+									conciseMode
+											?R.string.
+											accessibility_subtitle_selfpost_withperiod_concise
+											: R.string.
+											accessibility_subtitle_has_selftext_withperiod))
+							.append(separator);
+				}
 			}
 		}
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1755,4 +1755,7 @@
 	<string name="reddit_relogin_error_title">Re-login necessary</string>
 	<string name="reddit_relogin_error_message">Due to recent changes to the Reddit API, it is necessary to log in to your account again.</string>
 
+	<!-- 2023-07-05 -->
+	<string name="accessibility_subtitle_has_selftext_withperiod">Has self text.</string>
+
 </resources>


### PR DESCRIPTION
Hello! It has been awhile since I've contributed here due to personal reasons. With recent events, I've decided to return and work on RedReader once again. It's good to be back.

This shows the self-text of link posts when you open them, and also announces the presence of self-text in TalkBack if the domain information should be read. I reused the concise string for self-posts here, since it seemed suitable, but feel free to offer suggestions there.

This PR does *not* add any visual indicator on posts in listings that there is self-text. I figured that would make more sense to tackle, along with other types of posts, if working on an issue like #732.

Closes #1028, closes #1071.