### PR TITLE
Ability to mark individual messages as read in the inbox

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -118,6 +118,8 @@ public final class PrefsUtility {
 				|| key.equals(context.getString(
 						R.string.pref_behaviour_blocked_subredditsort_key))
 				|| key.equals(context.getString(
+				R.string.pref_behaviour_inbox_tapping_is_reading_key))
+				|| key.equals(context.getString(
 						R.string.pref_appearance_hide_headertoolbar_commentlist_key))
 				|| key.equals(context.getString(
 						R.string.pref_appearance_hide_headertoolbar_postlist_key))
@@ -884,6 +886,12 @@ public final class PrefsUtility {
 	public static boolean pref_behaviour_post_title_opens_comments() {
 		return getBoolean(
 				R.string.pref_behaviour_post_title_opens_comments_key,
+				false);
+	}
+
+	public static boolean pref_behaviour_inbox_tapping_is_reading() {
+		return getBoolean(
+				R.string.pref_behaviour_inbox_tapping_is_reading_key,
 				false);
 	}
 

--- a/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
+++ b/src/main/java/org/quantumbadger/redreader/reddit/RedditAPI.java
@@ -487,6 +487,41 @@ public final class RedditAPI {
 				}));
 	}
 
+	public static void markMessageAsRead(
+			final CacheManager cm,
+			final APIResponseHandler.ActionResponseHandler responseHandler,
+			final RedditAccount user,
+			final String messageId,
+			final Context context) {
+
+		final LinkedList<PostField> postFields = new LinkedList<>();
+
+		postFields.add(new PostField("id", messageId));
+
+		cm.makeRequest(createPostRequestUnprocessedResponse(
+				Constants.Reddit.getUri("/api/read_message"),
+				user,
+				postFields,
+				context,
+				new CacheRequestCallbacks() {
+					@Override
+					public void onFailure(@NonNull final RRError error) {
+						responseHandler.notifyFailure(error);
+					}
+
+					@Override
+					public void onDataStreamComplete(
+							@NonNull final GenericFactory<SeekableInputStream, IOException> stream,
+							final TimestampUTC timestamp,
+							@NonNull final UUID session,
+							final boolean fromCache,
+							@Nullable final String mimetype) {
+
+						responseHandler.notifySuccess();
+					}
+				}));
+	}
+
 	public static void editComment(
 			final CacheManager cm,
 			final APIResponseHandler.ActionResponseHandler responseHandler,

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1902,4 +1902,9 @@
 	<string name="album_grid_pref_horizontal_padding">Horizontal padding</string>
 
 	<string name="album_pref_compact_title">Compact title</string>
+
+	<!-- 2024-09-06 -->
+	<string name="pref_behaviour_inbox_header">Inbox</string>
+	<string name="pref_behaviour_inbox_tapping_is_reading_key" translatable="false">pref_behaviour_inbox_tapping_is_reading</string>
+	<string name="pref_behaviour_inbox_tapping_is_reading_title">Tapping a message marks it as read</string>
 </resources>

--- a/src/main/res/xml/prefs_behaviour.xml
+++ b/src/main/res/xml/prefs_behaviour.xml
@@ -200,6 +200,14 @@
 
     </PreferenceCategory>
 
+	<PreferenceCategory android:title="@string/pref_behaviour_inbox_header">
+
+		<CheckBoxPreference android:title="@string/pref_behaviour_inbox_tapping_is_reading_title"
+				android:key="@string/pref_behaviour_inbox_tapping_is_reading_key"
+				android:defaultValue="false"/>
+
+	</PreferenceCategory>
+
 	<PreferenceCategory android:title="@string/pref_behaviour_sharing_header">
 
 		<ListPreference android:title="@string/pref_behaviour_sharing_domain_title"


### PR DESCRIPTION
Hi, this PR implements the “read_message” function of the Reddit API, which allows to mark individual messages as read. 
A message that is tapped on in the inbox now gets individually marked as read.
I have disabled this option by default, but maybe it's not a big stretch to enable it by default.

Closes #554
