### PR TITLE
Add frame step buttons to internal video player

### DIFF
--- a/src/main/assets/changelog-alpha.txt
+++ b/src/main/assets/changelog-alpha.txt
@@ -1,3 +1,6 @@
+/Alpha 360 (2025-04-21)
+Added video frame step controls (thanks to ecawthorne and japanesephundroid)
+
 /Alpha 359 (2025-04-20)
 Added support for emotes in comment flairs (thanks to bharatknv)
 Added "Mark as Read/Unread" fling action, and optional context menu item (thanks to JoshAusHessen and codeofdusk)

--- a/src/main/assets/changelog.txt
+++ b/src/main/assets/changelog.txt
@@ -1,5 +1,6 @@
 114/1.25
 Added video playback speed control (thanks to folkemat)
+Added video frame step controls (thanks to ecawthorne and japanesephundroid)
 Added support for emotes in comment flairs (thanks to bharatknv)
 Show label on crossposts, and add "Go to Crosspost Origin" to post menu (thanks to folkemat)
 Added "Mark as Read/Unread" fling action, and optional post menu item (thanks to JoshAusHessen and codeofdusk)

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -802,6 +802,11 @@ public final class PrefsUtility {
 				true);
 	}
 
+	public static boolean pref_behaviour_video_frame_step() {
+		return getBoolean(R.string.pref_behaviour_video_frame_step_key,
+				false);
+	}
+
 	public static boolean pref_behaviour_video_mute_default() {
 		return getBoolean(
 				R.string.pref_behaviour_video_mute_default_key,

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -47,7 +47,6 @@ import androidx.media3.ui.PlayerView;
 import androidx.media3.ui.TimeBar;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.AndroidCommon;
 import org.quantumbadger.redreader.common.General;
@@ -146,7 +145,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			addButton(createButton(
 					context,
 					mControlView,
-					R.drawable.icon_previous,
+					R.drawable.icon_restart,
 					R.string.video_restart,
 					view -> {
 						mVideoPlayer.seekTo(0);
@@ -178,7 +177,66 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						updateProgress();
 					});
 
-			addButton(mPlayButton, buttons);
+			if (PrefsUtility.pref_behaviour_video_frame_step()) {
+				final AtomicReference<ImageButton> stepBackButton = new AtomicReference<>();
+				final AtomicReference<ImageButton> stepForwardButton = new AtomicReference<>();
+				stepBackButton.set(createButton(
+						context,
+						mControlView,
+						R.drawable.icon_step_back,
+						R.string.video_step_back,
+						view -> {
+							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - 33);
+							updateProgress();
+						}
+				));
+
+				stepForwardButton.set(createButton(
+						context,
+						mControlView,
+						R.drawable.icon_step_forward,
+						R.string.video_step_forward,
+						view -> {
+							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + 33);
+							updateProgress();
+						}
+				));
+
+				mVideoPlayer.addListener(new Player.Listener() {
+					@Override
+					public void onIsPlayingChanged(final boolean isPlaying) {
+						if (isPlaying) {
+							stepBackButton.get().setImageAlpha(0x3F);
+							stepBackButton.get().setContentDescription(
+									context.getString(R.string.video_step_back_disabled));
+							stepBackButton.get().setEnabled(false);
+
+							stepForwardButton.get().setImageAlpha(0x3F);
+							stepForwardButton.get().setContentDescription(
+									context.getString(R.string.video_step_forward_disabled));
+							stepForwardButton.get().setEnabled(false);
+
+						} else {
+							stepBackButton.get().setImageAlpha(0xFF);
+							stepBackButton.get().setContentDescription(
+									context.getString(R.string.video_step_back));
+							stepBackButton.get().setEnabled(true);
+
+							stepForwardButton.get().setImageAlpha(0xFF);
+							stepForwardButton.get().setContentDescription(
+									context.getString(R.string.video_step_forward));
+							stepForwardButton.get().setEnabled(true);
+						}
+					}
+				});
+
+				addButton(stepBackButton.get(), buttons);
+				addButton(mPlayButton, buttons);
+				addButton(stepForwardButton.get(), buttons);
+
+			} else {
+				addButton(mPlayButton, buttons);
+			}
 
 			addButton(createButton(
 					context,

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -35,11 +35,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.annotation.StringRes;
+
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.ExoPlayer;
-import androidx.media3.exoplayer.SeekParameters;
 import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -181,13 +181,16 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			if (PrefsUtility.pref_behaviour_video_frame_step()) {
 				final AtomicReference<ImageButton> stepBackButton = new AtomicReference<>();
 				final AtomicReference<ImageButton> stepForwardButton = new AtomicReference<>();
+				final long frameRate = mVideoPlayer.getVideoFormat() != null
+						? 1000 / (long) mVideoPlayer.getVideoFormat().frameRate
+						: 33;
+
 				stepBackButton.set(createButton(
 						context,
 						mControlView,
 						R.drawable.icon_step_back,
 						R.string.video_step_back,
 						view -> {
-							long frameRate = mVideoPlayer.getVideoFormat() != null ?  30 : (long) mVideoPlayer.getVideoFormat().frameRate;
 							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - frameRate);
 							updateProgress();
 						}
@@ -199,7 +202,6 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						R.drawable.icon_step_forward,
 						R.string.video_step_forward,
 						view -> {
-							long frameRate = mVideoPlayer.getVideoFormat() != null ?  30 : (long) mVideoPlayer.getVideoFormat().frameRate;
 							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + frameRate);
 							updateProgress();
 						}

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -39,6 +39,7 @@ import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.SeekParameters;
 import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -186,7 +187,8 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						R.drawable.icon_step_back,
 						R.string.video_step_back,
 						view -> {
-							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - 33);
+							long frameRate = mVideoPlayer.getVideoFormat() != null ?  30 : (long) mVideoPlayer.getVideoFormat().frameRate;
+							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - frameRate);
 							updateProgress();
 						}
 				));
