### PR TITLE
Crosspost support

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -1,6 +1,8 @@
 /Alpha 359 (2025-04-20)
 Added support for emotes in comment flairs (thanks to bharatknv)
 Added "Mark as Read/Unread" fling action, and optional context menu item (thanks to JoshAusHessen and codeofdusk)
+Show label on crossposts, and add "Go to Crosspost Origin" to post menu (thanks to folkemat)
+Added preference to prevent posts being marked as read when clicked (thanks to Daniel Ho)
 
 /Alpha 358 (2025-03-12)
 Added video playback speed control (thanks to folkemat)

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -1,7 +1,8 @@
 114/1.25
 Added video playback speed control (thanks to folkemat)
 Added support for emotes in comment flairs (thanks to bharatknv)
-Added "Mark as Read/Unread" fling action, and optional context menu item (thanks to JoshAusHessen and codeofdusk)
+Show label on crossposts, and add "Go to Crosspost Origin" to post menu (thanks to folkemat)
+Added "Mark as Read/Unread" fling action, and optional post menu item (thanks to JoshAusHessen and codeofdusk)
 Added preference to prevent posts being marked as read when clicked (thanks to Daniel Ho)
 
 113/1.24.1

--- a/src/main/java/org/quantumbadger/redreader/common/FeatureFlagHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/FeatureFlagHandler.java
@@ -57,7 +57,8 @@ public final class FeatureFlagHandler {
 		OPEN_COMMENT_EXTERNALLY_FEATURE("openCommentExternallyFeature"),
 		POST_TITLE_TAP_ACTION_FEATURE("postTitleTapActionFeature"),
 		DEFAULT_PREF_VIDEO_PLAYBACK_CONTROLS("defaultPrefVideoPlaybackControls"),
-		DEFAULT_PREF_CUSTOM_TABS("defaultPrefCustomTabs");
+		DEFAULT_PREF_CUSTOM_TABS("defaultPrefCustomTabs"),
+		CROSSPOST_ORIGIN_MENU_ITEM("crosspostOriginMenuItem");
 
 		@NonNull private final String id;
 
@@ -305,6 +306,27 @@ public final class FeatureFlagHandler {
 						.putBoolean(
 								context.getString(R.string.pref_behaviour_usecustomtabs_key),
 								true)
+						.apply();
+			}
+
+			if(getAndSetFeatureFlag(prefs, FeatureFlag.CROSSPOST_ORIGIN_MENU_ITEM)
+					== FeatureFlagStatus.UPGRADE_NEEDED) {
+
+				Log.i(TAG, "Upgrading, add crosspost origin button to post action menu.");
+
+				final Set<String> existingPostActionMenuItems = getStringSet(
+						R.string.pref_menus_post_context_items_key,
+						R.array.pref_menus_post_context_items_default,
+						context,
+						prefs);
+
+				existingPostActionMenuItems.add("crosspost_origin");
+
+				prefs.edit()
+						.putStringSet(
+								context.getString(
+										R.string.pref_menus_post_context_items_key),
+								existingPostActionMenuItems)
 						.apply();
 			}
 		});

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -589,6 +589,7 @@ public final class PrefsUtility {
 		SCORE,
 		AGE,
 		GOLD,
+		CROSSPOST,
 		SUBREDDIT,
 		DOMAIN,
 		STICKY,

--- a/src/main/java/org/quantumbadger/redreader/common/RRThemeAttributes.java
+++ b/src/main/java/org/quantumbadger/redreader/common/RRThemeAttributes.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.common;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+
 import org.quantumbadger.redreader.R;
 
 import java.util.EnumSet;
@@ -59,7 +60,7 @@ public class RRThemeAttributes {
 				R.attr.rrCommentHeaderCol,
 				R.attr.rrCommentBodyCol,
 				R.attr.rrMainTextCol,
-				com.google.android.material.R.attr.colorAccent
+				com.google.android.material.R.attr.colorAccent,
 				R.attr.rrCrosspostBackCol,
 				R.attr.rrCrosspostTextCol
 		});

