### PR TITLE
Add Submitted Comments to main menu user items

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -1,3 +1,6 @@
+/Alpha 353 (2024-06-16)
+Add Submitted Comments as an optional main menu user item (thanks to folkemat)
+
 /Alpha 352 (2024-06-16)
 Dependency updates and reorganisation (thanks to Alexey Rochev)
 Migrating from ExoPlayer to Media3 (thanks to Alexey Rochev)

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -4,6 +4,7 @@ Ability to upload an image when submitting a comment (thanks to folkemat)
 Dependency updates and reorganisation (thanks to Alexey Rochev)
 Migrating from ExoPlayer to Media3 (thanks to Alexey Rochev)
 Comments submitted by current user now have username highlighted (thanks to folkemat)
+Add Submitted Comments as an optional main menu user item (thanks to folkemat)
 Minimum supported Android version is now 5.0
 
 111/1.23.1

--- a/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/MainActivity.java
@@ -45,6 +45,7 @@ import org.quantumbadger.redreader.account.RedditAccountChangeListener;
 import org.quantumbadger.redreader.account.RedditAccountManager;
 import org.quantumbadger.redreader.adapters.MainMenuSelectionListener;
 import org.quantumbadger.redreader.common.AndroidCommon;
+import org.quantumbadger.redreader.common.Constants;
 import org.quantumbadger.redreader.common.DialogUtils;
 import org.quantumbadger.redreader.common.FeatureFlagHandler;
 import org.quantumbadger.redreader.common.General;
@@ -275,6 +276,16 @@ public class MainActivity extends RefreshableActivity
 
 			case MainMenuFragment.MENU_MENU_ACTION_SUBMITTED:
 				onSelected(UserPostListingURL.getSubmitted(username));
+				break;
+
+			case MainMenuFragment.MENU_MENU_ACTION_SUBMITTED_COMMENTS:
+				LinkHandler.onLinkClicked(
+						this,
+						Constants.Reddit.getUri(
+								"/user/" + username + "/comments.json"
+						).toString(),
+						false
+				);
 				break;
 
 			case MainMenuFragment.MENU_MENU_ACTION_SAVED:

--- a/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
+++ b/src/main/java/org/quantumbadger/redreader/adapters/MainMenuListingManager.java
@@ -353,6 +353,18 @@ public class MainMenuListingManager {
 									isFirst.getAndSet(false)));
 				}
 
