### PR TITLE
Mark all inbox messages as read when leaving the inbox

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/InboxListingActivity.java
@@ -485,7 +485,8 @@ public final class InboxListingActivity extends ViewsBaseActivity {
 
 		menu.add(0, OPTIONS_MENU_MARK_ALL_AS_READ, 0, R.string.mark_all_as_read);
 		menu.add(0, OPTIONS_MENU_SHOW_UNREAD_ONLY, 1, R.string.inbox_unread_only);
-		menu.add(0, OPTIONS_MENU_MARK_INBOX_AS_READ_WHEN_BACK, 2, R.string.mark_inbox_as_read_when_back);
+		menu.add(0, OPTIONS_MENU_MARK_INBOX_AS_READ_WHEN_BACK,
+				2, R.string.mark_inbox_as_read_when_back);
 		menu.getItem(1).setCheckable(true);
 		if(mOnlyShowUnread) {
 			menu.getItem(1).setChecked(true);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1894,4 +1894,7 @@
 
 	<string name="error_invalid_account_title">Invalid account</string>
 	<string name="error_invalid_account_message">Selected account is not currently logged in</string>
+
+	<!-- 2024-07-20 -->
+	<string name="mark_inbox_as_read_when_back">Read all when leaving</string>
 </resources>


### PR DESCRIPTION
I found it annoying to constantly have to press ‘Mark all as read’ in the inbox menu. So this PR adds the option to automatically mark all messages as read when you leave the inbox, toggled via a checkbox in the inbox menu. 