--- a/src/main/java/org/quantumbadger/redreader/common/RRThemeAttributes.java
+++ b/src/main/java/org/quantumbadger/redreader/common/RRThemeAttributes.java
@@ -37,6 +37,8 @@ public class RRThemeAttributes {
 	public final int rrCommentBodyCol;
 	public final int rrMainTextCol;
 	public final int colorAccent;
+	public final int rrCrosspostBackCol;
+	public final int rrCrosspostTextCol;
 
 	private final EnumSet<PrefsUtility.AppearanceCommentHeaderItem> mCommentHeaderItems;
 
@@ -58,6 +60,8 @@ public class RRThemeAttributes {
 				R.attr.rrCommentBodyCol,
 				R.attr.rrMainTextCol,
 				com.google.android.material.R.attr.colorAccent
+				R.attr.rrCrosspostBackCol,
+				R.attr.rrCrosspostTextCol
 		});
 
 		rrCommentHeaderBoldCol = appearance.getColor(0, 255);
@@ -72,6 +76,8 @@ public class RRThemeAttributes {
 		rrCommentBodyCol = appearance.getColor(9, 255);
 		rrMainTextCol = appearance.getColor(10, 255);
 		colorAccent = appearance.getColor(11, 255);
+		rrCrosspostBackCol = appearance.getColor(12, 255);
+		rrCrosspostTextCol = appearance.getColor(13, 255);
 
 		appearance.recycle();
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
@@ -50,6 +50,7 @@ import org.quantumbadger.redreader.common.PrefsUtility
 import org.quantumbadger.redreader.common.PrefsUtility.PostFlingAction
 import org.quantumbadger.redreader.common.RRError
 import org.quantumbadger.redreader.common.UriString
+import org.quantumbadger.redreader.common.RRError
 import org.quantumbadger.redreader.common.time.TimestampUTC
 import org.quantumbadger.redreader.fragments.PostPropertiesDialog
 import org.quantumbadger.redreader.reddit.APIResponseHandler.ActionResponseHandler
@@ -60,12 +61,14 @@ import org.quantumbadger.redreader.reddit.prepared.RedditChangeDataManager
 import org.quantumbadger.redreader.reddit.prepared.RedditPreparedPost
 import org.quantumbadger.redreader.reddit.things.InvalidSubredditNameException
 import org.quantumbadger.redreader.reddit.things.SubredditCanonicalId
+import org.quantumbadger.redreader.reddit.url.PostCommentListingURL
 import org.quantumbadger.redreader.reddit.url.SubredditPostListURL
 import org.quantumbadger.redreader.reddit.url.UserProfileURL
 import org.quantumbadger.redreader.views.AccessibilityActionManager
 import org.quantumbadger.redreader.views.RedditPostView.PostSelectionListener
 import org.quantumbadger.redreader.views.bezelmenu.SideToolbarOverlay
 import org.quantumbadger.redreader.views.bezelmenu.VerticalToolbar
+
 
 object RedditPostActions {
 
@@ -105,7 +108,9 @@ object RedditPostActions {
 		PIN(R.string.action_pin_subreddit),
 		UNPIN(R.string.action_unpin_subreddit),
 		SUBSCRIBE(R.string.action_subscribe_subreddit),
-		UNSUBSCRIBE(R.string.action_unsubscribe_subreddit)
+		UNSUBSCRIBE(R.string.action_unsubscribe_subreddit),
+		CROSSPOST_ORIGIN(R.string.action_crosspost_origin)
+
 	}
 
 	data class ActionDescriptionPair(
@@ -382,6 +387,11 @@ object RedditPostActions {
 				) { _, _ -> action(post, activity, RedditAPI.ACTION_REPORT) }
 				.setNegativeButton(R.string.dialog_cancel, null)
 				.show()
+
+			Action.CROSSPOST_ORIGIN -> {
+				val crosspostOriginPost = PostCommentListingURL.forPostId(post.src.isCrosspost)
+				LinkHandler.onLinkClicked(activity, crosspostOriginPost.toString())
+			}
 
 			Action.EXTERNAL -> {
 				try {
@@ -706,6 +716,18 @@ object RedditPostActions {
 					Action.COMMENTS
 				)
 			)
+		}
+		if (post.src.isCrosspost != null) {
+			if (itemPref.contains(Action.CROSSPOST_ORIGIN)) {
+				menu.add(
+						RPVMenuItem(
+								String.format(
+										activity.getText(R.string.action_crosspost_origin).toString(),
+								),
+								Action.CROSSPOST_ORIGIN
+						)
+				)
+			}
 		}
 		if (!RedditAccountManager.getInstance(activity).defaultAccount.isAnonymous) {
 			if (itemPref.contains(Action.SAVE)) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/api/RedditPostActions.kt
@@ -50,7 +50,6 @@ import org.quantumbadger.redreader.common.PrefsUtility
 import org.quantumbadger.redreader.common.PrefsUtility.PostFlingAction
 import org.quantumbadger.redreader.common.RRError
 import org.quantumbadger.redreader.common.UriString
-import org.quantumbadger.redreader.common.RRError
 import org.quantumbadger.redreader.common.time.TimestampUTC
 import org.quantumbadger.redreader.fragments.PostPropertiesDialog
 import org.quantumbadger.redreader.reddit.APIResponseHandler.ActionResponseHandler
@@ -390,7 +389,7 @@ object RedditPostActions {
 
 			Action.CROSSPOST_ORIGIN -> {
 				val crosspostOriginPost = PostCommentListingURL.forPostId(post.src.isCrosspost)
-				LinkHandler.onLinkClicked(activity, crosspostOriginPost.toString())
+				LinkHandler.onLinkClicked(activity, crosspostOriginPost.toUriString())
 			}
 
 			Action.EXTERNAL -> {

--- a/src/main/java/org/quantumbadger/redreader/reddit/kthings/RedditPost.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/kthings/RedditPost.kt
@@ -40,6 +40,7 @@ data class RedditPost(
 	val num_comments: Int,
 	val score: Int,
 	val gilded: Int = 0,
+	val crosspost_parent: String? = null,
 	val upvote_ratio: Double? = null,
 	val archived: Boolean = false,
 	val over_18: Boolean = false,

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditParsedPost.kt
@@ -32,7 +32,7 @@ class RedditParsedPost(
 	parseSelfText: Boolean
 ) : RedditThingWithIdAndType {
 
-    val title: String = src.title?.decoded?.replace('\n', ' ')?.trim() ?: "[null]"
+	val title: String = src.title?.decoded?.replace('\n', ' ')?.trim() ?: "[null]"
 
 	val url: UriString?
 	val selfText: BodyElement?
@@ -95,6 +95,8 @@ class RedditParsedPost(
 	val commentCount = src.num_comments
 
 	val goldAmount = src.gilded
+
+	val isCrosspost = src.crosspost_parent
 
 	val isNsfw = src.over_18
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -243,6 +243,22 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 			}
 		}
 
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.CROSSPOST)) {
+			if(src.isCrosspost() != null) {
+				postListDescSb.append(
+						" "
+								+ context.getString(R.string.crosspost)
+								+ " ",
+						BetterSSB.BOLD
+								| BetterSSB.FOREGROUND_COLOR
+								| BetterSSB.BACKGROUND_COLOR,
+						rrCrosspostTextCol,
+						rrCrosspostBackCol,
+						1f);
+				postListDescSb.append("  ", 0);
+			}
+		}
+
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.NSFW)) {
 			if(src.isNsfw()) {
 				postListDescSb.append(
@@ -399,21 +415,6 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.DOMAIN)) {
 			postListDescSb.append("(" + src.getDomain() + ")", 0);
-		}
-
-		//show crosspost at the end
-		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.CROSSPOST)) {
-			if(src.isCrosspost() != null) {
-				postListDescSb.append(" ", 0);
-				postListDescSb.append(
-						" "
-								+ context.getString(R.string.crosspost)
-								+ BetterSSB.NBSP,
-						BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR,
-						rrCrosspostTextCol,
-						rrCrosspostBackCol,
-						1f);
-			}
 		}
 
 		return postListDescSb.get();

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditPreparedPost.java
@@ -178,7 +178,9 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 				R.attr.rrFlairBackCol,
 				R.attr.rrFlairTextCol,
 				R.attr.rrGoldTextCol,
-				R.attr.rrGoldBackCol
+				R.attr.rrGoldBackCol,
+				R.attr.rrCrosspostTextCol,
+				R.attr.rrCrosspostBackCol
 		});
 
 		final int boldCol;
