### PR TITLE
Find Location: Hide keyboard when search is pressed and string queried (re #1022)

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/SubredditSearchActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/SubredditSearchActivity.java
@@ -354,6 +354,7 @@ public class SubredditSearchActivity extends BaseActivity implements
 			public boolean onQueryTextSubmit(final String query) {
 				handleQueryChanged(query);
 				queryEventListeners.send(query);
+				searchView.clearFocus();
 				return true;
 			}
 


### PR DESCRIPTION
Part fix for #1022 - particularly 'Hide keyboard when the "Search" button is pressed'

The only situation that this fix doesn't address is when there is no text in the SearchView (as onQueryTextSubmit() is not called). Could be fixed by extending the SearchView class: https://dev.to/foso/how-to-use-a-searchview-with-an-empty-query-text-submit-4afh, however feels overkill for an edge case (and frankly given the keyboard can be hidden with the back button in android, I cannot imagine many users intending to press the 'search' button on an empty string). 

