### PR TITLE
fix(#605): opt the embedded WebView out of Google Safe Browsing

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
 		<meta-data android:name="com.lge.support.SPLIT_WINDOW" android:value="true" />
 
 		<meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
+		<meta-data android:name="android.webkit.WebView.EnableSafeBrowsing" android:value="false" />
+
 
 		<activity android:name=".activities.MainActivity"
 				  android:configChanges="orientation|screenSize|keyboardHidden"


### PR DESCRIPTION
Closes QuantumBadger/RedReader#605.

## Background
On Android 8 and newer, every WebView request is checked against Google's Safe Browsing service unless the host application explicitly opts out. RedReader already opts out of WebView metrics, but never opted out of Safe Browsing, so each external link a user opens inside the in-app browser still leaks the URL to Google. The Android documentation lists the exact opt-out marker for this case.

## Fix
Add the documented manifest meta-data right next to the existing `MetricsOptOut` declaration so both privacy switches stay together.

```xml
<meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />

<meta-data android:name="android.webkit.WebView.EnableSafeBrowsing" android:value="false" />
```

## Why this is safe
- The flag is a documented public Android API, supported on every WebView version that ships with API 26 plus.
- It is a no-op on devices whose WebView does not yet implement Safe Browsing.
- No Java code paths change, so behaviour for users who never open an external link is identical.

## Validation
- `aapt2 dump xmltree` on a built APK confirms the new meta-data lands inside `<application>`.
- Tested manually by opening a link inside the in-app WebView and verifying the network trace no longer contains a request to `safebrowsing.googleapis.com`.
