### PR TITLE
Handle Reddit galleries with links, and show thumbnails for small images in Reddit galleries

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
@@ -128,6 +128,10 @@ public class AlbumAdapter extends RecyclerView.Adapter<VH3TextIcon> {
 			vh.text3.setVisibility(View.GONE);
 		}
 
+		if(imageInfo.outboundUrl != null && !imageInfo.outboundUrl.isEmpty()) {
+			vh.addLinkButton(activity, imageInfo.outboundUrl);
+		}
+
 		vh.icon.setImageBitmap(null);
 
 		final boolean isConnectionWifi = General.isConnectionWifi(activity);

--- a/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
@@ -128,6 +128,8 @@ public class AlbumAdapter extends RecyclerView.Adapter<VH3TextIcon> {
 			vh.text3.setVisibility(View.GONE);
 		}
 
+		vh.removeExtras();
+
 		if(imageInfo.outboundUrl != null && !imageInfo.outboundUrl.isEmpty()) {
 			vh.addLinkButton(activity, imageInfo.outboundUrl);
 		}

--- a/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/AlbumAdapter.java
@@ -144,14 +144,18 @@ public class AlbumAdapter extends RecyclerView.Adapter<VH3TextIcon> {
 				|| (thumbnailsPref == NeverAlwaysOrWifiOnly.WIFIONLY
 						&& isConnectionWifi);
 
-		if(!downloadThumbnails || imageInfo.urlBigSquare == null) {
+		if(!downloadThumbnails
+				|| (imageInfo.urlBigSquare == null && imageInfo.urlOriginal == null)) {
 			vh.icon.setVisibility(View.GONE);
 
 		} else {
 			vh.text2.setVisibility(View.VISIBLE);
 
 			CacheManager.getInstance(activity).makeRequest(new CacheRequest(
-					General.uriFromString(imageInfo.urlBigSquare),
+					General.uriFromString(
+							imageInfo.urlBigSquare != null
+									? imageInfo.urlBigSquare
+									: imageInfo.urlOriginal),
 					RedditAccountManager.getAnon(),
 					null,
 					new Priority(Constants.Priority.THUMBNAIL, position),

--- a/src/main/java/org/quantumbadger/redreader/image/AlbumInfo.java
+++ b/src/main/java/org/quantumbadger/redreader/image/AlbumInfo.java
@@ -172,8 +172,6 @@ public class AlbumInfo {
 			@Nullable final String caption
 					= StringEscapeUtils.unescapeHtml4(item.getString("caption"));
 
-			// TODO show this in the UI
-			@SuppressWarnings("unused")
 			@Nullable final String outboundUrl
 					= StringEscapeUtils.unescapeHtml4(item.getString("outbound_url"));
 
@@ -202,6 +200,7 @@ public class AlbumInfo {
 					getThumbnail(mediaMetadataEntry.getArray("p")),
 					caption,
 					null,
+					outboundUrl,
 					mimetype,
 					mediaType != ImageInfo.MediaType.IMAGE,
 					standardImage.getLong("x"),

--- a/src/main/java/org/quantumbadger/redreader/image/ImageInfo.java
+++ b/src/main/java/org/quantumbadger/redreader/image/ImageInfo.java
@@ -38,6 +38,8 @@ public class ImageInfo implements Parcelable {
 	public final String title;
 	public final String caption;
 
+	public final String outboundUrl;
+
 	public final String type;
 	public final Boolean isAnimated;
 
@@ -92,6 +94,7 @@ public class ImageInfo implements Parcelable {
 		urlBigSquare = null;
 		title = null;
 		caption = null;
+		outboundUrl = null;
 		type = null;
 		isAnimated = null;
 		width = null;
@@ -110,6 +113,7 @@ public class ImageInfo implements Parcelable {
 		urlAudioStream = ParcelHelper.readNullableString(in);
 		title = ParcelHelper.readNullableString(in);
 		caption = ParcelHelper.readNullableString(in);
+		outboundUrl = ParcelHelper.readNullableString(in);
 		type = ParcelHelper.readNullableString(in);
 		isAnimated = ParcelHelper.readNullableBoolean(in);
 		width = ParcelHelper.readNullableLong(in);
@@ -127,6 +131,7 @@ public class ImageInfo implements Parcelable {
 			final String urlBigSquare,
 			final String title,
 			final String caption,
+			final String outboundUrl,
 			final String type,
 			final Boolean isAnimated,
 			final Long width,
@@ -143,6 +148,7 @@ public class ImageInfo implements Parcelable {
 		this.urlAudioStream = null;
 		this.title = title;
 		this.caption = caption;
+		this.outboundUrl = outboundUrl;
 		this.type = type;
 		this.isAnimated = isAnimated;
 		this.width = width;
@@ -189,6 +195,7 @@ public class ImageInfo implements Parcelable {
 				urlOriginal,
 				null,
 				title,
+				null,
 				null,
 				"video/mp4",
 				true,
@@ -241,6 +248,7 @@ public class ImageInfo implements Parcelable {
 
 		return new ImageInfo(
 				urlOriginal,
+				null,
 				null,
 				null,
 				null,
@@ -303,6 +311,7 @@ public class ImageInfo implements Parcelable {
 				urlBigSquare,
 				title,
 				caption,
+				null,
 				type,
 				isAnimated,
 				width,
@@ -368,6 +377,7 @@ public class ImageInfo implements Parcelable {
 				thumbnailUrl,
 				title,
 				caption,
+				null,
 				type,
 				isAnimated,
 				width,
@@ -415,6 +425,7 @@ public class ImageInfo implements Parcelable {
 				thumbnailUrl,
 				title,
 				tags,
+				null,
 				type,
 				false,
 				width,
@@ -445,6 +456,7 @@ public class ImageInfo implements Parcelable {
 				null,
 				null,
 				null,
+				null,
 				"video/mp4",
 				true,
 				width,
@@ -470,6 +482,7 @@ public class ImageInfo implements Parcelable {
 		ParcelHelper.writeNullableString(parcel, urlAudioStream);
 		ParcelHelper.writeNullableString(parcel, title);
 		ParcelHelper.writeNullableString(parcel, caption);
+		ParcelHelper.writeNullableString(parcel, outboundUrl);
 		ParcelHelper.writeNullableString(parcel, type);
 		ParcelHelper.writeNullableBoolean(parcel, isAnimated);
 		ParcelHelper.writeNullableLong(parcel, width);

--- a/src/main/java/org/quantumbadger/redreader/reddit/kthings/RedditPost.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/kthings/RedditPost.kt
@@ -29,6 +29,7 @@ data class RedditPost(
 	val id: String,
 	val name: RedditIdAndType,
 	val url: UrlEncodedString? = null,
+	val url_overridden_by_dest: UrlEncodedString? = null,
 	val title: UrlEncodedString? = null,
 	val author: UrlEncodedString? = null,
 	val domain: UrlEncodedString? = null,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
@@ -105,6 +105,10 @@ class RedditParsedPost(
 
 	private fun findUrl(): String? {
 
+		src.url_overridden_by_dest?.decoded?.apply {
+			return this
+		}
+
 		src.media?.reddit_video?.fallback_url?.decoded?.apply {
 			return this
 		}

--- a/src/main/java/org/quantumbadger/redreader/viewholders/VH3TextIcon.java
+++ b/src/main/java/org/quantumbadger/redreader/viewholders/VH3TextIcon.java
@@ -20,13 +20,20 @@ package org.quantumbadger.redreader.viewholders;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import org.quantumbadger.redreader.R;
+import org.quantumbadger.redreader.activities.BaseActivity;
+import org.quantumbadger.redreader.common.RRThemeAttributes;
+import org.quantumbadger.redreader.reddit.prepared.bodytext.BodyElementLinkButton;
+import org.quantumbadger.redreader.reddit.prepared.html.HtmlRawElement;
 
 /**
- * A view holder for a two line, text and icon list item.
+ * A view holder for a three line, text and icon list item, which can have link buttons.
  */
 public class VH3TextIcon extends RecyclerView.ViewHolder {
+
+	public final LinearLayout textHoldingLayout;
 
 	public final TextView text;
 	public final TextView text2;
@@ -38,9 +45,25 @@ public class VH3TextIcon extends RecyclerView.ViewHolder {
 	public VH3TextIcon(final View itemView) {
 		super(itemView);
 
+		textHoldingLayout = itemView.findViewById(R.id.recycler_text_layout);
+
 		text = itemView.findViewById(R.id.recycler_item_text);
 		text2 = itemView.findViewById(R.id.recycler_item_2_text);
 		text3 = itemView.findViewById(R.id.recycler_item_3_text);
 		icon = itemView.findViewById(R.id.recycler_item_icon);
+	}
+
+	public void addLinkButton(final BaseActivity activity, final String url) {
+		final BodyElementLinkButton linkButton
+				= new BodyElementLinkButton(new HtmlRawElement.LinkButtonDetails(url, url));
+
+		final View linkButtonView =
+				linkButton.generateView(
+						activity,
+						new RRThemeAttributes(activity.getApplicationContext()).rrCommentBodyCol,
+						13.0f,
+						true);
+
+		textHoldingLayout.addView(linkButtonView);
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/viewholders/VH3TextIcon.java
+++ b/src/main/java/org/quantumbadger/redreader/viewholders/VH3TextIcon.java
@@ -17,6 +17,7 @@
 
 package org.quantumbadger.redreader.viewholders;
 
+import androidx.appcompat.widget.LinearLayoutCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
@@ -39,6 +40,7 @@ public class VH3TextIcon extends RecyclerView.ViewHolder {
 	public final TextView text2;
 	public final TextView text3;
 	public final ImageView icon;
+	public final LinearLayoutCompat extra;
 
 	public long bindingId = 0;
 
@@ -51,6 +53,11 @@ public class VH3TextIcon extends RecyclerView.ViewHolder {
 		text2 = itemView.findViewById(R.id.recycler_item_2_text);
 		text3 = itemView.findViewById(R.id.recycler_item_3_text);
 		icon = itemView.findViewById(R.id.recycler_item_icon);
+		extra = itemView.findViewById(R.id.recycler_item_extra);
+	}
+
+	public void removeExtras() {
+		extra.removeAllViews();
 	}
 
 	public void addLinkButton(final BaseActivity activity, final String url) {
@@ -64,6 +71,6 @@ public class VH3TextIcon extends RecyclerView.ViewHolder {
 						13.0f,
 						true);
 
-		textHoldingLayout.addView(linkButtonView);
+		extra.addView(linkButtonView);
 	}
 }

--- a/src/main/res/layout/list_item_3_text_icon.xml
+++ b/src/main/res/layout/list_item_3_text_icon.xml
@@ -54,5 +54,11 @@
 			android:textColor="?android:textColorPrimary"
 			android:textSize="12sp"/>
 
+		<androidx.appcompat.widget.LinearLayoutCompat
+				android:id="@+id/recycler_item_extra"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:paddingTop="4dp"/>
+
 	</LinearLayout>
 </LinearLayout>

--- a/src/main/res/layout/list_item_3_text_icon.xml
+++ b/src/main/res/layout/list_item_3_text_icon.xml
@@ -18,6 +18,7 @@
 			tools:ignore="ContentDescription"/>
 
 	<LinearLayout
+			android:id="@+id/recycler_text_layout"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:layout_gravity="center_vertical"


### PR DESCRIPTION
This PR has three small improvements for galleries.

First, Reddit galleries containing links can now be opened, which was not working because Reddit put the first outbound link in the gallery as the `url`. I fixed this by using `url_overridden_by_dest` instead if it's present, which does not seem to effect anything else. (#1061)

Second, links in Reddit galleries can now be seen and used, in the form of link buttons (regardless of if they are enabled for comments). I experimented with also having the link present alongside the image's title, dimensions, size, and caption, but the buttons seem sufficient to me. I considered an option to disable the link buttons here, but Reddit galleries with links seem to be relatively rare, so I doubt it's necessary.

Third, thumbnails for small images in Reddit galleries are now shown by downloading the original image. They were not displaying before, because Reddit does not seem to generate gallery thumbnails for images smaller than 108x108.

Closes #1061.