@@ -197,7 +199,8 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						R.drawable.icon_step_forward,
 						R.string.video_step_forward,
 						view -> {
-							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + 33);
+							long frameRate = mVideoPlayer.getVideoFormat() != null ?  30 : (long) mVideoPlayer.getVideoFormat().frameRate;
+							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + frameRate);
 							updateProgress();
 						}
 				));

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -179,13 +179,11 @@ public class ExoPlayerWrapperView extends FrameLayout {
 					});
 
 			if (PrefsUtility.pref_behaviour_video_frame_step()) {
-				final AtomicReference<ImageButton> stepBackButton = new AtomicReference<>();
-				final AtomicReference<ImageButton> stepForwardButton = new AtomicReference<>();
 				final long frameDuration = (long)(1000f / (mVideoPlayer.getVideoFormat() != null
 						? mVideoPlayer.getVideoFormat().frameRate
 						: 30));
 
-				stepBackButton.set(createButton(
+				final ImageButton stepBackButton = createButton(
 						context,
 						mControlView,
 						R.drawable.icon_step_back,
@@ -194,9 +192,9 @@ public class ExoPlayerWrapperView extends FrameLayout {
 							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - frameDuration);
 							updateProgress();
 						}
-				));
+				);
 
-				stepForwardButton.set(createButton(
+				final ImageButton stepForwardButton = createButton(
 						context,
 						mControlView,
 						R.drawable.icon_step_forward,
@@ -205,39 +203,39 @@ public class ExoPlayerWrapperView extends FrameLayout {
 							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + frameDuration);
 							updateProgress();
 						}
-				));
+				);
 
 				mVideoPlayer.addListener(new Player.Listener() {
 					@Override
 					public void onIsPlayingChanged(final boolean isPlaying) {
 						if (isPlaying) {
-							stepBackButton.get().setImageAlpha(0x3F);
-							stepBackButton.get().setContentDescription(
+							stepBackButton.setImageAlpha(0x3F);
+							stepBackButton.setContentDescription(
 									context.getString(R.string.video_step_back_disabled));
-							stepBackButton.get().setEnabled(false);
+							stepBackButton.setEnabled(false);
 
-							stepForwardButton.get().setImageAlpha(0x3F);
-							stepForwardButton.get().setContentDescription(
+							stepForwardButton.setImageAlpha(0x3F);
+							stepForwardButton.setContentDescription(
 									context.getString(R.string.video_step_forward_disabled));
-							stepForwardButton.get().setEnabled(false);
+							stepForwardButton.setEnabled(false);
 
 						} else {
-							stepBackButton.get().setImageAlpha(0xFF);
-							stepBackButton.get().setContentDescription(
+							stepBackButton.setImageAlpha(0xFF);
+							stepBackButton.setContentDescription(
 									context.getString(R.string.video_step_back));
-							stepBackButton.get().setEnabled(true);
+							stepBackButton.setEnabled(true);
 
-							stepForwardButton.get().setImageAlpha(0xFF);
-							stepForwardButton.get().setContentDescription(
+							stepForwardButton.setImageAlpha(0xFF);
+							stepForwardButton.setContentDescription(
 									context.getString(R.string.video_step_forward));
-							stepForwardButton.get().setEnabled(true);
+							stepForwardButton.setEnabled(true);
 						}
 					}
 				});
 
-				addButton(stepBackButton.get(), buttons);
+				addButton(stepBackButton, buttons);
 				addButton(mPlayButton, buttons);
-				addButton(stepForwardButton.get(), buttons);
+				addButton(stepForwardButton, buttons);
 
 			} else {
 				addButton(mPlayButton, buttons);

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -35,7 +35,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.annotation.StringRes;
-
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.util.UnstableApi;
@@ -48,6 +47,7 @@ import androidx.media3.ui.PlayerView;
 import androidx.media3.ui.TimeBar;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.quantumbadger.redreader.R;
 import org.quantumbadger.redreader.common.AndroidCommon;
 import org.quantumbadger.redreader.common.General;
@@ -181,9 +181,9 @@ public class ExoPlayerWrapperView extends FrameLayout {
 			if (PrefsUtility.pref_behaviour_video_frame_step()) {
 				final AtomicReference<ImageButton> stepBackButton = new AtomicReference<>();
 				final AtomicReference<ImageButton> stepForwardButton = new AtomicReference<>();
-				final long frameRate = mVideoPlayer.getVideoFormat() != null
-						? 1000 / (long) mVideoPlayer.getVideoFormat().frameRate
-						: 33;
+				final long frameDuration = (long)(1000f / (mVideoPlayer.getVideoFormat() != null
+						? mVideoPlayer.getVideoFormat().frameRate
+						: 30));
 
 				stepBackButton.set(createButton(
 						context,
@@ -191,7 +191,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						R.drawable.icon_step_back,
 						R.string.video_step_back,
 						view -> {
-							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - frameRate);
+							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() - frameDuration);
 							updateProgress();
 						}
 				));
@@ -202,7 +202,7 @@ public class ExoPlayerWrapperView extends FrameLayout {
 						R.drawable.icon_step_forward,
 						R.string.video_step_forward,
 						view -> {
-							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + frameRate);
+							mVideoPlayer.seekTo(mVideoPlayer.getCurrentPosition() + frameDuration);
 							updateProgress();
 						}
 				));

--- a/src/main/res/drawable/icon_restart.xml
+++ b/src/main/res/drawable/icon_restart.xml
@@ -1,0 +1,26 @@
+<!-- Copyright (C) 2024 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+	android:width="32dp"
+	android:height="32dp"
+	android:viewportHeight="24.0"
+	android:viewportWidth="24.0">
+
+	<path
+		android:fillColor="#FFFFFFFF"
+		android:pathData="M12,4C14.1,4 16.1,4.8 17.6,6.3C20.7,9.4 20.7,14.5 17.6,17.6C15.8,19.5 13.3,20.2 10.9,19.9L11.4,17.9C13.1,18.1 14.9,17.5 16.2,16.2C18.5,13.9 18.5,10.1 16.2,7.7C15.1,6.6 13.5,6 12,6V10.6L7,5.6L12,0.6V4M6.3,17.6C3.7,15 3.3,11 5.1,7.9L6.6,9.4C5.5,11.6 5.9,14.4 7.8,16.2C8.3,16.7 8.9,17.1 9.6,17.4L9,19.4C8,19 7.1,18.4 6.3,17.6Z"/>
+
+</vector>

--- a/src/main/res/drawable/icon_step_back.xml
+++ b/src/main/res/drawable/icon_step_back.xml
@@ -1,4 +1,4 @@
-<!-- Copyright (C) 2017 The Android Open Source Project
+<!-- Copyright (C) 2024 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -12,14 +12,17 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="32dp"
-    android:height="32dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0">
+	android:height="32dp"
+	android:viewportHeight="24.0"
+	android:viewportWidth="24.0">
 
-  <path
-      android:fillColor="#FFFFFFFF"
-      android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z"/>
+	<path
+	    android:fillColor="#FFFFFFFF"
+		android:pathData="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z"/>
 
 </vector>
+
+

--- a/src/main/res/drawable/icon_step_forward.xml
+++ b/src/main/res/drawable/icon_step_forward.xml
@@ -1,0 +1,26 @@
+<!-- Copyright (C) 2024 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+		android:width="32dp"
+		android:height="32dp"
+		android:viewportHeight="24.0"
+		android:viewportWidth="24.0">
+
+	<path
+			android:fillColor="#FFFFFFFF"
+			android:pathData="M16,18H18V6H16M6,18L14.5,12L6,6V18Z"/>
+
+</vector>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1482,9 +1482,13 @@
 	<string name="video_unmute">Unmute</string>
 	<string name="video_restart">Restart video</string>
 	<string name="video_rewind">Rewind</string>
+	<string name="video_step_back">Step back</string>
+	<string name="video_step_back_disabled">Step back disabled</string>
 	<string name="video_play">Play</string>
 	<string name="video_pause">Pause</string>
 	<string name="video_fast_forward">Fast forward</string>
+	<string name="video_step_forward">Step forward</string>
+	<string name="video_step_forward_disabled">Step forward disabled</string>
 	<string name="video_zoom_in">Zoom in</string>
 	<string name="video_zoom_out">Zoom out</string>
 
@@ -1910,4 +1914,8 @@
 	<string name="pref_appearance_post_subtitle_items_crosspost">Crosspost tag</string>
 	<string name="accessibility_subtitle_crosspost">Crosspost.</string>
 	<string name="action_crosspost_origin">Go to Crosspost Origin</string>
+
+	<string name="pref_behaviour_video_frame_step_title">Enable stepping frame by frame</string>
+	<string name="pref_behaviour_video_frame_step_key" translatable="false">pref_behaviour_video_frame_step</string>
+
 </resources>

--- a/src/main/res/xml/prefs_images_video.xml
+++ b/src/main/res/xml/prefs_images_video.xml
@@ -43,6 +43,10 @@
 							android:key="@string/pref_behaviour_video_playback_controls_key"
 							android:defaultValue="true"/>
 
+		<CheckBoxPreference android:title="@string/pref_behaviour_video_frame_step_title"
+							android:key="@string/pref_behaviour_video_frame_step_key"
+							android:defaultValue="false"/>
+
 		<CheckBoxPreference android:title="@string/pref_behaviour_video_mute_default_title"
 							android:key="@string/pref_behaviour_video_mute_default_key"
 							android:defaultValue="true"/>


### PR DESCRIPTION
Hi! This PR is based on #716. It adds an option for stepping through videos approximately frame by frame. 

The setting is disabled by default and the new buttons are grayed out and disabled when playing as per this comment https://github.com/QuantumBadger/RedReader/pull/716#issuecomment-594867307 by @QuantumBadger 

> Thanks! This looks good to me, when I get a chance I'll test/merge it and maybe add new icons.
> 
> I think it would be good to keep the new buttons hidden by default and have a preference to enable them, but I'm happy to do this if it's not clear how.
> 
> It might also be worth greying out the buttons while the video isn't paused (which may require another set of icons in a different colour).

I apologize if I'm stepping on any toes, there's been no activity on #716 for over a year so I figured I'd pick it up. Any feedback or suggestions are very welcome if there's more that needs to be done.

<img src="https://github.com/user-attachments/assets/79143e74-142b-429b-a2ea-aeccaeeef97f" height="400" />
<img src="https://github.com/user-attachments/assets/28d8d52b-7446-4ff9-8e0c-feea43e9a0a3" height="400" />
<img src="https://github.com/user-attachments/assets/d71b6b24-3e8b-4eb9-bcba-363a8ca70083" height="400" />