@@ -194,6 +196,8 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 		final int rrFlairTextCol = appearance.getColor(4, 255);
 		final int rrGoldTextCol = appearance.getColor(5, 255);
 		final int rrGoldBackCol = appearance.getColor(6, 255);
+		final int rrCrosspostTextCol = appearance.getColor(7, 255);
+		final int rrCrosspostBackCol = appearance.getColor(8, 255);
 
 		appearance.recycle();
 
@@ -395,6 +399,21 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 
 		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.DOMAIN)) {
 			postListDescSb.append("(" + src.getDomain() + ")", 0);
+		}
+
+		//show crosspost at the end
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.CROSSPOST)) {
+			if(src.isCrosspost() != null) {
+				postListDescSb.append(" ", 0);
+				postListDescSb.append(
+						" "
+								+ context.getString(R.string.crosspost)
+								+ BetterSSB.NBSP,
+						BetterSSB.FOREGROUND_COLOR | BetterSSB.BACKGROUND_COLOR,
+						rrCrosspostTextCol,
+						rrCrosspostBackCol,
+						1f);
+			}
 		}
 
 		return postListDescSb.get();
@@ -662,6 +681,15 @@ public final class RedditPreparedPost implements RedditChangeDataManager.Listene
 										: R.string.accessibility_subtitle_flair_withperiod,
 								src.getFlairText()
 										+ General.LTR_OVERRIDE_MARK))
