### PR TITLE
Fix navbar color preference title

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -828,7 +828,7 @@
 
 	<!-- 2016-07-29 -->
 	<string name="pref_appearance_navbar_color_key" translatable="false">pref_appearance_navbar_color</string>
-	<string name="pref_appearance_navbar_color_title">Navigation and status bar colour</string>
+	<string name="pref_appearance_navbar_color_title">Navigation bar colour</string>
 
 	<string name="pref_appearance_navbar_color_option_black">Black</string>
 	<string name="pref_appearance_navbar_color_option_primary">Primary (light)</string>


### PR DESCRIPTION
The title of the navbar color preference falsely states that it also controls the status bar color, despite the fact that it does not and never has. For reasons unknown I changed the string to say this in #710.

If it's desired, I could instead make the preference actually control both bars, or add a separate preference for the status bar, although I don't think there is very much demand for that.