### PR TITLE
Ability to block and unblock users, hide or flag comments from blocked users, show a blocked chip in profile

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -119,6 +119,8 @@ public final class PrefsUtility {
 						R.string.pref_appearance_hide_headertoolbar_commentlist_key))
 				|| key.equals(context.getString(
 						R.string.pref_appearance_hide_headertoolbar_postlist_key))
+				|| key.equals(context.getString(
+					R.string.pref_appearance_hide_comments_from_blocked_users_key))
 				|| key.equals(context.getString(R.string.pref_images_thumbnail_size_key))
 				|| key.equals(context.getString(R.string.pref_images_inline_image_previews_key))
 				|| key.equals(context.getString(
@@ -573,6 +575,12 @@ public final class PrefsUtility {
 	public static boolean pref_appearance_hide_headertoolbar_commentlist() {
 		return getBoolean(
 				R.string.pref_appearance_hide_headertoolbar_commentlist_key,
+				false);
+	}
+
+	public static boolean pref_appearance_hide_comments_from_blocked_users() {
+		return getBoolean(
+				R.string.pref_appearance_hide_comments_from_blocked_users_key,
 				false);
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.kt
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.kt
@@ -90,6 +90,7 @@ object UserProfileDialog {
 		val commentsKarma = dialog.findViewById<MaterialTextView>(R.id.user_profile_comments_karma)!!
 		val chipMoreInfo = dialog.findViewById<Chip>(R.id.user_profile_chip_more_info)!!
 		val chipBlock = dialog.findViewById<Chip>(R.id.user_profile_chip_block)!!
+		val chipUnblock = dialog.findViewById<Chip>(R.id.user_profile_chip_unblock)!!
 
 		val cm = CacheManager.getInstance(activity)
 		val accountManager = RedditAccountManager.getInstance(activity)
@@ -138,8 +139,10 @@ object UserProfileDialog {
 
 						if (user.is_blocked != true) {
 							chipBlocked.visibility = View.GONE
+							chipUnblock.visibility = View.GONE
 						}else {
 							chipBlock.visibility = View.GONE //dont show block button if blocked
+							chipUnblock.visibility = View.VISIBLE
 						}
 
 						if (user.is_friend != true) {
@@ -237,10 +240,14 @@ object UserProfileDialog {
 									.setMessage(activity.getString(R.string.are_you_sure_block_user))
 									.setPositiveButton(activity.getString(R.string.block_yes)) { dialog, which ->
 										chipBlock.text = activity.getString(R.string.block_button_loading)
-										blockUser(activity, username, chipBlock, chipBlocked)
+										blockUser(activity, username, chipBlock, chipBlocked, chipUnblock)
 									}
 									.setNegativeButton(activity.getString(R.string.block_no), null)
 									.show()
+						}
+						chipUnblock.setOnClickListener {
+							chipUnblock.text = activity.getString(R.string.unblock_button_loading)
+							unblockUser(activity, username, chipBlock, chipBlocked, chipUnblock)
 						}
 					}
 				}
@@ -265,7 +272,83 @@ object UserProfileDialog {
 			activity
 		)
 	}
-	private fun blockUser(activity: AppCompatActivity, username: String, chipBlock: Chip, chipBlocked: Chip) {
+
+	private fun unblockUser(activity: AppCompatActivity, username: String, chipBlock: Chip, chipBlocked: Chip, chipUnblock: Chip) {
+		val cm = CacheManager.getInstance(activity)
+		val currentUser = RedditAccountManager.getInstance(activity).defaultAccount
+
+		RedditAPI.getUser(
+				cm,
+				currentUser.username,
+				object : UserResponseHandler(activity) {
+					override fun onDownloadStarted() {}
+
+					override fun onSuccess(redditUser: RedditUser, timestamp: TimestampUTC) {
+						val currentUserFullname = redditUser.fullname()
+						unblockUserApiCall(activity, username, currentUserFullname, chipBlock, chipBlocked, chipUnblock)
+					}
+
+					override fun onCallbackException(t: Throwable) {
+						activity.runOnUiThread {
+							chipUnblock.text = activity.getString(R.string.userprofile_button_unblock)
+						}
+						BugReportActivity.handleGlobalError(context, t)
+					}
+
+					override fun onFailure(error: RRError) {
+						activity.runOnUiThread {
+							chipUnblock.text = activity.getString(R.string.userprofile_button_unblock)
+						}
+					}
+				},
+				currentUser,
+				DownloadStrategyAlways.INSTANCE,
+				activity
+		)
+	}
+
+	private fun unblockUserApiCall(activity: AppCompatActivity, usernameToUnblock: String, currentUserFullname: String, chipBlock: Chip, chipBlocked: Chip, chipUnblock: Chip) {
+		val cm = CacheManager.getInstance(activity)
+		val currentUser = RedditAccountManager.getInstance(activity).defaultAccount
+
+		RedditAPI.unblockUser(
+				cm,
+				usernameToUnblock,
+				currentUserFullname,
+				object : ActionResponseHandler(activity) {
+					override fun onSuccess() {
+						activity.runOnUiThread {
+							chipUnblock.text = activity.getString(R.string.userprofile_button_unblock)
+							chipUnblock.visibility = View.GONE
+							chipBlocked.visibility = View.GONE
+							chipBlock.visibility = View.VISIBLE
+						}
+					}
+
+					override fun onFailure(error: RRError) {
+						activity.runOnUiThread {
+							chipUnblock.text = activity.getString(R.string.userprofile_button_unblock)
+						}
+						//During testing I quickly ran into rate limits, so show the user what's going on
+						val errorTitle = activity.getString(R.string.unblock_user_failed_title)
+						val errorMessageBase = activity.getString(R.string.unblock_user_failed_message)
+						val errorMessage = "$errorMessageBase\n\n${error.message}"
+						DialogUtils.showDialog(activity, errorTitle, errorMessage)
+					}
+
+					override fun onCallbackException(t: Throwable?) {
+						BugReportActivity.handleGlobalError(activity, t)
+						activity.runOnUiThread {
+							chipUnblock.text = activity.getString(R.string.userprofile_button_unblock)
+						}
+					}
+				},
+				currentUser,
+				activity
+		)
+	}
+
+	private fun blockUser(activity: AppCompatActivity, username: String, chipBlock: Chip, chipBlocked: Chip, chipUnblock: Chip) {
 		val cm = CacheManager.getInstance(activity)
 		val currentUser = RedditAccountManager.getInstance(activity).defaultAccount
 
@@ -275,8 +358,10 @@ object UserProfileDialog {
 				object : ActionResponseHandler(activity) {
 					override fun onSuccess() {
 						activity.runOnUiThread {
+							chipBlock.text = activity.getString(R.string.userprofile_button_block)
 							chipBlock.visibility = View.GONE
 							chipBlocked.visibility = View.VISIBLE
+							chipUnblock.visibility = View.VISIBLE
 						}
 					}
 
@@ -284,7 +369,11 @@ object UserProfileDialog {
 						activity.runOnUiThread {
 							chipBlock.text = activity.getString(R.string.userprofile_button_block)
 						}
-						DialogUtils.showDialog(activity, R.string.block_user_failed_title, R.string.block_user_failed_message)
+						//During testing I quickly ran into rate limits, so show the user what's going on
+						val errorTitle = activity.getString(R.string.block_user_failed_title)
+						val errorMessageBase = activity.getString(R.string.block_user_failed_message)
+						val errorMessage = "$errorMessageBase\n\n${error.message}"
+						DialogUtils.showDialog(activity, errorTitle, errorMessage)
 					}
 
 					override fun onCallbackException(t: Throwable?) {

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.kt
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserProfileDialog.kt
@@ -77,6 +77,7 @@ object UserProfileDialog {
 		val textviewAccountAge = dialog.findViewById<MaterialTextView>(R.id.user_profile_account_age)!!
 		val chipYou = dialog.findViewById<Chip>(R.id.user_profile_chip_you)!!
 		val chipSuspended = dialog.findViewById<Chip>(R.id.user_profile_chip_suspended)!!
+		val chipBlocked = dialog.findViewById<Chip>(R.id.user_profile_chip_blocked)!!
 		val chipFriend = dialog.findViewById<Chip>(R.id.user_profile_chip_friend)!!
 		val chipAdmin = dialog.findViewById<Chip>(R.id.user_profile_chip_admin)!!
 		val chipMod = dialog.findViewById<Chip>(R.id.user_profile_chip_moderator)!!
@@ -129,6 +130,10 @@ object UserProfileDialog {
 
 						if (user.is_suspended != true) {
 							chipSuspended.visibility = View.GONE
+						}
+
+						if (user.is_blocked != true) {
+							chipBlocked.visibility = View.GONE
 						}
 
 						if (user.is_friend != true) {

--- a/src/main/java/org/quantumbadger/redreader/fragments/UserPropertiesDialog.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/UserPropertiesDialog.java
@@ -121,6 +121,14 @@ public final class UserPropertiesDialog extends PropertiesDialog {
 					false));
 		}
 
+		if (user.is_blocked != null) {
+			items.addView(propView(
+					context,
+					R.string.userprofile_tag_blocked,
+					user.is_blocked ? R.string.general_true : R.string.general_false,
+					false));
+		}
+
 		if (user.icon_img != null) {
 			items.addView(propView(
 					context,

--- a/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
@@ -377,7 +377,7 @@ public class CommentListingRequest {
 					&& mCommentListingURL.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL;
 
 			final RedditCommentListItem item;
-			RedditRenderableComment renderableComment = new RedditRenderableComment(
+			final RedditRenderableComment renderableComment = new RedditRenderableComment(
 					new RedditParsedComment(comment, mActivity),
 					parentPostAuthor,
 					minimumCommentScore,
@@ -386,8 +386,8 @@ public class CommentListingRequest {
 					showSubredditName,
 					neverAutoCollapse);
 
-			if (comment.isBlockedByUser() && !PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
-				//adds [blocked user] to author name and collapses comment if user is blocked but comment not hidden
+			if (comment.isBlockedByUser()
+					&& !PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
 				renderableComment.setBlockedUser(true);
 			}
 
@@ -399,7 +399,8 @@ public class CommentListingRequest {
 					mCommentListingURL);
 
 			// hide comment if user is blocked
-			if (comment.isBlockedByUser() && PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
+			if (comment.isBlockedByUser()
+					&& PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
 				return;
 			}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/CommentListingRequest.java
@@ -376,19 +376,32 @@ public class CommentListingRequest {
 			final boolean neverAutoCollapse = mCommentListingURL != null
 					&& mCommentListingURL.pathType() == RedditURLParser.USER_COMMENT_LISTING_URL;
 
-			final RedditCommentListItem item = new RedditCommentListItem(
-					new RedditRenderableComment(
-							new RedditParsedComment(comment, mActivity),
-							parentPostAuthor,
-							minimumCommentScore,
-							currentCanonicalUserName,
-							true,
-							showSubredditName,
-							neverAutoCollapse),
+			final RedditCommentListItem item;
+			RedditRenderableComment renderableComment = new RedditRenderableComment(
+					new RedditParsedComment(comment, mActivity),
+					parentPostAuthor,
+					minimumCommentScore,
+					currentCanonicalUserName,
+					true,
+					showSubredditName,
+					neverAutoCollapse);
+
+			if (comment.isBlockedByUser() && !PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
+				//adds [blocked user] to author name and collapses comment if user is blocked but comment not hidden
+				renderableComment.setBlockedUser(true);
+			}
+
+			item = new RedditCommentListItem(
+					renderableComment,
 					parent,
 					mFragment,
 					mActivity,
 					mCommentListingURL);
+
+			// hide comment if user is blocked
+			if (comment.isBlockedByUser() && PrefsUtility.pref_appearance_hide_comments_from_blocked_users()) {
+				return;
+			}
 
 			output.add(item);
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
@@ -660,6 +660,25 @@ public final class RedditAPI {
 				}));
 	}
 
+	public static void blockUser(
+			final CacheManager cm,
+			final String usernameToBlock,
+			final APIResponseHandler.ActionResponseHandler responseHandler,
+			final RedditAccount user,
+			final Context context
+	) {
+		final LinkedList<PostField> postFields = new LinkedList<>();
+		postFields.add(new PostField("name", usernameToBlock));
+		postFields.add(new PostField("api_type", "json"));
+
+		cm.makeRequest(createPostRequest(
+				Constants.Reddit.getUri("/api/block_user"),
+				user,
+				postFields,
+				context,
+				new GenericResponseHandler(responseHandler)));
+	}
+
 	public static void sendReplies(
 			final CacheManager cm,
 			final APIResponseHandler.ActionResponseHandler responseHandler,

--- a/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
@@ -660,6 +660,27 @@ public final class RedditAPI {
 				}));
 	}
 
+	public static void unblockUser(
+			final CacheManager cm,
+			final String usernameToUnblock,
+			final String currentUserFullname,
+			final APIResponseHandler.ActionResponseHandler responseHandler,
+			final RedditAccount user,
+			final Context context
+	) {
+		final LinkedList<PostField> postFields = new LinkedList<>();
+		postFields.add(new PostField("name", usernameToUnblock));
+		postFields.add(new PostField("container", currentUserFullname));
+		postFields.add(new PostField("type", "enemy"));
+
+		cm.makeRequest(createPostRequest(
+				Constants.Reddit.getUri("/api/unfriend"),
+				user,
+				postFields,
+				context,
+				new GenericResponseHandler(responseHandler)));
+	}
+
 	public static void blockUser(
 			final CacheManager cm,
 			final String usernameToBlock,

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditOAuth.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditOAuth.kt
@@ -53,7 +53,7 @@ object RedditOAuth {
     private const val ALL_SCOPES = ("identity edit flair history "
             + "modconfig modflair modlog modposts modwiki mysubreddits "
             + "privatemessages read report save submit subscribe vote "
-            + "wikiedit wikiread")
+            + "wikiedit wikiread account")
     private const val ACCESS_TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
 
     @JvmStatic

--- a/src/main/java/org/quantumbadger/redreader/reddit/kthings/RedditComment.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/kthings/RedditComment.kt
@@ -33,6 +33,7 @@ import org.quantumbadger.redreader.reddit.url.PostCommentListingURL
 data class RedditComment(
 	val body: UrlEncodedString? = null,
 	val body_html: UrlEncodedString? = null,
+	val COLLAPSED_REASON_BLOCKED_AUTHOR: String = "BLOCKED_AUTHOR",
 
 	val author: UrlEncodedString? = null,
 	val subreddit: UrlEncodedString? = null,
@@ -66,7 +67,9 @@ data class RedditComment(
 
 	val distinguished: String? = null, // TODO enum? Test unknown values
 
-	val stickied: Boolean = false
+	val stickied: Boolean = false,
+
+	val collapsed_reason_code: String? = null
 
 ) : Parcelable, RedditThingWithIdAndType {
 
@@ -107,4 +110,8 @@ data class RedditComment(
 	fun wasEdited(): Boolean = edited != RedditFieldEdited.Bool(false)
 
 	fun isControversial(): Boolean = controversiality == 1
+
+	fun isBlockedByUser(): Boolean {
+		return COLLAPSED_REASON_BLOCKED_AUTHOR == collapsed_reason_code
+	}
 }

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -55,6 +55,7 @@ public class RedditRenderableComment
 	private final boolean mShowScore;
 	private final boolean mShowSubreddit;
 	private final boolean mNeverAutoCollapse;
+	private boolean isBlockedUser = false;
 
 	public RedditRenderableComment(
 			final RedditParsedComment comment,
@@ -72,6 +73,10 @@ public class RedditRenderableComment
 		mShowScore = showScore;
 		mShowSubreddit = showSubreddit;
 		mNeverAutoCollapse = neverAutoCollapse;
+	}
+
+	public void setBlockedUser(boolean blocked) {
+		isBlockedUser = blocked;
 	}
 
 	private int computeScore(final RedditChangeDataManager changeDataManager) {
@@ -163,6 +168,9 @@ public class RedditRenderableComment
 						theme.rrCommentHeaderAuthorCol,
 						0,
 						1f);
+			}
+			if (isBlockedUser) {
+				sb.append(" [blocked user]", BetterSSB.FOREGROUND_COLOR, Color.RED, 0, 1f);
 			}
 		}
 
@@ -614,6 +622,11 @@ public class RedditRenderableComment
 
 		if(collapsed != null) {
 			return collapsed;
+		}
+
+		//Always collapse blocked users
+		if (isBlockedUser) {
+			return true;
 		}
 
 		if(mNeverAutoCollapse) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -75,7 +75,7 @@ public class RedditRenderableComment
 		mNeverAutoCollapse = neverAutoCollapse;
 	}
 
-	public void setBlockedUser(boolean blocked) {
+	public void setBlockedUser(final boolean blocked) {
 		isBlockedUser = blocked;
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -170,7 +170,7 @@ public class RedditRenderableComment
 						1f);
 			}
 			if (isBlockedUser) {
-				sb.append(" [blocked user]", BetterSSB.FOREGROUND_COLOR, Color.RED, 0, 1f);
+				sb.append(" " + context.getString(R.string.blocked_user_comment), BetterSSB.FOREGROUND_COLOR, Color.RED, 0, 1f);
 			}
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -170,7 +170,8 @@ public class RedditRenderableComment
 						1f);
 			}
 			if (isBlockedUser) {
-				sb.append(" " + context.getString(R.string.blocked_user_comment), BetterSSB.FOREGROUND_COLOR, Color.RED, 0, 1f);
+				sb.append(" [" + context.getString(R.string.blocked_user_comment) + "]",
+				BetterSSB.FOREGROUND_COLOR, Color.RED, 0, 1f);
 			}
 		}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditThing.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditThing.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 public final class RedditThing implements JsonObject.JsonDeserializable {
 
+	public static final String KIND_USER = "t2";
+
 	public enum Kind {
 		POST, USER, COMMENT, MESSAGE, SUBREDDIT, MORE_COMMENTS, LISTING
 	}
@@ -35,7 +37,7 @@ public final class RedditThing implements JsonObject.JsonDeserializable {
 	static {
 		kinds = new HashMap<>();
 		kinds.put("t1", Kind.COMMENT);
-		kinds.put("t2", Kind.USER);
+		kinds.put(KIND_USER, Kind.USER);
 		kinds.put("t3", Kind.POST);
 		kinds.put("t4", Kind.MESSAGE);
 		kinds.put("t5", Kind.SUBREDDIT);

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -40,6 +40,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 	@Nullable public Boolean is_mod;
 	@Nullable public Boolean is_suspended;
 	@Nullable public Boolean over_18;
+	@Nullable public Boolean is_blocked;
 
 	@Nullable public String id;
 	@NonNull public String name;
@@ -82,6 +83,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		is_gold = in.readInt() == 1;
 		is_mod = in.readInt() == 1;
 		over_18 = in.readInt() == 1;
+		is_blocked = in.readInt() == 1;
 
 		id = in.readString();
 		name = in.readString();
@@ -115,6 +117,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 		parcel.writeInt(is_gold ? 1 : 0);
 		parcel.writeInt(is_mod ? 1 : 0);
 		parcel.writeInt(over_18 ? 1 : 0);
+		parcel.writeInt(is_blocked ? 1 : 0);
 
 		parcel.writeString(id);
 		parcel.writeString(name);

--- a/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/things/RedditUser.java
@@ -147,4 +147,7 @@ public class RedditUser implements Parcelable, JsonObject.JsonDeserializable {
 			return new RedditUser[size];
 		}
 	};
+	public String fullname() {
+		return String.format("%s_%s", RedditThing.KIND_USER, id);
+	}
 }

--- a/src/main/res/layout/user_profile_dialog.xml
+++ b/src/main/res/layout/user_profile_dialog.xml
@@ -110,6 +110,16 @@
 						app:chipMinTouchTargetSize="0dp"/>
 
 				<com.google.android.material.chip.Chip
+						android:id="@+id/user_profile_chip_blocked"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:text="@string/userprofile_tag_blocked"
+						style="@style/Widget.Material3.Chip.Assist"
+						android:clickable="false"
+						android:checkable="false"
+						app:chipMinTouchTargetSize="0dp"/>
+
+				<com.google.android.material.chip.Chip
 						android:id="@+id/user_profile_chip_friend"
 						android:layout_width="wrap_content"
 						android:layout_height="wrap_content"

--- a/src/main/res/layout/user_profile_dialog.xml
+++ b/src/main/res/layout/user_profile_dialog.xml
@@ -342,6 +342,16 @@
 						style="@style/Widget.Material3.Chip.Assist.Elevated"
 						android:checkable="false"/>
 
+				<com.google.android.material.chip.Chip
+						android:id="@+id/user_profile_chip_unblock"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						app:chipIcon="?rrIconTick"
+						app:chipIconSize="16sp"
+						android:text="@string/userprofile_button_unblock"
+						style="@style/Widget.Material3.Chip.Assist.Elevated"
+						android:checkable="false"/>
+
 			</com.google.android.material.chip.ChipGroup>
 
 		</androidx.appcompat.widget.LinearLayoutCompat>

--- a/src/main/res/layout/user_profile_dialog.xml
+++ b/src/main/res/layout/user_profile_dialog.xml
@@ -332,6 +332,16 @@
 						style="@style/Widget.Material3.Chip.Assist.Elevated"
 						android:checkable="false"/>
 
+				<com.google.android.material.chip.Chip
+						android:id="@+id/user_profile_chip_block"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						app:chipIcon="?rrIconCross"
+						app:chipIconSize="16sp"
+						android:text="@string/userprofile_button_block"
+						style="@style/Widget.Material3.Chip.Assist.Elevated"
+						android:checkable="false"/>
+
 			</com.google.android.material.chip.ChipGroup>
 
 		</androidx.appcompat.widget.LinearLayoutCompat>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1831,6 +1831,16 @@
 
 	<!-- 2024-01-06 -->
 	<string name="pref_appearance_hide_comments_from_blocked_users_key" translatable="false">pref_appearance_hide_comments_from_blocked_users</string>
-	<string name="pref_appearance_hide_comments_from_blocked_users_title">Hide comment chains from blocked users</string>
-	<string name="userprofile_tag_blocked">Blocked</string>
+	<string name="pref_appearance_hide_comments_from_blocked_users_title" translatable="true">Hide comment chains from blocked users</string>
+	<string name="userprofile_tag_blocked" translatable="true">Blocked</string>
+
+	<!-- 2024-01-07 -->
+	<string name="userprofile_button_block" translatable="true">Block</string>
+	<string name="block_user_failed_title" translatable="true">Failed to block</string>
+	<string name="block_user_failed_message" translatable="true">Failed to block user. You may have to log out and re-add your account.</string>
+	<string name="block_button_loading" translatable="true">Blocking…</string>
+	<string name="block_confirmation" translatable="true">Block confirmation</string>
+	<string name="are_you_sure_block_user" translatable="true">Are you sure you want to block this user?</string>
+	<string name="block_yes" translatable="true">Yes, block</string>
+	<string name="block_no" translatable="true">No, do not block</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1849,5 +1849,5 @@
 	<string name="unblock_button_loading" translatable="true">Unblocking…</string>
 	<string name="unblock_user_failed_title" translatable="true">Failed to unblock</string>
 	<string name="unblock_user_failed_message" translatable="true">Failed to unblock user. You may have to log out and re-add your account. Message from Reddit:</string>
-
+	<string name="blocked_user_comment" translatable="true">[blocked]</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1837,10 +1837,17 @@
 	<!-- 2024-01-07 -->
 	<string name="userprofile_button_block" translatable="true">Block</string>
 	<string name="block_user_failed_title" translatable="true">Failed to block</string>
-	<string name="block_user_failed_message" translatable="true">Failed to block user. You may have to log out and re-add your account.</string>
+	<string name="block_user_failed_message" translatable="true">Failed to block user. You may have to log out and re-add your account. Message from Reddit:</string>
 	<string name="block_button_loading" translatable="true">Blocking…</string>
 	<string name="block_confirmation" translatable="true">Block confirmation</string>
 	<string name="are_you_sure_block_user" translatable="true">Are you sure you want to block this user?</string>
 	<string name="block_yes" translatable="true">Yes, block</string>
 	<string name="block_no" translatable="true">No, do not block</string>
+
+	<!-- 2024-01-08 -->
+	<string name="userprofile_button_unblock" translatable="true">Unblock</string>
+	<string name="unblock_button_loading" translatable="true">Unblocking…</string>
+	<string name="unblock_user_failed_title" translatable="true">Failed to unblock</string>
+	<string name="unblock_user_failed_message" translatable="true">Failed to unblock user. You may have to log out and re-add your account. Message from Reddit:</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1829,4 +1829,8 @@
 	<string name="pref_album_skip_to_first_key" translatable="false">pref_album_skip_to_first_key</string>
 	<string name="pref_album_skip_to_first_title">Automatically open first album image</string>
 
+	<!-- 2024-01-06 -->
+	<string name="pref_appearance_hide_comments_from_blocked_users_key" translatable="false">pref_appearance_hide_comments_from_blocked_users</string>
+	<string name="pref_appearance_hide_comments_from_blocked_users_title">Hide comment chains from blocked users</string>
+	<string name="userprofile_tag_blocked">Blocked</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1831,23 +1831,22 @@
 
 	<!-- 2024-01-06 -->
 	<string name="pref_appearance_hide_comments_from_blocked_users_key" translatable="false">pref_appearance_hide_comments_from_blocked_users</string>
-	<string name="pref_appearance_hide_comments_from_blocked_users_title" translatable="true">Hide comment chains from blocked users</string>
-	<string name="userprofile_tag_blocked" translatable="true">Blocked</string>
+	<string name="pref_appearance_hide_comments_from_blocked_users_title">Hide comment chains from blocked users</string>
+	<string name="userprofile_tag_blocked">Blocked</string>
 
 	<!-- 2024-01-07 -->
-	<string name="userprofile_button_block" translatable="true">Block</string>
-	<string name="block_user_failed_title" translatable="true">Failed to block</string>
-	<string name="block_user_failed_message" translatable="true">Failed to block user. You may have to log out and re-add your account. Message from Reddit:</string>
-	<string name="block_button_loading" translatable="true">Blocking…</string>
-	<string name="block_confirmation" translatable="true">Block confirmation</string>
-	<string name="are_you_sure_block_user" translatable="true">Are you sure you want to block this user?</string>
-	<string name="block_yes" translatable="true">Yes, block</string>
-	<string name="block_no" translatable="true">No, do not block</string>
+	<string name="userprofile_button_block">Block</string>
+	<string name="block_button_loading">Blocking…</string>
+	<string name="block_confirmation">Block confirmation</string>
+	<string name="are_you_sure_block_user">Are you sure you want to block this user?</string>
 
 	<!-- 2024-01-08 -->
-	<string name="userprofile_button_unblock" translatable="true">Unblock</string>
-	<string name="unblock_button_loading" translatable="true">Unblocking…</string>
-	<string name="unblock_user_failed_title" translatable="true">Failed to unblock</string>
-	<string name="unblock_user_failed_message" translatable="true">Failed to unblock user. You may have to log out and re-add your account. Message from Reddit:</string>
-	<string name="blocked_user_comment" translatable="true">[blocked]</string>
+	<string name="userprofile_button_unblock">Unblock</string>
+	<string name="unblock_button_loading">Unblocking…</string>
+	<string name="blocked_user_comment">blocked</string>
+
+	<!-- 2024-01-25 -->
+	<string name="block_permission_denied_message">A new login is required to enable RedReader to handle the blocking of users. Please do a re-login and try again.</string>
+	<string name="block_permission_denied_title">Missing permission to block</string>
+	<string name="block_permission_denied_relogin">Re-login</string>
 </resources>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -170,6 +170,11 @@
 				android:key="@string/pref_appearance_hide_headertoolbar_commentlist_key"
 				android:defaultValue="false"/>
 
+		<CheckBoxPreference
+				android:title="@string/pref_appearance_hide_comments_from_blocked_users_title"
+				android:key="@string/pref_appearance_hide_comments_from_blocked_users_key"
+				android:defaultValue="true"/>
+
     </PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/pref_appearance_user_header">


### PR DESCRIPTION
Hi, this PR copies most of the dead/inactive pull request [940](https://github.com/QuantumBadger/RedReader/pull/940) with some changes.

- "Hide comment chains from blocked users" is enabled by default
- If disabled, "[blocked]" is added to the author and the comment collapses 
- A "Blocked" chip is displayed in the profile of blocked users
- Users can be blocked via a "Block" button in the profile
- Users can be unblocked via a "Unblock" button in the profile
