### PR TITLE
Playback speed control

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -1,3 +1,6 @@
+/Alpha 358 (2025-03-12)
+Added video playback speed control (thanks to folkemat)
+
 /Alpha 357 (2024-08-25)
 Fix "Malformed URL" error for Imgur images (thanks to Alexey Rochev)
 Remove red background/border behind transparent images in the gallery

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -1,3 +1,6 @@
+114/1.25
+Added video playback speed control (thanks to folkemat)
+
 113/1.24.1
 Fix "Malformed URL" error for Imgur images (thanks to Alexey Rochev)
 Remove red background/border behind transparent images in the gallery

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -27,7 +27,8 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
+import android.widget.Button;
+import android.widget.SeekBar;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -44,6 +45,7 @@ import androidx.media3.ui.DefaultTimeBar;
 import androidx.media3.ui.PlayerView;
 import androidx.media3.ui.TimeBar;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.AndroidCommon;
 import org.quantumbadger.redreader.common.General;
@@ -69,6 +71,9 @@ public class ExoPlayerWrapperView extends FrameLayout {
 
 	@Nullable private final DefaultTimeBar mTimeBarView;
 	@Nullable private final TextView mTimeTextView;
+
+	@Nullable private final TextView mSpeedTextView;
+	private float mCurrentPlaybackSpeed = 1.0f;
 
 	private boolean mReleased;
 
@@ -233,6 +238,15 @@ public class ExoPlayerWrapperView extends FrameLayout {
 				addButton(zoomButton.get(), buttons);
 			}
 
+			addButton(createButton(
+					context,
+					mControlView,
+					R.drawable.ic_time_dark,
+					R.string.video_speed_setting,
+					view -> {
+						openSpeedSettingDialog(context);
+					}), buttons);
+
 			mTimeBarView = new DefaultTimeBar(context, null);
 			controlBar.addView(mTimeBarView);
 
@@ -279,10 +293,19 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			updateProgressRunnable.run();
 
 			{
+				final LinearLayout timeAndSpeedLayout = new LinearLayout(context);
+				timeAndSpeedLayout.setOrientation(LinearLayout.HORIZONTAL);
+				controlBar.addView(timeAndSpeedLayout);
+
 				mTimeTextView = new TextView(context);
-				controlBar.addView(mTimeTextView);
+				timeAndSpeedLayout.addView(mTimeTextView);
 				mTimeTextView.setTextColor(Color.WHITE);
 				mTimeTextView.setTextSize(18);
+
+				mSpeedTextView = new TextView(context);
+				timeAndSpeedLayout.addView(mSpeedTextView);
+				mSpeedTextView.setTextColor(Color.WHITE);
+				mSpeedTextView.setText(String.format(Locale.US, "(%.2fx)", mCurrentPlaybackSpeed));
 
 				final int marginSidesPx = General.dpToPixels(context, 16);
 				final int marginBottomPx = General.dpToPixels(context, 8);
@@ -300,6 +323,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			mControlView = null;
 			mTimeBarView = null;
 			mTimeTextView = null;
+			mSpeedTextView = null;
 		}
 
 		videoPlayerView.setLayoutParams(new FrameLayout.LayoutParams(
@@ -435,5 +459,121 @@ public class ExoPlayerWrapperView extends FrameLayout {
 		final int secs = secondsTotal % 60;
 
 		return String.format(Locale.US, "%d:%02d", mins, secs);
+	}
+	private void openSpeedSettingDialog(final Context context) {
+		// Pause video playback before opening the dialog
+		mVideoPlayer.setPlayWhenReady(false);
+
+		final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context);
+		builder.setTitle(R.string.video_speed_instruction);
+
+		final LinearLayout speedSettingsLayout = new LinearLayout(context);
+		speedSettingsLayout.setOrientation(LinearLayout.VERTICAL);
+		speedSettingsLayout.setPadding(20, 20, 20, 20);
+
+		final TextView speedValue = new TextView(context);
+		speedValue.setText(String.format(
+			Locale.US,
+			getResources().getString(R.string.video_speed_term) + ": %.2fx",
+			mCurrentPlaybackSpeed)
+		);
+		speedValue.setTextSize(18);
+		speedValue.setPadding(10, 10, 10, 10);
+
+		final SeekBar speedSeekBar = new SeekBar(context);
+		speedSeekBar.setMax(300 - 1); // 3.00 is max for now
+
+		final LinearLayout.LayoutParams seekBarParams = new LinearLayout.LayoutParams(
+				LinearLayout.LayoutParams.MATCH_PARENT,
+				LinearLayout.LayoutParams.WRAP_CONTENT
+		);
+		seekBarParams.height = 150;
+		speedSeekBar.setLayoutParams(seekBarParams);
+
+		speedSeekBar.setProgress((int) ((mCurrentPlaybackSpeed - 0.01) * 100));
+
+		// Listener for changes in the SeekBar's position
+		speedSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+			@Override
+			public void onProgressChanged(final SeekBar seekBar,
+											final int progress,final boolean fromUser) {
+				final float selectedSpeed = 0.01f * (progress + 1);
+				speedValue.setText(String.format(
+					Locale.US,
+					getResources().getString(R.string.video_speed_term) + ": %.2fx",
+					selectedSpeed)
+				);
+			}
+
+			@Override
+			public void onStartTrackingTouch(final SeekBar seekBar) { }
+
+			@Override
+			public void onStopTrackingTouch(final SeekBar seekBar) { }
+		});
+
+		speedSettingsLayout.addView(speedValue);
+		speedSettingsLayout.addView(speedSeekBar);
+
+		// Creating rows for the speed preset buttons
+		final LinearLayout[] rows = new LinearLayout[4];
+		for (int i = 0; i < rows.length; i++) {
+			rows[i] = new LinearLayout(context);
+			rows[i].setOrientation(LinearLayout.HORIZONTAL);
+			speedSettingsLayout.addView(rows[i]);
+		}
+
+		// Labels and values for the preset speed buttons
+		final String[] speedLabels = {"0.5", "1.0", "1.5", "2.0"};
+		final int[] speedProgressValues = {49, 99, 149, 199};
+
+		// Adding preset speed buttons to the layout
+		for (int i = 0; i < speedLabels.length; i++) {
+			addPresetSpeedButton(rows[i / 4], speedLabels[i],
+					speedProgressValues[i], speedSeekBar, speedValue, context);
+		}
+
+		builder.setView(speedSettingsLayout);
+
+		builder.setPositiveButton(R.string.dialog_go, (dialog, which) -> {
+			mCurrentPlaybackSpeed = 0.01f * (speedSeekBar.getProgress() + 1);
+			mVideoPlayer.setPlaybackSpeed(mCurrentPlaybackSpeed);
+			mSpeedTextView.setText(String.format(Locale.US, "(%.2fx)", mCurrentPlaybackSpeed));
+			// Resume video playback when dialog is dismissed
+			mVideoPlayer.setPlayWhenReady(true);
+		});
+		builder.setNegativeButton(R.string.dialog_cancel, (dialog, which) -> {
+			// Resume video playback when dialog is dismissed
+			mVideoPlayer.setPlayWhenReady(true);
+		});
+
+		builder.setOnCancelListener(dialog -> {
+			// Resume video playback when dialog is canceled
+			mVideoPlayer.setPlayWhenReady(true);
+		});
+
+		builder.show();
+	}
+
+	// Method to add a preset speed button to the layout
+	private void addPresetSpeedButton(final LinearLayout rowLayout, final String label,
+										final int progress, final SeekBar seekBar,
+										final TextView speedValue, final Context context) {
+		final Button speedButton = new Button(context);
+		speedButton.setText(label);
+		// Setting button click behavior to update the SeekBar and speedValue TextView
+		speedButton.setOnClickListener(v -> {
+			seekBar.setProgress(progress);
+			final float selectedSpeed = 0.01f * (progress + 1);
+			speedValue.setText(String.format(
+				Locale.US,
+				getResources().getString(R.string.video_speed_term) + ": %.2fx",
+				selectedSpeed)
+			);
+		});
+
+		final LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+				0, LayoutParams.WRAP_CONTENT, 1.0f);
+		rowLayout.addView(speedButton, params);
 	}
 }

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -335,7 +335,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			}
 
 			@Override
