### PR TITLE
Add setting for marking posts as read

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -46,6 +46,7 @@ Minimum supported Android version is now 5.0
 /Alpha 350 (2024-04-14)
 Ability to upload an image when submitting a comment (thanks to folkemat)
 Comments submitted by current user now have username highlighted (thanks to folkemat)
+Added preference to prevent posts being marked as read when clicked (thanks to Daniel Ho)
 
 /Alpha 349 (2024-03-24)
 Ability to block users in user profile (thanks to folkemat)

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -2,6 +2,7 @@
 Added video playback speed control (thanks to folkemat)
 Added support for emotes in comment flairs (thanks to bharatknv)
 Added "Mark as Read/Unread" fling action, and optional context menu item (thanks to JoshAusHessen and codeofdusk)
+Added preference to prevent posts being marked as read when clicked (thanks to Daniel Ho)
 
 113/1.24.1
 Fix "Malformed URL" error for Imgur images (thanks to Alexey Rochev)

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -1164,6 +1164,12 @@ public final class PrefsUtility {
 				false);
 	}
 
+	public static boolean pref_behaviour_mark_posts_as_read() {
+		return getBoolean(
+				R.string.pref_behaviour_mark_posts_as_read_key,
+				true);
+	}
+
 	public enum SharingDomain {
 		STANDARD_REDDIT("reddit.com"),
 		SHORT_REDDIT("redd.it"),

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
@@ -19,7 +19,9 @@ package org.quantumbadger.redreader.reddit.prepared;
 
 import android.content.Context;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
+
 import org.quantumbadger.redreader.account.RedditAccount;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.common.AndroidCommon;
@@ -376,7 +378,7 @@ public final class RedditChangeDataManager {
 					timestamp,
 					mIsUpvoted,
 					mIsDownvoted,
-					PrefsUtility.pref_behaviour_mark_posts_as_read() && read,
+					read,
 					mIsSaved,
 					mIsHidden);
 		}
@@ -563,8 +565,8 @@ public final class RedditChangeDataManager {
 	}
 
 	public void markRead(
-		final TimestampUTC timestamp, 
-		final RedditIdAndType thing, 
+		final TimestampUTC timestamp,
+		final RedditIdAndType thing,
 		final Boolean read) {
 
 		synchronized(mLock) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditChangeDataManager.java
@@ -331,7 +331,8 @@ public final class RedditChangeDataManager {
 					timestamp,
 					Boolean.TRUE.equals(post.getLikes()),
 					Boolean.FALSE.equals(post.getLikes()),
-					post.getClicked() || mIsRead,
+					(PrefsUtility.pref_behaviour_mark_posts_as_read() && post.getClicked())
+							|| mIsRead,
 					post.getSaved(),
 					post.getHidden() ? true : null);
 		}
@@ -375,7 +376,7 @@ public final class RedditChangeDataManager {
 					timestamp,
 					mIsUpvoted,
 					mIsDownvoted,
-					read,
+					PrefsUtility.pref_behaviour_mark_posts_as_read() && read,
 					mIsSaved,
 					mIsHidden);
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -790,7 +790,9 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 	}
 
 	public void markAsRead(final Context context) {
-		markAsRead(context, true);
+		if (PrefsUtility.pref_behaviour_mark_posts_as_read()) {
+			markAsRead(context, true);
+		}
 	}
 
 	public void markAsRead(

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1911,4 +1911,7 @@
 	<!-- 2025-04-20 -->
 	<string name="action_mark_read">Mark as Read</string>
 	<string name="action_mark_unread">Mark as Unread</string>
+	<string name="pref_behaviour_mark_posts_as_read_key" translatable="false">pref_behaviour_mark_posts_as_read</string>
+	<string name="pref_behaviour_mark_posts_as_read_title">Mark posts as read</string>
+
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -175,6 +175,10 @@
 				android:key="@string/pref_behaviour_hide_read_posts_key"
 				android:defaultValue="false"/>
 
+		<CheckBoxPreference android:title="@string/pref_behaviour_mark_posts_as_read_title"
+							android:key="@string/pref_behaviour_mark_posts_as_read_key"
+							android:defaultValue="true"/>
+
         <ListPreference android:title="@string/pref_behaviour_postcount_title"
                         android:key="@string/pref_behaviour_postcount_key"
                         android:entries="@array/pref_behaviour_postcount_items"


### PR DESCRIPTION
This PR adds a setting for marking posts as read, which is enabled by default. If the setting is disabled, then posts will not be marked as read, meaning that there will be no visual cue that the post is read and the post will not be hidden if "hide read posts" is enabled. Posts that were already marked as read will remain marked even after enabling this setting.

Closes https://github.com/QuantumBadger/RedReader/issues/1135.