+						.append(separator);
+			}
+		}
+
+		if(mPostSubtitleItems.contains(PrefsUtility.AppearancePostSubtitleItem.CROSSPOST)) {
+			if(src.isCrosspost() != null) {
+				a11yEmbellish
+						.append(context.getString(
+								R.string.accessibility_subtitle_crosspost))
 						.append(separator);
 			}
 		}

--- a/src/main/java/org/quantumbadger/redreader/reddit/url/RedditURLParser.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/url/RedditURLParser.java
@@ -281,15 +281,18 @@ public class RedditURLParser {
 			return builder.toString();
 		}
 
+		@NonNull
 		public UriString browserUrl() {
 			return new UriString(Constants.Reddit.SCHEME_HTTPS + "://" + humanReadableUrl());
 		}
 
 		@Override
+		@NonNull
 		public String toString() {
 			return generateJsonUri().toString();
 		}
 
+		@NonNull
 		public UriString toUriString() {
 			return new UriString(toString());
 		}

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -441,6 +441,7 @@
         <item>@string/action_upvote</item>
         <item>@string/action_downvote</item>
 		<item>@string/action_comments</item>
+		<item>@string/action_crosspost_origin</item>
         <item>@string/action_save</item>
         <item>@string/action_hide</item>
         <item>@string/action_delete</item>
@@ -469,6 +470,7 @@
         <item>upvote</item>
         <item>downvote</item>
 		<item>comments</item>
+		<item>crosspost_origin</item>
         <item>save</item>
         <item>hide</item>
         <item>delete</item>
@@ -1134,6 +1136,7 @@
 		<item>user_profile</item>
 		<item>properties</item>
 		<item>edit</item>
+		<item>crosspost_origin</item>
 	</string-array>
 
 	<!-- 2020-10-31 -->

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -877,6 +877,7 @@
 		<item>@string/pref_appearance_post_subtitle_items_sticky</item>
 		<item>@string/pref_appearance_post_subtitle_items_spoiler</item>
 		<item>@string/pref_appearance_post_subtitle_items_nsfw</item>
+		<item>@string/pref_appearance_post_subtitle_items_crosspost</item>
 	</string-array>
 
 	<!-- Constants. Do not change. -->
@@ -893,6 +894,7 @@
 		<item>sticky</item>
 		<item>spoiler</item>
 		<item>nsfw</item>
+		<item>crosspost</item>
 	</string-array>
 
 	<!-- Constants. Do not change. -->
@@ -907,6 +909,7 @@
 		<item>sticky</item>
 		<item>spoiler</item>
 		<item>nsfw</item>
+		<item>crosspost</item>
 	</string-array>
 
 	<!-- 2020-02-05 -->

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -55,6 +55,8 @@
     <attr name="rrGoldBackCol" format="color" />
     <attr name="rrGoldTextCol" format="color" />
 	<attr name="rrPostInlinePreviewDivider" format="color" />
+	<attr name="rrCrosspostBackCol" format="color" />
+	<attr name="rrCrosspostTextCol" format="color" />
 
     <attr name="rrCommentBodyCol" format="color" />
     <attr name="rrCommentHeaderCol" format="color" />

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1914,4 +1914,7 @@
 	<string name="pref_behaviour_mark_posts_as_read_key" translatable="false">pref_behaviour_mark_posts_as_read</string>
 	<string name="pref_behaviour_mark_posts_as_read_title">Mark posts as read</string>
 
+	<string name="crosspost">Crosspost</string>
+	<string name="pref_appearance_post_subtitle_items_crosspost">Crosspost tag</string>
+	<string name="accessibility_subtitle_crosspost">Crosspost.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1917,4 +1917,5 @@
 	<string name="crosspost">Crosspost</string>
 	<string name="pref_appearance_post_subtitle_items_crosspost">Crosspost tag</string>
 	<string name="accessibility_subtitle_crosspost">Crosspost.</string>
