### PR TITLE
Add Follow system theme mode

### DIFF
--- a/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/activities/OptionsMenuUtility.java
@@ -19,6 +19,7 @@ package org.quantumbadger.redreader.activities;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -670,11 +671,50 @@ public final class OptionsMenuUtility {
 							final AppearanceTheme currentTheme
 									= PrefsUtility.appearance_theme();
 
-							final String[] themeNames = activity.getResources()
-									.getStringArray(R.array.pref_appearance_theme);
+							// When following the system theme, the single theme
+							// key is ignored - the active theme is the light or
+							// dark selection for the current mode. Offer only the
+							// themes for that mode and write to its key, so every
+							// choice changes the theme currently on screen instead
+							// of silently doing nothing.
+							final String[] themeNames;
+							final String[] themeValues;
+							final String themeKey;
+							final int titleRes;
 
-							final String[] themeValues = activity.getResources()
-									.getStringArray(R.array.pref_appearance_theme_return);
+							if(PrefsUtility.appearance_theme_use_system()) {
+
+								final int uiMode = activity.getResources()
+										.getConfiguration().uiMode
+										& Configuration.UI_MODE_NIGHT_MASK;
+
+								if(uiMode == Configuration.UI_MODE_NIGHT_YES) {
+									themeNames = activity.getResources().getStringArray(
+											R.array.pref_appearance_theme_dark);
+									themeValues = activity.getResources().getStringArray(
+											R.array.pref_appearance_theme_dark_return);
+									themeKey = activity.getString(
+											R.string.pref_appearance_theme_dark_key);
+									titleRes = R.string.pref_appearance_theme_dark_title;
+								} else {
+									themeNames = activity.getResources().getStringArray(
+											R.array.pref_appearance_theme_light);
+									themeValues = activity.getResources().getStringArray(
+											R.array.pref_appearance_theme_light_return);
+									themeKey = activity.getString(
+											R.string.pref_appearance_theme_light_key);
+									titleRes = R.string.pref_appearance_theme_light_title;
+								}
+
+							} else {
+								themeNames = activity.getResources().getStringArray(
+										R.array.pref_appearance_theme);
+								themeValues = activity.getResources().getStringArray(
+										R.array.pref_appearance_theme_return);
+								themeKey = activity.getString(
+										R.string.pref_appearance_theme_key);
+								titleRes = R.string.pref_appearance_theme_title;
+							}
 
 							int selectedPos = -1;
 							for(int i = 0; i < themeValues.length; i++) {
@@ -688,17 +728,14 @@ public final class OptionsMenuUtility {
 
 							final MaterialAlertDialogBuilder dialog
 									= new MaterialAlertDialogBuilder(activity);
-							dialog.setTitle(R.string.pref_appearance_theme_title);
+							dialog.setTitle(titleRes);
 
 							dialog.setSingleChoiceItems(
 									themeNames,
 									selectedPos,
 									(dialog1, item1) -> {
 										prefs.edit()
-												.putString(
-														activity.getString(
-														R.string.pref_appearance_theme_key),
-														themeValues[item1])
+												.putString(themeKey, themeValues[item1])
 												.apply();
 										dialog1.dismiss();
 									});

--- a/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
+++ b/src/main/java/org/quantumbadger/redreader/common/PrefsUtility.java
@@ -156,6 +156,9 @@ public final class PrefsUtility {
 	public static boolean isRestartRequired(final Context context, final String key) {
 		return context.getString(R.string.pref_appearance_twopane_key).equals(key)
 				|| context.getString(R.string.pref_appearance_theme_key).equals(key)
+				|| context.getString(R.string.pref_appearance_theme_use_system_key).equals(key)
+				|| context.getString(R.string.pref_appearance_theme_light_key).equals(key)
+				|| context.getString(R.string.pref_appearance_theme_dark_key).equals(key)
 				|| context.getString(R.string.pref_appearance_navbar_color_key).equals(key)
 				|| context.getString(R.string.pref_appearance_langforce_key).equals(key)
 				|| context.getString(R.string.pref_behaviour_bezel_toolbar_swipezone_key)
@@ -206,15 +209,42 @@ public final class PrefsUtility {
 	}
 
 	public static boolean isNightMode() {
-
-		final AppearanceTheme theme = appearance_theme();
-
+		final AppearanceTheme theme = appearance_theme(mRes);
 		return theme == AppearanceTheme.NIGHT
 				|| theme == AppearanceTheme.NIGHT_LOWCONTRAST
 				|| theme == AppearanceTheme.ULTRABLACK;
 	}
 
+	public static boolean appearance_theme_use_system() {
+		return getBoolean(R.string.pref_appearance_theme_use_system_key, false);
+	}
+
+	public static AppearanceTheme appearance_theme_light() {
+		return AppearanceTheme.valueOf(StringUtils.asciiUppercase(getString(
+				R.string.pref_appearance_theme_light_key,
+				"red")));
+	}
+
+	public static AppearanceTheme appearance_theme_dark() {
+		return AppearanceTheme.valueOf(StringUtils.asciiUppercase(getString(
+				R.string.pref_appearance_theme_dark_key,
+				"night")));
+	}
+
 	public static AppearanceTheme appearance_theme() {
+		return appearance_theme(mRes);
+	}
+
+	public static AppearanceTheme appearance_theme(@Nullable final Resources resources) {
+		if(resources != null && appearance_theme_use_system()) {
+			final int uiMode = resources.getConfiguration().uiMode
+					& android.content.res.Configuration.UI_MODE_NIGHT_MASK;
+			if(uiMode == android.content.res.Configuration.UI_MODE_NIGHT_YES) {
+				return appearance_theme_dark();
+			} else {
+				return appearance_theme_light();
+			}
+		}
 		return AppearanceTheme.valueOf(StringUtils.asciiUppercase(getString(
 				R.string.pref_appearance_theme_key,
 				"red")));
@@ -232,7 +262,7 @@ public final class PrefsUtility {
 
 	public static void applyTheme(@NonNull final Activity activity) {
 
-		final AppearanceTheme theme = appearance_theme();
+		final AppearanceTheme theme = appearance_theme(activity.getResources());
 
 		switch(theme) {
 			case RED:

--- a/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
+++ b/src/main/java/org/quantumbadger/redreader/settings/SettingsFragment.java
@@ -22,6 +22,7 @@ import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.text.Html;
 import android.util.Log;
@@ -64,6 +65,7 @@ import org.quantumbadger.redreader.reddit.prepared.RedditChangeDataManager;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -119,6 +121,8 @@ public final class SettingsFragment extends PreferenceFragmentCompat {
 				R.string.pref_behaviour_fling_comment_left_key,
 				R.string.pref_behaviour_fling_comment_right_key,
 				R.string.pref_appearance_theme_key,
+				R.string.pref_appearance_theme_light_key,
+				R.string.pref_appearance_theme_dark_key,
 				R.string.pref_appearance_navbar_color_key,
 				R.string.pref_cache_maxage_listing_key,
 				R.string.pref_cache_maxage_thumb_key,
@@ -233,6 +237,50 @@ public final class SettingsFragment extends PreferenceFragmentCompat {
 				}
 				return true;
 			});
+		}
+
+		{
+			final CheckBoxPreference useSystemThemePref =
+					findPreference(getString(R.string.pref_appearance_theme_use_system_key));
+			final ListPreference themePref =
+					findPreference(getString(R.string.pref_appearance_theme_key));
+			final ListPreference themeLightPref =
+					findPreference(getString(R.string.pref_appearance_theme_light_key));
+			final ListPreference themeDarkPref =
+					findPreference(getString(R.string.pref_appearance_theme_dark_key));
+
+			if(useSystemThemePref != null && themePref != null
+					&& themeLightPref != null && themeDarkPref != null) {
+
+				final boolean useSystem = useSystemThemePref.isChecked();
+				themePref.setVisible(!useSystem);
+				themeLightPref.setVisible(useSystem);
+				themeDarkPref.setVisible(useSystem);
+
+				useSystemThemePref.setOnPreferenceChangeListener((preference, newValue) -> {
+					final boolean nowUseSystem = Boolean.TRUE.equals(newValue);
+					themePref.setVisible(!nowUseSystem);
+					themeLightPref.setVisible(nowUseSystem);
+					themeDarkPref.setVisible(nowUseSystem);
+
+					// Carry the currently-active theme across the toggle so it
+					// isn't replaced by a stale value the user never chose.
+					if(nowUseSystem) {
+						// Turning on: route the single theme into its natural
+						// light or dark slot (themes are inherently one or the
+						// other). The active theme then still shows if it matches
+						// the current system mode; otherwise the mode-appropriate
+						// theme is shown, which is the point of following system.
+						carryThemeToSystemSlot(themePref, themeLightPref, themeDarkPref);
+					} else {
+						// Turning off: adopt whichever of light/dark is currently
+						// active for the system mode, so the single theme matches
+						// what is already on screen.
+						carryActiveThemeToSingle(themePref, themeLightPref, themeDarkPref);
+					}
+					return true;
+				});
+			}
 		}
 
 		{
@@ -577,6 +625,64 @@ public final class SettingsFragment extends PreferenceFragmentCompat {
 				});
 			}
 
+		}
+	}
+
+	// When Follow system theme is turned on, move the single theme selection
+	// into its natural light or dark slot so the active theme carries over.
+	private void carryThemeToSystemSlot(
+			final ListPreference themePref,
+			final ListPreference themeLightPref,
+			final ListPreference themeDarkPref) {
+
+		final String value = themePref.getValue();
+		if(value == null) {
+			return;
+		}
+
+		if(isDarkThemeValue(value)) {
+			themeDarkPref.setValue(value);
+			updateListPreferenceSummary(themeDarkPref);
+		} else {
+			themeLightPref.setValue(value);
+			updateListPreferenceSummary(themeLightPref);
+		}
+	}
+
+	// When Follow system theme is turned off, adopt whichever of the light/dark
+	// selections is currently active for the system's mode, so the single theme
+	// matches what is already displayed.
+	private void carryActiveThemeToSingle(
+			final ListPreference themePref,
+			final ListPreference themeLightPref,
+			final ListPreference themeDarkPref) {
+
+		final int uiMode = getResources().getConfiguration().uiMode
+				& Configuration.UI_MODE_NIGHT_MASK;
+
+		final String value = uiMode == Configuration.UI_MODE_NIGHT_YES
+				? themeDarkPref.getValue()
+				: themeLightPref.getValue();
+
+		if(value != null) {
+			themePref.setValue(value);
+			updateListPreferenceSummary(themePref);
+		}
+	}
+
+	private boolean isDarkThemeValue(final String value) {
+		return Arrays.asList(getResources().getStringArray(
+				R.array.pref_appearance_theme_dark_return)).contains(value);
+	}
+
+	// setValue() persists and re-applies the theme, but the row summary is set
+	// manually elsewhere (and only via the change listener, which programmatic
+	// setValue does not trigger), so refresh it here to keep the displayed
+	// selection in sync without a settings reload.
+	private void updateListPreferenceSummary(final ListPreference pref) {
+		final int index = pref.findIndexOfValue(pref.getValue());
+		if(index >= 0) {
+			pref.setSummary(pref.getEntries()[index]);
 		}
 	}
 

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -266,6 +266,38 @@
 		<item>ultrablack</item>
 	</string-array>
 
+	<string-array name="pref_appearance_theme_light">
+		<item>@string/theme_name_red</item>
+		<item>@string/theme_name_green</item>
+		<item>@string/theme_name_blue</item>
+		<item>@string/theme_name_ltblue</item>
+		<item>@string/theme_name_orange</item>
+		<item>@string/theme_name_gray</item>
+	</string-array>
+
+	<!-- Constants. Do not change. -->
+	<string-array name="pref_appearance_theme_light_return">
+		<item>red</item>
+		<item>green</item>
+		<item>blue</item>
+		<item>ltblue</item>
+		<item>orange</item>
+		<item>gray</item>
+	</string-array>
+
+	<string-array name="pref_appearance_theme_dark">
+		<item>@string/theme_name_night</item>
+		<item>@string/theme_name_night_lowcontrast</item>
+		<item>@string/theme_name_ultrablack</item>
+	</string-array>
+
+	<!-- Constants. Do not change. -->
+	<string-array name="pref_appearance_theme_dark_return">
+		<item>night</item>
+		<item>night_lowcontrast</item>
+		<item>ultrablack</item>
+	</string-array>
+
     <string-array name="pref_appearance_langforce">
 		<item>@string/lang_auto</item>
 		<item>@string/lang_en</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -46,6 +46,13 @@
     <string name="pref_appearance_theme_key" translatable="false">pref_appearance_theme</string>
     <string name="pref_appearance_theme_title">Theme</string>
 
+    <string name="pref_appearance_theme_use_system_key" translatable="false">pref_appearance_theme_use_system</string>
+    <string name="pref_appearance_theme_use_system_title">Follow system theme</string>
+    <string name="pref_appearance_theme_light_key" translatable="false">pref_appearance_theme_light</string>
+    <string name="pref_appearance_theme_light_title">Light theme</string>
+    <string name="pref_appearance_theme_dark_key" translatable="false">pref_appearance_theme_dark</string>
+    <string name="pref_appearance_theme_dark_title">Dark theme</string>
+
     <string name="pref_appearance_fontscale_posts_key" translatable="false">pref_appearance_fontscale_posts</string>
     <string name="pref_appearance_fontscale_posts_title">Post titles</string>
 

--- a/src/main/res/xml/prefs_appearance.xml
+++ b/src/main/res/xml/prefs_appearance.xml
@@ -31,11 +31,27 @@
 
     <PreferenceCategory android:title="@string/pref_appearance_theme_header">
 
+        <CheckBoxPreference android:title="@string/pref_appearance_theme_use_system_title"
+                            android:key="@string/pref_appearance_theme_use_system_key"
+                            android:defaultValue="false"/>
+
         <ListPreference android:title="@string/pref_appearance_theme_title"
                         android:key="@string/pref_appearance_theme_key"
                         android:entries="@array/pref_appearance_theme"
                         android:entryValues="@array/pref_appearance_theme_return"
                         android:defaultValue="red"/>
+
+        <ListPreference android:title="@string/pref_appearance_theme_light_title"
+                        android:key="@string/pref_appearance_theme_light_key"
+                        android:entries="@array/pref_appearance_theme_light"
+                        android:entryValues="@array/pref_appearance_theme_light_return"
+                        android:defaultValue="red"/>
+
+        <ListPreference android:title="@string/pref_appearance_theme_dark_title"
+                        android:key="@string/pref_appearance_theme_dark_key"
+                        android:entries="@array/pref_appearance_theme_dark"
+                        android:entryValues="@array/pref_appearance_theme_dark_return"
+                        android:defaultValue="night"/>
 
 		<ListPreference android:title="@string/pref_appearance_navbar_color_title"
 						android:key="@string/pref_appearance_navbar_color_key"


### PR DESCRIPTION
 Adds an optional "Follow system theme" setting that switches between a light and
  a dark theme automatically, based on the device's dark-mode setting.
  
  When enabled, separate "Light theme" and "Dark theme" selectors are shown (a 
  single "Theme" selector otherwise), and the active theme carries across the
  toggle so it isn't replaced by a value the user never chose. The quick theme
  selector in the options menu also becomes mode-aware while following the system,
  offering only the current mode's themes so every choice changes what's on screen.
  
  pmd, checkstyle, lint, test and assembleRelease all pass locally; tested on-device.
  
  Closes #1241
