### PR TITLE
fix(#539): finish the CookieSyncManager removal by calling CookieManager.flush()

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/fragments/WebViewFragment.java
@@ -523,8 +523,11 @@ public class WebViewFragment extends Fragment
 		outer.removeAllViews();
 		webView.destroy();
 
+		// CookieSyncManager was removed in favour of CookieManager flush()
+		// for API 21 plus, see https://developer.android.com/reference/android/webkit/CookieManager#flush()
 		final CookieManager cookieManager = CookieManager.getInstance();
 		cookieManager.removeAllCookies(null);
+		cookieManager.flush();
 
 		super.onDestroyView();
 	}


### PR DESCRIPTION
Closes QuantumBadger/RedReader#539.

## Context
Issue #539 reported that `CookieSyncManager` is deprecated since API 21 and is no longer required. The legacy call is already gone from master, but the modern half of the contract is still missing. The Android docs make the new pattern explicit:

> Apps targeting API level 21 or above should call `CookieManager.flush()` to ensure that cookies are written to persistent storage.

Without that call the recently issued `removeAllCookies()` request is only queued and may be lost when the fragment tears down its WebView and the OS later reclaims the process.

## Fix
Add the explicit `flush()` call inside `WebViewFragment.onDestroyView()` so the cookie store is durably written before the fragment finishes destruction. A short comment records the rationale so future contributors do not reintroduce `CookieSyncManager`.

```java
// CookieSyncManager was removed in favour of CookieManager flush()
// for API 21 plus, see https://developer.android.com/reference/android/webkit/CookieManager#flush()
final CookieManager cookieManager = CookieManager.getInstance();
cookieManager.removeAllCookies(null);
cookieManager.flush();
```

## Validation
- The diff only adds two comment lines and one method call inside the same `onDestroyView()` block.
- `flush()` has been part of the WebView public API since API 21, which matches the project's existing `minSdkVersion`.
- Manual smoke test: open the in-app browser, navigate, then back out. The next launch starts with a clean cookie store as expected.
