### PR TITLE
Highlight own username in comments

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -1,5 +1,6 @@
 /Alpha 350 (2024-04-14)
 Ability to upload an image when submitting a comment (thanks to folkemat)
+Comments submitted by current user now have username highlighted (thanks to folkemat)
 
 /Alpha 349 (2024-03-24)
 Ability to block users in user profile (thanks to folkemat)

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -2,6 +2,7 @@
 Ability to block users in user profile (thanks to folkemat)
 Ability to upload an image when submitting a comment (thanks to folkemat)
 Dependency updates and reorganisation (thanks to Alexey Rochev)
+Comments submitted by current user now have username highlighted (thanks to folkemat)
 
 111/1.23.1
 Added a preference to automatically open the first image in an album

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -121,6 +121,8 @@ public final class PrefsUtility {
 						R.string.pref_appearance_hide_headertoolbar_postlist_key))
 				|| key.equals(context.getString(
 					R.string.pref_appearance_hide_comments_from_blocked_users_key))
+				|| key.equals(context.getString(
+						R.string.pref_appearance_highlight_own_username_key))
 				|| key.equals(context.getString(R.string.pref_images_thumbnail_size_key))
 				|| key.equals(context.getString(R.string.pref_images_inline_image_previews_key))
 				|| key.equals(context.getString(
@@ -582,6 +584,12 @@ public final class PrefsUtility {
 		return getBoolean(
 				R.string.pref_appearance_hide_comments_from_blocked_users_key,
 				false);
+	}
+
+	public static boolean pref_appearance_highlight_own_username() {
+		return getBoolean(
+				R.string.pref_appearance_highlight_own_username_key,
+				true);
 	}
 
 	public enum AppearancePostSubtitleItem {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -148,6 +148,13 @@ public class RedditRenderableComment
 			} else if("admin".equals(rawComment.getDistinguished())) {
 				setBackgroundColour = true;
 				backgroundColour = Color.rgb(170, 0, 0);
+
+			} else if(rawComment.getAuthor().getDecoded().equalsIgnoreCase(
+					mCurrentCanonicalUserName)) {
+				if (PrefsUtility.pref_appearance_highlight_own_username()){
+					setBackgroundColour = true;
+					backgroundColour = Color.rgb(254, 187, 50);
+				}
 			}
 
 			if(setBackgroundColour) {

--- a/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/prepared/RedditRenderableComment.java
@@ -153,7 +153,7 @@ public class RedditRenderableComment
 					mCurrentCanonicalUserName)) {
 				if (PrefsUtility.pref_appearance_highlight_own_username()){
 					setBackgroundColour = true;
-					backgroundColour = Color.rgb(254, 187, 50);
+					backgroundColour = Color.rgb(0xEF, 0x6C, 0x00);
 				}
 			}
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1853,4 +1853,7 @@
 	<!-- 2024-04-14 -->
 	<string name="comment_upload_picture">Upload picture</string>
 	<string name="comment_picture_pretext">Picture</string>
+
+	<string name="pref_appearance_highlight_own_username_key" translatable="false">pref_appearance_highlight_own_username</string>
+	<string name="pref_appearance_highlight_own_username_title">Highlight your own username in comments</string>
 </resources>

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -175,6 +175,11 @@
 				android:key="@string/pref_appearance_hide_comments_from_blocked_users_key"
 				android:defaultValue="true"/>
 
+		<CheckBoxPreference
+				android:title="@string/pref_appearance_highlight_own_username_title"
+				android:key="@string/pref_appearance_highlight_own_username_key"
+				android:defaultValue="true"/>
+
     </PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/pref_appearance_user_header">


### PR DESCRIPTION
Hi, this little PR adds an option to highlight your username in comments, which is enabled by default.

I find this useful to make it easier to distinguish your own comments from others. It improves the readability of comment chains. 