+	<string name="action_crosspost_origin">Go to Crosspost Origin</string>
 </resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -91,6 +91,8 @@
         <item name="rrFlairTextCol">#AAAAAA</item>
         <item name="rrGoldBackCol">#B0923C</item>
         <item name="rrGoldTextCol">#000000</item>
+		<item name="rrCrosspostBackCol">#87CEEB</item>
+		<item name="rrCrosspostTextCol">#333333</item>
 
 		<item name="rrPostToolbarCol">#181818</item>
 
@@ -195,6 +197,8 @@
 		<item name="rrFlairTextCol">#AAAAAA</item>
 		<item name="rrGoldBackCol">#B0923C</item>
 		<item name="rrGoldTextCol">#000000</item>
+		<item name="rrCrosspostBackCol">#87CEEB</item>
+		<item name="rrCrosspostTextCol">#333333</item>
 
 		<!-- Comment -->
 
@@ -263,6 +267,8 @@
 		<item name="rrFlairTextCol">#AAAAAA</item>
 		<item name="rrGoldBackCol">#B0923C</item>
 		<item name="rrGoldTextCol">#000000</item>
+		<item name="rrCrosspostBackCol">#87CEEB</item>
+		<item name="rrCrosspostTextCol">#333333</item>
 
 		<item name="rrPostToolbarCol">#000000</item>
 
@@ -387,6 +393,8 @@
         <item name="rrFlairTextCol">#444444</item>
         <item name="rrGoldBackCol">#FFDF52</item>
         <item name="rrGoldTextCol">#000000</item>
+		<item name="rrCrosspostBackCol">#87CEEB</item>
+		<item name="rrCrosspostTextCol">#333333</item>
 
 		<item name="rrPostToolbarCol">#F2FBFB</item>
 

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -91,8 +91,8 @@
         <item name="rrFlairTextCol">#AAAAAA</item>
         <item name="rrGoldBackCol">#B0923C</item>
         <item name="rrGoldTextCol">#000000</item>
-		<item name="rrCrosspostBackCol">#87CEEB</item>
-		<item name="rrCrosspostTextCol">#333333</item>
+		<item name="rrCrosspostBackCol">#0288D1</item>
+		<item name="rrCrosspostTextCol">#FFFFFF</item>
 
 		<item name="rrPostToolbarCol">#181818</item>
 
@@ -197,8 +197,8 @@
 		<item name="rrFlairTextCol">#AAAAAA</item>
 		<item name="rrGoldBackCol">#B0923C</item>
 		<item name="rrGoldTextCol">#000000</item>
-		<item name="rrCrosspostBackCol">#87CEEB</item>
-		<item name="rrCrosspostTextCol">#333333</item>
+		<item name="rrCrosspostBackCol">#0288D1</item>
+		<item name="rrCrosspostTextCol">#FFFFFF</item>
 
 		<!-- Comment -->
 
@@ -267,8 +267,8 @@
 		<item name="rrFlairTextCol">#AAAAAA</item>
 		<item name="rrGoldBackCol">#B0923C</item>
 		<item name="rrGoldTextCol">#000000</item>
-		<item name="rrCrosspostBackCol">#87CEEB</item>
-		<item name="rrCrosspostTextCol">#333333</item>
+		<item name="rrCrosspostBackCol">#0288D1</item>
+		<item name="rrCrosspostTextCol">#FFFFFF</item>
 
 		<item name="rrPostToolbarCol">#000000</item>
 
@@ -393,8 +393,8 @@
         <item name="rrFlairTextCol">#444444</item>
         <item name="rrGoldBackCol">#FFDF52</item>
         <item name="rrGoldTextCol">#000000</item>
-		<item name="rrCrosspostBackCol">#87CEEB</item>
-		<item name="rrCrosspostTextCol">#333333</item>
+		<item name="rrCrosspostBackCol">#0288D1</item>
+		<item name="rrCrosspostTextCol">#FFFFFF</item>
 
 		<item name="rrPostToolbarCol">#F2FBFB</item>
 


### PR DESCRIPTION
Heyho, This PR adds support for indicating the existence and navigating to the origin of crossposts:

- If a post is a crosspost, it gets a blue "Crosspost" tag.
- An action menu item for posts "Go to Crosspost Origin" leads to the original post (crosspost_parent).

Closes #921 
Closes #791

For the future, the "view discussions in x other communities" function mentioned in #943 can be realised by creating a list from crosspost_parent_list