-			public void onPlayWhenReadyChanged(boolean playWhenReady, int reason) {
+			public void onPlayWhenReadyChanged(final boolean playWhenReady, final int reason) {
 
 				if (mPlayButton == null) {
 					return;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1902,4 +1902,9 @@
 	<string name="album_grid_pref_horizontal_padding">Horizontal padding</string>
 
 	<string name="album_pref_compact_title">Compact title</string>
+
+	<!-- 2025-03-12 -->
+	<string name="video_speed_setting">Change video speed</string>
+	<string name="video_speed_instruction">Choose playback speed</string>
+	<string name="video_speed_term">Speed</string>
 </resources>


### PR DESCRIPTION
To be able to change the speed of a video, this PR adds a video speed control setting.

It can be accessed via an icon/button in the playback control. I chose the clock (ic_time_dark) for this (because I couldn't find a more suitable icon). Maybe a dedicated icon would be better.

Tapping on the clock opens a material alert dialogue with a seekbar through which you can set the speed. I added four buttons (0.5x, 1x, 1.5x and 2x speed) as a fast setting underneath the seekbar. The slowest setting is 0.01 and the fastest is 3.0.

The current speed is displayed in brackets next to the time progress.

Demo picture:
[photo_2024-01-07_20-37-13](https://github.com/QuantumBadger/RedReader/assets/96705437/eb11b9b9-9ddc-425c-a3e7-4b084676fb94)

Finally, I set the default setting for displaying the Video Controls to true, because it seems to me to be an elementary thing and people are often confused that there are none (see e.g. #1057).