+				if(mainMenuUserItems.contains(
+					MainMenuFragment.MainMenuUserItems.SUBMITTED_COMMENTS)
+				){
+					mAdapter.appendToGroup(
+							GROUP_USER_ITEMS,
+							makeItem(
+									R.string.mainmenu_submitted_comments,
+									MainMenuFragment.MENU_MENU_ACTION_SUBMITTED_COMMENTS,
+									rrIconSend,
+									isFirst.getAndSet(false)));
+				}
+
 				if(mainMenuUserItems.contains(MainMenuFragment.MainMenuUserItems.SAVED)) {
 					mAdapter.appendToGroup(
 							GROUP_USER_ITEMS,

--- a/src/main/java/org/quantumbadger/redreader/fragments/MainMenuFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/MainMenuFragment.java
@@ -59,24 +59,26 @@ public class MainMenuFragment extends RRFragment implements
 	public static final int MENU_MENU_ACTION_PROFILE = 1;
 	public static final int MENU_MENU_ACTION_INBOX = 2;
 	public static final int MENU_MENU_ACTION_SUBMITTED = 3;
-	public static final int MENU_MENU_ACTION_UPVOTED = 4;
-	public static final int MENU_MENU_ACTION_DOWNVOTED = 5;
-	public static final int MENU_MENU_ACTION_SAVED = 6;
-	public static final int MENU_MENU_ACTION_MODMAIL = 7;
-	public static final int MENU_MENU_ACTION_HIDDEN = 8;
-	public static final int MENU_MENU_ACTION_CUSTOM = 9;
-	public static final int MENU_MENU_ACTION_ALL = 10;
-	public static final int MENU_MENU_ACTION_POPULAR = 11;
-	public static final int MENU_MENU_ACTION_RANDOM = 12;
-	public static final int MENU_MENU_ACTION_RANDOM_NSFW = 13;
-	public static final int MENU_MENU_ACTION_SENT_MESSAGES = 14;
-	public static final int MENU_MENU_ACTION_FIND_SUBREDDIT = 15;
+	public static final int MENU_MENU_ACTION_SUBMITTED_COMMENTS = 4;
+	public static final int MENU_MENU_ACTION_UPVOTED = 5;
+	public static final int MENU_MENU_ACTION_DOWNVOTED = 6;
+	public static final int MENU_MENU_ACTION_SAVED = 7;
+	public static final int MENU_MENU_ACTION_MODMAIL = 8;
+	public static final int MENU_MENU_ACTION_HIDDEN = 9;
+	public static final int MENU_MENU_ACTION_CUSTOM = 10;
+	public static final int MENU_MENU_ACTION_ALL = 11;
+	public static final int MENU_MENU_ACTION_POPULAR = 12;
+	public static final int MENU_MENU_ACTION_RANDOM = 13;
+	public static final int MENU_MENU_ACTION_RANDOM_NSFW = 14;
+	public static final int MENU_MENU_ACTION_SENT_MESSAGES = 15;
+	public static final int MENU_MENU_ACTION_FIND_SUBREDDIT = 16;
 
 	@IntDef({
 			MENU_MENU_ACTION_FRONTPAGE,
 			MENU_MENU_ACTION_PROFILE,
 			MENU_MENU_ACTION_INBOX,
 			MENU_MENU_ACTION_SUBMITTED,
+			MENU_MENU_ACTION_SUBMITTED_COMMENTS,
 			MENU_MENU_ACTION_UPVOTED,
 			MENU_MENU_ACTION_DOWNVOTED,
 			MENU_MENU_ACTION_SAVED,
@@ -206,7 +208,8 @@ public class MainMenuFragment extends RRFragment implements
 	}
 
 	public enum MainMenuUserItems {
-		PROFILE, INBOX, SUBMITTED, SAVED, HIDDEN, UPVOTED, DOWNVOTED, MODMAIL, SENT_MESSAGES
+		PROFILE, INBOX, SUBMITTED, SUBMITTED_COMMENTS, SAVED,
+		HIDDEN, UPVOTED, DOWNVOTED, MODMAIL, SENT_MESSAGES
 	}
 
 	public enum MainMenuShortcutItems {

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -630,6 +630,7 @@
         <item>@string/mainmenu_inbox</item>
         <item>@string/mainmenu_sent_messages</item>
         <item>@string/mainmenu_submitted</item>
+		<item>@string/mainmenu_submitted_comments</item>
         <item>@string/mainmenu_saved</item>
         <item>@string/mainmenu_hidden</item>
         <item>@string/mainmenu_upvoted</item>
@@ -643,6 +644,7 @@
         <item>inbox</item>
         <item>sent_messages</item>
         <item>submitted</item>
+		<item>submitted_comments</item>
         <item>saved</item>
         <item>hidden</item>
         <item>upvoted</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1853,4 +1853,7 @@
 
 	<string name="pref_appearance_highlight_own_username_key" translatable="false">pref_appearance_highlight_own_username</string>
 	<string name="pref_appearance_highlight_own_username_title">Highlight your own username in comments</string>
+
+	<!-- 2024-06-16 -->
+	<string name="mainmenu_submitted_comments">Submitted Comments</string>
 </resources>


### PR DESCRIPTION
Hi, this PR adds a new user item "Submitted Comments" to the main menu, directly under Submitted Posts. 

In my opinion, it was inconsistent that this did not exist. It has the same icon as Submitted Posts to identify it as a submitted item. It looks quite good this way, I think.

Closes #1073