### PR TITLE
Add support for opaque shared URLs, fixes #1122

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -46,6 +46,7 @@ import org.quantumbadger.redreader.activities.WebViewActivity;
 import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.fragments.ShareOrderDialog;
 import org.quantumbadger.redreader.fragments.UserProfileDialog;
+import org.quantumbadger.redreader.http.HTTPBackend;
 import org.quantumbadger.redreader.image.AlbumInfo;
 import org.quantumbadger.redreader.image.DeviantArtAPI;
 import org.quantumbadger.redreader.image.GetAlbumInfoListener;
@@ -230,9 +231,11 @@ public class LinkHandler {
 				case RedditURLParser.OPAQUE_SHARED_URL:
 					// kick off a thread to get the real url
 					new Thread(() -> {
-						final String realUrl = OpaqueSharedURL.resolveUsingNetwork(
+						final String toFetchUrl = OpaqueSharedURL.getUrlToFetch(
 								(OpaqueSharedURL) redditURL
-						);
+						).toString();
+						final String realUrl = HTTPBackend.getBackend()
+								.resolveRedirectUri(toFetchUrl);
 						if(realUrl != null) {
 							activity.runOnUiThread(() -> onLinkClicked(
 									activity,

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -230,7 +230,9 @@ public class LinkHandler {
 				case RedditURLParser.OPAQUE_SHARED_URL:
 					// kick off a thread to get the real url
 					new Thread(() -> {
-						final String realUrl = OpaqueSharedURL.resolveUsingNetwork((OpaqueSharedURL) redditURL);
+						final String realUrl = OpaqueSharedURL.resolveUsingNetwork(
+								(OpaqueSharedURL) redditURL
+						);
 						if(realUrl != null) {
 							activity.runOnUiThread(() -> onLinkClicked(
 									activity,

--- a/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/LinkHandler.java
@@ -62,6 +62,7 @@ import org.quantumbadger.redreader.image.StreamableAPI;
 import org.quantumbadger.redreader.reddit.kthings.RedditPost;
 import org.quantumbadger.redreader.reddit.url.ComposeMessageURL;
 import org.quantumbadger.redreader.reddit.url.PostCommentListingURL;
+import org.quantumbadger.redreader.reddit.url.OpaqueSharedURL;
 import org.quantumbadger.redreader.reddit.url.RedditURLParser;
 
 import java.util.ArrayList;
@@ -226,7 +227,22 @@ public class LinkHandler {
 		if(redditURL != null) {
 
 			switch(redditURL.pathType()) {
-
+				case RedditURLParser.OPAQUE_SHARED_URL:
+					// kick off a thread to get the real url
+					new Thread(() -> {
+						final String realUrl = OpaqueSharedURL.resolveUsingNetwork((OpaqueSharedURL) redditURL);
+						if(realUrl != null) {
+							activity.runOnUiThread(() -> onLinkClicked(
+									activity,
+									realUrl,
+									forceNoImage,
+									post,
+									albumInfo,
+									albumImageIndex,
+									fromExternalIntent));
+						}
+					}).start();
+					return;
 				case RedditURLParser.SUBREDDIT_POST_LISTING_URL:
 				case RedditURLParser.MULTIREDDIT_POST_LISTING_URL:
 				case RedditURLParser.USER_POST_LISTING_URL:

--- a/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/PostListingFragment.java
@@ -376,6 +376,7 @@ public class PostListingFragment extends RRFragment
 			case RedditURLParser.USER_COMMENT_LISTING_URL:
 			case RedditURLParser.USER_PROFILE_URL:
 			case RedditURLParser.COMPOSE_MESSAGE_URL:
+			case RedditURLParser.OPAQUE_SHARED_URL:
 				BugReportActivity.handleGlobalError(getActivity(), new RuntimeException(
 						"Unknown url type "
 								+ mPostListingURL.pathType()

--- a/src/main/java/org/quantumbadger/redreader/http/HTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/HTTPBackend.java
@@ -18,8 +18,10 @@
 package org.quantumbadger.redreader.http;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import org.quantumbadger.redreader.cache.CacheRequest;
 import org.quantumbadger.redreader.common.Optional;
 import org.quantumbadger.redreader.http.body.HTTPRequestBody;
@@ -86,6 +88,8 @@ public abstract class HTTPBackend {
 
 		void onSuccess(String mimetype, Long bodyBytes, InputStream body);
 	}
+
+	public abstract @Nullable String resolveRedirectUri(String url);
 
 	public abstract Request prepareRequest(Context context, RequestDetails details);
 

--- a/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
+++ b/src/main/java/org/quantumbadger/redreader/http/okhttp/OKHTTPBackend.java
@@ -168,6 +168,11 @@ public class OKHTTPBackend extends HTTPBackend {
 		return httpBackend;
 	}
 
+	@Deprecated
+	public OkHttpClient getClientDirectly() {
+		return mClient;
+	}
+
 	@Override
 	public synchronized void recreateHttpBackend() {
 		httpBackend = new OKHTTPBackend();

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
@@ -17,20 +17,14 @@
 
 package org.quantumbadger.redreader.reddit.url;
 
-import android.content.Context;
 import android.net.Uri;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.quantumbadger.redreader.common.Optional;
-import org.quantumbadger.redreader.http.FailedRequestBody;
 import org.quantumbadger.redreader.http.HTTPBackend;
 import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
 import java.util.List;
 
 import okhttp3.OkHttpClient;

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of RedReader.
+ *
+ * RedReader is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RedReader is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RedReader.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.quantumbadger.redreader.reddit.url;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.quantumbadger.redreader.common.Optional;
+import org.quantumbadger.redreader.http.FailedRequestBody;
+import org.quantumbadger.redreader.http.HTTPBackend;
+import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+public class OpaqueSharedURL extends RedditURLParser.RedditURL {
+
+	@Nullable
+	public final String subreddit;
+	@Nullable public final String shareKey;
+
+	public OpaqueSharedURL(@Nullable String subreddit, @Nullable String shareKey) {
+		this.subreddit = subreddit;
+		this.shareKey = shareKey;
+	}
+
+	@Override
+	public Uri generateJsonUri() {
+		return null;
+	}
+
+	@Override
+	public int pathType() {
+		return RedditURLParser.OPAQUE_SHARED_URL;
+	}
+
+	public static OpaqueSharedURL parse(final Uri uri) {
+		// URLs look like https://reddit.com/r/RedReader/s/<alphanumeric>
+		// first pull out the path segments and ensure they match the example (should be 4)
+		List<String> pathSegments = uri.getPathSegments();
+		if (pathSegments.size() != 4) {
+			return null;
+		}
+
+		// ensure the first segment is "r" and the third is "s"
+		if (!pathSegments.get(0).equals("r") || !pathSegments.get(2).equals("s")) {
+			return null;
+		}
+
+		return new OpaqueSharedURL(pathSegments.get(1), pathSegments.get(3));
+	}
+
+	public static String resolveUsingNetwork(final OpaqueSharedURL url) {
+		Uri toFetch = Uri.parse(String.format("https://www.reddit.com/r/%s/s/%s", url.subreddit, url.shareKey));
+		// Send a HTTP HEAD request to toFetch, and return back the Location header
+		// This will be the URL of the post
+		OkHttpClient client = ((OKHTTPBackend) HTTPBackend.getBackend()).getClientDirectly();
+		client = client.newBuilder().followRedirects(false).build();
+		Request request = new Request.Builder().url(toFetch.toString()).head().build();
+		try {
+			try (okhttp3.Response response = client.newCall(request).execute()) {
+				if (response.isRedirect()) {
+					return response.header("Location");
+				}
+			}
+		} catch (IOException e) {
+			return null;
+		}
+		return null;
+	}
+
+	@Nullable
+	public String getSubreddit() {
+		return subreddit;
+	}
+
+	@Nullable
+	public String getShareKey() {
+		return shareKey;
+	}
+}

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
@@ -21,14 +21,7 @@ import android.net.Uri;
 
 import androidx.annotation.Nullable;
 
-import org.quantumbadger.redreader.http.HTTPBackend;
-import org.quantumbadger.redreader.http.okhttp.OKHTTPBackend;
-
-import java.io.IOException;
 import java.util.List;
-
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
 
 public class OpaqueSharedURL extends RedditURLParser.RedditURL {
 
@@ -67,23 +60,8 @@ public class OpaqueSharedURL extends RedditURLParser.RedditURL {
 		return new OpaqueSharedURL(pathSegments.get(1), pathSegments.get(3));
 	}
 
-	public static String resolveUsingNetwork(final OpaqueSharedURL url) {
-		final Uri toFetch = Uri.parse(String.format("https://www.reddit.com/r/%s/s/%s", url.subreddit, url.shareKey));
-		// Send a HTTP HEAD request to toFetch, and return back the Location header
-		// This will be the URL of the post
-		OkHttpClient client = ((OKHTTPBackend) HTTPBackend.getBackend()).getClientDirectly();
-		client = client.newBuilder().followRedirects(false).build();
-		final Request request = new Request.Builder().url(toFetch.toString()).head().build();
-		try {
-			try (okhttp3.Response response = client.newCall(request).execute()) {
-				if (response.isRedirect()) {
-					return response.header("Location");
-				}
-			}
-		} catch (final IOException e) {
-			return null;
-		}
-		return null;
+	public static Uri getUrlToFetch(final OpaqueSharedURL url) {
+		return Uri.parse(String.format("https://www.reddit.com/r/%s/s/%s", url.subreddit, url.shareKey));
 	}
 
 	@Nullable

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/OpaqueSharedURL.java
@@ -42,7 +42,7 @@ public class OpaqueSharedURL extends RedditURLParser.RedditURL {
 	public final String subreddit;
 	@Nullable public final String shareKey;
 
-	public OpaqueSharedURL(@Nullable String subreddit, @Nullable String shareKey) {
+	public OpaqueSharedURL(@Nullable final String subreddit, @Nullable final String shareKey) {
 		this.subreddit = subreddit;
 		this.shareKey = shareKey;
 	}
@@ -60,7 +60,7 @@ public class OpaqueSharedURL extends RedditURLParser.RedditURL {
 	public static OpaqueSharedURL parse(final Uri uri) {
 		// URLs look like https://reddit.com/r/RedReader/s/<alphanumeric>
 		// first pull out the path segments and ensure they match the example (should be 4)
-		List<String> pathSegments = uri.getPathSegments();
+		final List<String> pathSegments = uri.getPathSegments();
 		if (pathSegments.size() != 4) {
 			return null;
 		}
@@ -74,19 +74,19 @@ public class OpaqueSharedURL extends RedditURLParser.RedditURL {
 	}
 
 	public static String resolveUsingNetwork(final OpaqueSharedURL url) {
-		Uri toFetch = Uri.parse(String.format("https://www.reddit.com/r/%s/s/%s", url.subreddit, url.shareKey));
+		final Uri toFetch = Uri.parse(String.format("https://www.reddit.com/r/%s/s/%s", url.subreddit, url.shareKey));
 		// Send a HTTP HEAD request to toFetch, and return back the Location header
 		// This will be the URL of the post
 		OkHttpClient client = ((OKHTTPBackend) HTTPBackend.getBackend()).getClientDirectly();
 		client = client.newBuilder().followRedirects(false).build();
-		Request request = new Request.Builder().url(toFetch.toString()).head().build();
+		final Request request = new Request.Builder().url(toFetch.toString()).head().build();
 		try {
 			try (okhttp3.Response response = client.newCall(request).execute()) {
 				if (response.isRedirect()) {
 					return response.header("Location");
 				}
 			}
-		} catch (IOException e) {
+		} catch (final IOException e) {
 			return null;
 		}
 		return null;

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/RedditURLParser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/RedditURLParser.java
@@ -41,6 +41,7 @@ public class RedditURLParser {
 	public static final int POST_COMMENT_LISTING_URL = 7;
 	public static final int MULTIREDDIT_POST_LISTING_URL = 8;
 	public static final int COMPOSE_MESSAGE_URL = 9;
+	public static final int OPAQUE_SHARED_URL = 10;
 
 	@IntDef({
 			SUBREDDIT_POST_LISTING_URL,
@@ -52,7 +53,9 @@ public class RedditURLParser {
 			UNKNOWN_COMMENT_LISTING_URL,
 			POST_COMMENT_LISTING_URL,
 			MULTIREDDIT_POST_LISTING_URL,
-			COMPOSE_MESSAGE_URL})
+			COMPOSE_MESSAGE_URL,
+			OPAQUE_SHARED_URL
+	})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface PathType {
 	}
@@ -121,6 +124,13 @@ public class RedditURLParser {
 		}
 
 		final Uri uri = optionalUri.get();
+
+		{
+			final OpaqueSharedURL opaqueSharedURL = OpaqueSharedURL.parse(uri);
+			if(opaqueSharedURL != null) {
+				return opaqueSharedURL;
+			}
+		}
 
 		{
 			final SubredditPostListURL subredditPostListURL = SubredditPostListURL.parse(uri);


### PR DESCRIPTION
This isn't very good quality code, but it _does_ seem to work for me on my device at least!

Particularly cringeworthy is the way in which I've ended up reaching around the whole `HTTPBackend` abstraction to get at the `okhttp` client directly. `RequestDetails` just isn't a flexible enough/low-level enough abstraction unfortunately for sending an unauthenticated HTTP HEAD request and pulling a response header out. I wanted to ensure it'd still use e.g. the SOCKS proxy settings though - which is why I'm not just using OKHttp directly.