### PR TITLE
Add preference to disable video autoplay

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/common/FeatureFlagHandler.java
+++ b/src/main/java/org/quantumbadger/redreader/common/FeatureFlagHandler.java
@@ -59,7 +59,8 @@ public final class FeatureFlagHandler {
 		DEFAULT_PREF_VIDEO_PLAYBACK_CONTROLS("defaultPrefVideoPlaybackControls"),
 		DEFAULT_PREF_CUSTOM_TABS("defaultPrefCustomTabs"),
 		CROSSPOST_ORIGIN_MENU_ITEM("crosspostOriginMenuItem"),
-		MAIN_MENU_RANDOM_REMOVED("mainMenuRandomRemoved");
+		MAIN_MENU_RANDOM_REMOVED("mainMenuRandomRemoved"),
+		DEFAULT_PREF_VIDEO_AUTOPLAY("defaultPrefVideoAutoplay");
 
 		@NonNull private final String id;
 
@@ -348,6 +349,15 @@ public final class FeatureFlagHandler {
 				prefs.edit().putStringSet(
 						context.getString(R.string.pref_menus_mainmenu_shortcutitems_key),
 						existingShortcutPreferences).apply();
+			}
+
+			if(getAndSetFeatureFlag(prefs, FeatureFlag.DEFAULT_PREF_VIDEO_AUTOPLAY)
+					== FeatureFlagStatus.UPGRADE_NEEDED) {
+
+				prefs.edit().putBoolean(
+								context.getString(R.string.pref_behaviour_video_autoplay_key),
+								true)
+						.apply();
 			}
 		});
 	}

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -813,6 +813,12 @@ public final class PrefsUtility {
 				true);
 	}
 
+	public static boolean pref_behaviour_video_autoplay() {
+		return getBoolean(
+				R.string.pref_behaviour_video_autoplay_key,
+				true);
+	}
+
 	public static boolean pref_behaviour_video_zoom_default() {
 		return getBoolean(R.string.pref_behaviour_video_zoom_default_key,
 				false);

--- a/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
+++ b/src/main/java/org/quantumbadger/redreader/views/video/ExoPlayerWrapperView.java
@@ -109,7 +109,15 @@ public class ExoPlayerWrapperView extends FrameLayout {
 
 		mVideoPlayer.setRepeatMode(Player.REPEAT_MODE_ONE);
 
-		mVideoPlayer.setPlayWhenReady(true);
+		// Autoplay cannot be disabled if video controls are disabled
+		if(
+			PrefsUtility.pref_behaviour_video_playback_controls()
+				&& !PrefsUtility.pref_behaviour_video_autoplay()
+		) {
+			mVideoPlayer.setPlayWhenReady(false);
+		} else {
+			mVideoPlayer.setPlayWhenReady(true);
+		}
 
 		if(PrefsUtility.pref_behaviour_video_zoom_default()) {
 			videoPlayerView.setResizeMode(AspectRatioFrameLayout.RESIZE_MODE_ZOOM);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1921,4 +1921,9 @@
 	<!-- 2025-11-08 -->
 	<string name="login_reddit_error_title">Reddit login issue</string>
 	<string name="login_reddit_error_message">There was a problem logging into Reddit. Try again in an different browser?</string>
+
+	<!-- 2024-11-15 -->
+	<string name="pref_behaviour_video_autoplay_key" translatable="false">pref_behaviour_video_autoplay</string>
+	<string name="pref_behaviour_video_autoplay_title">Autoplay videos</string>
+	<string name="pref_behaviour_video_autoplay_summary">If video playback controls are not enabled, this preference is ignored and videos will always autoplay</string>
 </resources>

--- a/src/main/res/xml/prefs_images_video.xml
+++ b/src/main/res/xml/prefs_images_video.xml
@@ -52,6 +52,7 @@
 							android:defaultValue="true"/>
 
 		<CheckBoxPreference android:title="@string/pref_behaviour_video_autoplay_title"
+							android:dependency="@string/pref_behaviour_video_playback_controls_key"
 							android:key="@string/pref_behaviour_video_autoplay_key"
 							android:summary="@string/pref_behaviour_video_autoplay_summary"
 							android:defaultValue="true"/>

--- a/src/main/res/xml/prefs_images_video.xml
+++ b/src/main/res/xml/prefs_images_video.xml
@@ -51,6 +51,11 @@
 							android:key="@string/pref_behaviour_video_mute_default_key"
 							android:defaultValue="true"/>
 
+		<CheckBoxPreference android:title="@string/pref_behaviour_video_autoplay_title"
+							android:key="@string/pref_behaviour_video_autoplay_key"
+							android:summary="@string/pref_behaviour_video_autoplay_summary"
+							android:defaultValue="true"/>
+
 		<CheckBoxPreference android:title="@string/pref_behaviour_video_zoom_default_title"
 							android:key="@string/pref_behaviour_video_zoom_default_key"
 							android:defaultValue="false"/>


### PR DESCRIPTION
Relevant feature request: #1075 

Untested: Waiting on Reddit to give me an API key (they seem to have made this process more complicated)

Similar to my previous PR #1323 

- Adds `pref_behaviour_video_autoplay` (default = true to match current behaviour) with a corresponding checkbox on the "Images/Video" settings page
- Autoplay is only disabled if `pref_behaviour_video_autoplay` is false **and** playback controls are enabled (because I assume that there would be no way to initiate playback otherwise)
  - The checkbox is therefore disabled if `pref_behaviour_video_playback_controls` is false (btw, this could be applied to other relevant preference checkboxes using the `android:dependency` attribute)
  - I've added summary text to `strings.xml` explaining this limitation
- Autoplay is disabled in the `ExoPlayerWrapperView` constructor by calling `mVideoPlayer.setPlayWhenReady(false)` instead of `(true)` — can't be sure that this is the correct approach without an API key