### PR TITLE
Extend tappable title area when "Post title opens comments" is enabled

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -1,5 +1,6 @@
 /Alpha 339 (2023-09-03)
 Hide keyboard in Find Location when search button is pressed (thanks to mattdbr)
+Fix issue with "Post title opens comments" not covering whole post area (thanks to Domenico Sibilio)
 
 /Alpha 338 (2023-07-28)
 Fix for permission denied errors on videos due to Reddit API change

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -1,5 +1,6 @@
 109/1.23
 Hide keyboard in Find Location when search button is pressed (thanks to mattdbr)
+Fix issue with "Post title opens comments" not covering whole post area (thanks to Domenico Sibilio)
 
 108/1.22
 Fix for permission denied errors on videos due to Reddit API change

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -236,7 +236,13 @@ public final class RedditPostView extends FlingableItemView
 		mImagePreviewLoadingSpinner = new LoadingSpinnerView(activity);
 		mImagePreviewHolder.addView(mImagePreviewLoadingSpinner);
 
-		mOuterView.setOnClickListener(v -> fragmentParent.onPostSelected(mPost));
+		final boolean postTitleOpensPost = PrefsUtility.pref_behaviour_post_title_opens_comments();
+
+		if(postTitleOpensPost) {
+			mOuterView.setOnClickListener(v -> fragmentParent.onPostCommentsSelected(mPost));
+		} else {
+			mOuterView.setOnClickListener(v -> fragmentParent.onPostSelected(mPost));
+		}
 
 		mOuterView.setOnLongClickListener(v -> {
 			RedditPostActions.INSTANCE.showActionMenu(mActivity, mPost);
@@ -285,14 +291,6 @@ public final class RedditPostView extends FlingableItemView
 
 		if(mCommentsButtonPref) {
 			mCommentsButton.setOnClickListener(v -> fragmentParent.onPostCommentsSelected(mPost));
-		}
-
-		final boolean postTitleOpensPost = PrefsUtility.pref_behaviour_post_title_opens_comments();
-
-		if(postTitleOpensPost) {
-			final LinearLayout textLayout = Objects.requireNonNull(
-					rootView.findViewById(R.id.reddit_post_textLayout));
-			textLayout.setOnClickListener(v -> fragmentParent.onPostCommentsSelected(mPost));
 		}
 
 		title.setTextSize(

--- a/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/RedditPostView.java
@@ -290,7 +290,9 @@ public final class RedditPostView extends FlingableItemView
 		final boolean postTitleOpensPost = PrefsUtility.pref_behaviour_post_title_opens_comments();
 
 		if(postTitleOpensPost) {
-			title.setOnClickListener(v -> fragmentParent.onPostCommentsSelected(mPost));
+			final LinearLayout textLayout = Objects.requireNonNull(
+					rootView.findViewById(R.id.reddit_post_textLayout));
+			textLayout.setOnClickListener(v -> fragmentParent.onPostCommentsSelected(mPost));
 		}
 
 		title.setTextSize(


### PR DESCRIPTION
@QuantumBadger as per https://github.com/QuantumBadger/RedReader/issues/1085#issuecomment-1641031432, thanks for the heads up!

I tested this manually on Android 12 and it seems to behave as expected👍